### PR TITLE
Add new class SnoContext - resolves --repo consistently

### DIFF
--- a/sno/checkout.py
+++ b/sno/checkout.py
@@ -18,7 +18,7 @@ from .working_copy import WorkingCopy
 @click.argument("refish", default=None, required=False)
 def checkout(ctx, branch, fmt, force, path, datasets, refish):
     """ Switch branches or restore working tree files """
-    repo_dir = ctx.obj.repo_dir
+    repo_path = ctx.obj.repo_path
     repo = ctx.obj.repo
 
     # refish could be:
@@ -79,7 +79,7 @@ def checkout(ctx, branch, fmt, force, path, datasets, refish):
 
     else:
         if path is None:
-            path = f"{Path(repo_dir).resolve().stem}.gpkg"
+            path = f"{repo_path.resolve().stem}.gpkg"
 
         # new working-copy path
         click.echo(f'Checkout {refish or "HEAD"} to {path} as {fmt} ...')
@@ -237,7 +237,7 @@ def restore(ctx, source, pathspec):
 @click.argument("new", nargs=1, type=click.Path(exists=True, dir_okay=False))
 def workingcopy_set_path(ctx, new):
     """ Change the path to the working-copy """
-    repo_dir = ctx.obj.repo_dir
+    repo_path = ctx.obj.repo_path
     repo = ctx.obj.repo
 
     repo_cfg = repo.config
@@ -245,7 +245,8 @@ def workingcopy_set_path(ctx, new):
         raise click.ClickException("No working copy? Try `sno checkout`")
 
     new = Path(new)
+    # TODO(olsen): This doesn't seem to do anything?
     if not new.is_absolute():
-        new = os.path.relpath(os.path.join(repo_dir, new), repo_dir)
+        new = os.path.relpath(os.path.join(repo_path, new), repo_path)
 
     repo.config["sno.workingcopy.path"] = str(new)

--- a/sno/checkout.py
+++ b/sno/checkout.py
@@ -245,7 +245,7 @@ def workingcopy_set_path(ctx, new):
         raise click.ClickException("No working copy? Try `sno checkout`")
 
     new = Path(new)
-    # TODO(olsen): This doesn't seem to do anything?
+    # TODO: This doesn't seem to do anything?
     if not new.is_absolute():
         new = os.path.relpath(os.path.join(repo_path, new), repo_path)
 

--- a/sno/checkout.py
+++ b/sno/checkout.py
@@ -18,10 +18,8 @@ from .working_copy import WorkingCopy
 @click.argument("refish", default=None, required=False)
 def checkout(ctx, branch, fmt, force, path, datasets, refish):
     """ Switch branches or restore working tree files """
-    repo_dir = ctx.obj["repo_dir"]
-    repo = pygit2.Repository(repo_dir)
-    if not repo or not repo.is_bare:
-        raise click.BadParameter("Not an existing repository", param_hint="--repo")
+    repo_dir = ctx.obj.repo_dir
+    repo = ctx.obj.repo
 
     # refish could be:
     # - branch name
@@ -129,10 +127,7 @@ def switch(ctx, create, force_create, discard_changes, refish):
     """
     from .structure import RepositoryStructure
 
-    repo_dir = ctx.obj["repo_dir"]
-    repo = pygit2.Repository(repo_dir)
-    if not repo:
-        raise click.BadParameter("Not an existing repository", param_hint="--repo")
+    repo = ctx.obj.repo
 
     if create and force_create:
         raise click.BadParameter("-c/--create and -C/--force-create are incompatible")
@@ -217,10 +212,7 @@ def restore(ctx, source, pathspec):
     """
     from .structure import RepositoryStructure
 
-    repo_dir = ctx.obj["repo_dir"]
-    repo = pygit2.Repository(repo_dir)
-    if not repo:
-        raise click.BadParameter("Not an existing repository", param_hint="--repo")
+    repo = ctx.obj.repo
 
     repo_structure = RepositoryStructure(repo)
     working_copy = repo_structure.working_copy
@@ -245,10 +237,8 @@ def restore(ctx, source, pathspec):
 @click.argument("new", nargs=1, type=click.Path(exists=True, dir_okay=False))
 def workingcopy_set_path(ctx, new):
     """ Change the path to the working-copy """
-    repo_dir = ctx.obj["repo_dir"] or "."
-    repo = pygit2.Repository(repo_dir)
-    if not repo:
-        raise click.BadParameter("Not an existing repository", param_hint="--repo")
+    repo_dir = ctx.obj.repo_dir
+    repo = ctx.obj.repo
 
     repo_cfg = repo.config
     if "sno.workingcopy.path" not in repo_cfg:

--- a/sno/clone.py
+++ b/sno/clone.py
@@ -16,7 +16,7 @@ from .structure import RepositoryStructure
 @click.argument("directory", type=click.Path(exists=False, file_okay=False, writable=True), required=False)
 def clone(ctx, do_checkout, url, directory):
     """ Clone a repository into a new directory """
-    repo_dir = Path(directory or os.path.split(url)[1])
+    repo_path = Path(directory or os.path.split(url)[1])
 
     # we use subprocess because it deals with credentials much better & consistently than we can do at the moment.
     # pygit2.clone_repository() works fine except for that
@@ -25,17 +25,17 @@ def clone(ctx, do_checkout, url, directory):
         "--bare",
         "--config", "remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*",
         url,
-        repo_dir.resolve()
+        repo_path.resolve()
     ])
 
-    repo = pygit2.Repository(str(repo_dir.resolve()))
+    repo = pygit2.Repository(str(repo_path.resolve()))
     head_ref = repo.head.shorthand  # master
     repo.config[f"branch.{head_ref}.remote"] = "origin"
     repo.config[f"branch.{head_ref}.merge"] = f"refs/heads/{head_ref}"
 
     if do_checkout:
         # Checkout a working copy
-        wc_path = f"{repo_dir.stem}.gpkg"
+        wc_path = f"{repo_path.stem}.gpkg"
 
         click.echo(f'Checkout to {wc_path} as GPKG ...')
 

--- a/sno/commit.py
+++ b/sno/commit.py
@@ -46,10 +46,7 @@ from .cli_util import MutexOption
 )
 def commit(ctx, message, message_file, allow_empty):
     """ Record changes to the repository """
-    repo_dir = ctx.obj["repo_dir"]
-    repo = pygit2.Repository(repo_dir)
-    if not repo:
-        raise click.BadParameter("Not an existing repository", param_hint="--repo")
+    repo = ctx.obj.repo
 
     check_git_user(repo)
 

--- a/sno/context.py
+++ b/sno/context.py
@@ -1,42 +1,47 @@
+from pathlib import Path
+
 import click
 import pygit2
-import os
 
 
-class SnoContext(object):
+class Context(object):
+    DEFAULT_REPO_PATH = Path()
+
     def __init__(self):
-        self._repo_dir = None
+        self._repo_path = None
 
     @property
-    def repo_dir(self):
+    def repo_path(self):
         """The path of the repository. Defaults to the current directory."""
-        return self._repo_dir or os.curdir
+        return self._repo_path or self.DEFAULT_REPO_PATH
 
-    @repo_dir.setter
-    def repo_dir(self, repo_dir):
-        self._repo_dir = repo_dir
+    @repo_path.setter
+    def repo_path(self, repo_path):
+        if isinstance(repo_path, str):
+            repo_path = Path(repo_path)
+        self._repo_path = repo_path
         if hasattr(self, "_repo"):
             del self._repo
 
     @property
-    def repo_dir_is_set(self):
-        """True if repo_dir has been explicitly set."""
-        return self._repo_dir is not None
+    def has_repo_path(self):
+        return self._repo_path is not None
+
 
     @property
     def repo(self):
         """
-        Returns the sno repository at repo_dir.
-        Raises an error if there isn't a valid repo at repo_dir.
+        Returns the sno repository at repo_path.
+        Raises an error if there isn't a valid repo at repo_path.
         """
         if not hasattr(self, "_repo"):
             try:
-                self._repo = pygit2.Repository(self.repo_dir)
+                self._repo = pygit2.Repository(str(self.repo_path))
             except pygit2.GitError:
                 self._repo = None
 
         if not self._repo or not self._repo.is_bare:
-            if self.repo_dir_is_set:
+            if self.has_repo_path:
                 raise click.BadParameter("Not an existing repository", param_hint="--repo")
             else:
                 raise click.UsageError("Current directory is not an existing repository")

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -419,10 +419,7 @@ def diff(ctx, output_format, output_path, exit_code, args):
         if output_path and output_path != "-":
             output_path = Path(output_path).expanduser()
 
-        repo_dir = ctx.obj["repo_dir"]
-        repo = pygit2.Repository(repo_dir)
-        if not repo:
-            raise click.BadParameter("Not an existing repository", param_hint="--repo")
+        repo = ctx.obj.repo
 
         paths = {}
         commit_head = repo.head.peel(pygit2.Commit)

--- a/sno/fsck.py
+++ b/sno/fsck.py
@@ -61,10 +61,8 @@ def _fsck_reset(repo_structure, working_copy, dataset_paths):
 @click.argument("fsck_args", nargs=-1, type=click.UNPROCESSED)
 def fsck(ctx, reset_datasets, fsck_args):
     """ Verifies the connectivity and validity of the objects in the database """
-    repo_dir = ctx.obj["repo_dir"] or "."
-    repo = pygit2.Repository(repo_dir)
-    if not repo or not repo.is_bare:
-        raise click.BadParameter("Not an existing repository", param_hint="--repo")
+    repo_dir = ctx.obj.repo_dir
+    repo = ctx.obj.repo
 
     click.echo("Checking repository integrity...")
     r = subprocess.call(["git", "-C", repo_dir, "fsck"] + list(fsck_args))

--- a/sno/fsck.py
+++ b/sno/fsck.py
@@ -61,11 +61,11 @@ def _fsck_reset(repo_structure, working_copy, dataset_paths):
 @click.argument("fsck_args", nargs=-1, type=click.UNPROCESSED)
 def fsck(ctx, reset_datasets, fsck_args):
     """ Verifies the connectivity and validity of the objects in the database """
-    repo_dir = ctx.obj.repo_dir
+    repo_path = ctx.obj.repo_path
     repo = ctx.obj.repo
 
     click.echo("Checking repository integrity...")
-    r = subprocess.call(["git", "-C", repo_dir, "fsck"] + list(fsck_args))
+    r = subprocess.call(["git", "-C", repo_path, "fsck"] + list(fsck_args))
     if r:
         click.Abort()
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -26,7 +26,7 @@ def import_gpkg(ctx, geopackage, table, list_tables):
 
     click.secho('"import-gpkg" is deprecated and will be removed in future, use "init" instead', fg='yellow')
 
-    directory = ctx.obj["repo_dir"] or os.curdir
+    directory = ctx.obj.repo_dir
 
     check_git_user(repo=None)
 
@@ -255,10 +255,8 @@ def import_table(ctx, source, directory, do_list, version, method):
     To show available tables in the import data, use
     $ sno import --list GPKG:my.gpkg
     """
-    repo_dir = ctx.obj["repo_dir"] or "."
-    repo = pygit2.Repository(repo_dir)
-    if not repo or not repo.is_bare:
-        raise click.BadParameter("Not an existing repository", param_hint="--repo")
+    repo_dir = ctx.obj.repo_dir
+    repo = ctx.obj.repo
 
     check_git_user(repo)
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -26,7 +26,7 @@ def import_gpkg(ctx, geopackage, table, list_tables):
 
     click.secho('"import-gpkg" is deprecated and will be removed in future, use "init" instead', fg='yellow')
 
-    directory = ctx.obj.repo_dir
+    repo_path = ctx.obj.repo_path
 
     check_git_user(repo=None)
 
@@ -34,10 +34,10 @@ def import_gpkg(ctx, geopackage, table, list_tables):
     if table and not list_tables:
         import_from[2] = table
 
-    if not list_tables and directory:
-        Path(directory).mkdir(exist_ok=True)
+    if not list_tables and repo_path:
+        repo_path.mkdir(exist_ok=True)
 
-    ctx.invoke(init, directory=directory, import_from=tuple(import_from), do_checkout=False)
+    ctx.invoke(init, directory=str(repo_path), import_from=tuple(import_from), do_checkout=False)
 
 
 class ImportPath(click.Path):
@@ -255,7 +255,7 @@ def import_table(ctx, source, directory, do_list, version, method):
     To show available tables in the import data, use
     $ sno import --list GPKG:my.gpkg
     """
-    repo_dir = ctx.obj.repo_dir
+    repo_path = ctx.obj.repo_path
     repo = ctx.obj.repo
 
     check_git_user(repo)
@@ -300,7 +300,7 @@ def import_table(ctx, source, directory, do_list, version, method):
         ctx.exit(1)
 
     if directory:
-        directory = os.path.relpath(directory, os.path.abspath(repo_dir))
+        directory = os.path.relpath(directory, os.path.abspath(repo_path))
         if not directory:
             raise click.BadParameter("Invalid import directory", param_hint="directory")
     else:
@@ -380,14 +380,14 @@ def init(ctx, import_from, do_checkout, directory):
     elif not Path(directory).exists():
         Path(directory).mkdir(parents=True)
 
-    repo_dir = Path(directory).resolve()
-    if any(repo_dir.iterdir()):
+    repo_path = Path(directory).resolve()
+    if any(repo_path.iterdir()):
         raise click.BadParameter(
-            f'"{repo_dir}" isn\'t empty', param_hint="directory"
+            f'"{repo_path}" isn\'t empty', param_hint="directory"
         )
 
     # Create the repository
-    repo = pygit2.init_repository(str(repo_dir), bare=True)
+    repo = pygit2.init_repository(str(repo_path), bare=True)
 
     if import_from:
         importer = structure.DatasetStructure.importer(import_table)
@@ -395,7 +395,7 @@ def init(ctx, import_from, do_checkout, directory):
 
         if do_checkout:
             # Checkout a working copy
-            wc_path = repo_dir / f"{repo_dir.stem}.gpkg"
+            wc_path = repo_path / f"{repo_path.stem}.gpkg"
 
             click.echo(f'Checkout {import_table} to {wc_path} as GPKG ...')
 
@@ -405,4 +405,4 @@ def init(ctx, import_from, do_checkout, directory):
                 commit=repo.head.peel(pygit2.Commit),
             )
     else:
-        click.echo(f"Created an empty repository at {repo_dir} — import some data with `sno import`")
+        click.echo(f"Created an empty repository at {repo_path} — import some data with `sno import`")

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -26,8 +26,7 @@ from .structure import RepositoryStructure
 @click.pass_context
 def merge(ctx, ff, ff_only, commit):
     """ Incorporates changes from the named commits (usually other branch heads) into the current branch. """
-    repo_dir = ctx.obj["repo_dir"]
-    repo = pygit2.Repository(repo_dir)
+    repo = ctx.obj.repo
 
     if ff_only and not ff:
         raise click.BadParameter(

--- a/sno/pull.py
+++ b/sno/pull.py
@@ -34,12 +34,7 @@ from . import merge
 @click.pass_context
 def pull(ctx, ff, ff_only, repository, refspecs):
     """ Fetch from and integrate with another repository or a local branch """
-    repo_dir = ctx.obj["repo_dir"] or "."
-    repo = pygit2.Repository(repo_dir)
-    if not repo or not repo.is_bare:
-        raise click.BadParameter(
-            "Not an existing repository", param_hint="--repo"
-        )
+    repo = ctx.obj.repo
 
     if repository is None:
         # matches git-pull behaviour
@@ -68,7 +63,7 @@ def pull(ctx, ff, ff_only, repository, refspecs):
     # do the fetch
     print("Running fetch:", repository, refspecs)
     remote.fetch((refspecs or None))
-    # subprocess.check_call(["git", "-C", ctx.obj['repo_dir'], 'fetch', repository] + list(refspecs))
+    # subprocess.check_call(["git", "-C", ctx.obj.repo_dir, 'fetch', repository] + list(refspecs))
 
     # now merge with FETCH_HEAD
     print("Running merge:", {'ff': ff, 'ff_only': ff_only, 'commit': "FETCH_HEAD"})

--- a/sno/pull.py
+++ b/sno/pull.py
@@ -63,7 +63,7 @@ def pull(ctx, ff, ff_only, repository, refspecs):
     # do the fetch
     print("Running fetch:", repository, refspecs)
     remote.fetch((refspecs or None))
-    # subprocess.check_call(["git", "-C", ctx.obj.repo_dir, 'fetch', repository] + list(refspecs))
+    # subprocess.check_call(["git", "-C", ctx.obj.repo_path, 'fetch', repository] + list(refspecs))
 
     # now merge with FETCH_HEAD
     print("Running merge:", {'ff': ff, 'ff_only': ff_only, 'commit': "FETCH_HEAD"})

--- a/sno/query.py
+++ b/sno/query.py
@@ -46,7 +46,7 @@ def query(ctx, path, command, params):
     WARNING: Spatial indexing is a proof of concept.
     Significantly, indexes don't update when the repo changes in any way.
     """
-    repo = pygit2.Repository(ctx.obj["repo_dir"] or os.curdir)
+    repo = ctx.obj.repo
     rs = structure.RepositoryStructure(repo)
     dataset = rs[path]
 

--- a/sno/sno_context.py
+++ b/sno/sno_context.py
@@ -1,0 +1,43 @@
+import click
+import pygit2
+import os
+
+
+class SnoContext(object):
+    def __init__(self):
+        self._repo_dir = None
+
+    @property
+    def repo_dir(self):
+        """The path of the repository. Defaults to the current directory."""
+        return self._repo_dir or os.curdir
+
+    @repo_dir.setter
+    def repo_dir(self, repo_dir):
+        self._repo_dir = repo_dir
+        if hasattr(self, "_repo"):
+            del self._repo
+
+    @property
+    def repo_dir_is_set(self):
+        """True if repo_dir has been explicitly set."""
+        return self._repo_dir is not None
+
+    @property
+    def repo(self):
+        """
+        Returns the sno repository at repo_dir.
+        Raises an error if there isn't a valid repo at repo_dir.
+        """
+        if not hasattr(self, "_repo"):
+            try:
+                self._repo = pygit2.Repository(self.repo_dir)
+            except pygit2.GitError:
+                self._repo = None
+
+        if not self._repo or not self._repo.is_bare:
+            if self.repo_dir_is_set:
+                raise click.BadParameter("Not an existing repository", param_hint="--repo")
+            else:
+                raise click.UsageError("Current directory is not an existing repository")
+        return self._repo

--- a/sno/status.py
+++ b/sno/status.py
@@ -8,15 +8,7 @@ from .structure import RepositoryStructure
 @click.pass_context
 def status(ctx):
     """ Show the working copy status """
-    repo_dir = ctx.obj["repo_dir"] or "."
-    try:
-        repo = pygit2.Repository(repo_dir)
-    except pygit2.GitError:
-        repo = None
-
-    if not repo or not repo.is_bare:
-        raise click.BadParameter("Not an existing repository", param_hint="--repo")
-
+    repo = ctx.obj.repo
     rs = RepositoryStructure(repo)
 
     if repo.is_empty:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -151,4 +151,4 @@ def test_status_none(tmp_path, cli_runner, chdir):
     with chdir(tmp_path):
         r = cli_runner.invoke(["status"])
         assert r.exit_code == 2, r
-        assert r.stdout.splitlines()[-1] == 'Error: Invalid value for --repo: Not an existing repository'
+        assert r.stdout.splitlines()[-1] == 'Error: Current directory is not an existing repository'


### PR DESCRIPTION
![](https://media2.giphy.com/media/Pw3ah2NJPoyPe/giphy-downsized-medium.gif)

Lots of sno commands will need machine readable output (ie, json)...
... including reporting errors in a consistent, machine readable way.

In order that "non-existent repo" is reported in a consistent way, I have moved the non-existent repo error handling code into the context object itself. In a follow up change, I will make sure that this error is output using json when json flag is set.

At least two (very minor) bugs were fixed as a side effect of this:
- Some subcommands catch and re-raise a GitError as a click.BadParameter, but not all do (eg sno diff) - instead they test if the the repo returned is falsey, but this is not how pygit2 works.
- In cli.py, code tests for ctx.obj["repo_dir"] - but this string is always truthy, it defaults to "." - the result of this being always-true is that the flag "-C ." is always passed to the git executable, even if this is not the user's intent. (It doesn't seem to matter much though).