### PR TITLE
Added support for sno status --json

### DIFF
--- a/sno/cli_util.py
+++ b/sno/cli_util.py
@@ -21,7 +21,7 @@ class MutexOption(click.Option):
         assert self.exclusive_with, "'exclusive_with' parameter required"
         kwargs["help"] = (
             kwargs.get("help", "")
-            + "Option is mutually exclusive with "
+            + "\nOption is mutually exclusive with "
             + ", ".join(self.exclusive_with)
             + "."
         ).strip()

--- a/sno/context.py
+++ b/sno/context.py
@@ -27,7 +27,6 @@ class Context(object):
     def has_repo_path(self):
         return self._repo_path is not None
 
-
     @property
     def repo(self):
         """

--- a/sno/status.py
+++ b/sno/status.py
@@ -1,34 +1,132 @@
 import click
 import pygit2
 
+from .cli_util import MutexOption
 from .structure import RepositoryStructure
+from .output_util import merge_outputs, print_output
+
+
+JSON_DEFAULT_ATTRS = {
+    "commit": None,
+    "branch": None,
+    "upstream": None,
+    "workingCopy": None,
+}
 
 
 @click.command()
 @click.pass_context
-def status(ctx):
+@click.option(
+    "--text",
+    "is_output_json",
+    flag_value=False,
+    default=True,
+    help="Get the status in text format",
+    cls=MutexOption,
+    exclusive_with=["json"],
+)
+@click.option(
+    "--json",
+    "is_output_json",
+    flag_value=True,
+    help="Get the status in JSON format",
+    cls=MutexOption,
+    exclusive_with=["text"],
+)
+def status(ctx, is_output_json):
     """ Show the working copy status """
     repo = ctx.obj.repo
     rs = RepositoryStructure(repo)
 
     if repo.is_empty:
-        click.echo('Empty repository.\n  (use "sno import" to add some data)')
-        return
+        if is_output_json:
+            output = JSON_DEFAULT_ATTRS
+        else:
+            output = 'Empty repository.\n  (use "sno import" to add some data)'
+    else:
+        output = merge_outputs(
+            [
+                get_branch_status(repo, is_output_json),
+                get_working_copy_status(rs, is_output_json)
+            ],
+            is_output_json,
+            json_default_attrs=JSON_DEFAULT_ATTRS,
+            text_join_str="\n")
 
+    print_output(output, is_output_json, json_version_tag="sno.status/v1")
+
+
+def get_branch_status_message(repo):
+    return "\n".join(get_branch_status(repo))
+
+
+def get_branch_status(repo, is_output_json):
     commit = repo.head.peel(pygit2.Commit)
 
     if repo.head_is_detached:
-        click.echo(f"{click.style('HEAD detached at', fg='red')} {commit.short_id}")
-    else:
-        click.echo(get_branch_status_message(repo))
+        if is_output_json:
+            return {"commit": commit.short_id}
+        else:
+            return f"{click.style('HEAD detached at', fg='red')} {commit.short_id}\n"
 
-    # working copy state
-    working_copy = rs.working_copy
-    if not working_copy:
-        click.echo(
-            '\nNo working copy.\n  (use "sno checkout" to create a working copy)'
+    branch = repo.branches[repo.head.shorthand]
+
+    if is_output_json:
+        return {
+            "commit": commit.short_id,
+            "branch": branch.shorthand,
+            **get_upstream_status(repo, commit, branch, is_output_json)
+        }
+    else:
+        return (
+            f"On branch {branch.shorthand}\n" +
+            get_upstream_status(repo, commit, branch, is_output_json)
         )
-        return
+
+
+def get_upstream_status(repo, commit, branch, is_output_json):
+    upstream = branch.upstream
+    if not upstream:
+        if is_output_json:
+            return {"upstream": None}
+        else:
+            return ""
+
+    upstream_head = upstream.peel(pygit2.Commit)
+    n_ahead, n_behind = repo.ahead_behind(commit.id, upstream_head.id)
+
+    if is_output_json:
+        return {"upstream": upstream.shorthand, "ahead": n_ahead, "behind": n_behind}
+
+    if n_ahead == n_behind == 0:
+        return [f"Your branch is up to date with '{upstream.shorthand}'."]
+    elif n_ahead > 0 and n_behind > 0:
+        return [
+            f"Your branch and '{upstream.shorthand}' have diverged,",
+            f"and have {n_ahead} and {n_behind} different commits each, respectively.",
+            '  (use "sno pull" to merge the remote branch into yours)',
+        ]
+    elif n_ahead > 0:
+        return [
+            f"Your branch is ahead of '{upstream.shorthand}' by {n_ahead} {_pc(n_ahead)}.",
+            '  (use "sno push" to publish your local commits)',
+        ]
+    elif n_behind > 0:
+        return [
+            f"Your branch is behind '{upstream.shorthand}' by {n_behind} {_pc(n_behind)}, "
+            "and can be fast-forwarded.",
+            '  (use "sno pull" to update your local branch)',
+        ]
+
+
+def get_working_copy_status(rs, is_output_json):
+    working_copy = rs.working_copy
+    if not rs.working_copy:
+        if is_output_json:
+            return {}
+        else:
+            return 'No working copy\n  (use "sno checkout" to create a working copy)\n'
+
 
     wc_changes = {}
     for dataset in rs:
@@ -36,51 +134,33 @@ def status(ctx):
         if any(status.values()):
             wc_changes[dataset.path] = status
 
-    if not wc_changes:
-        click.echo("\nNothing to commit, working copy clean")
+    if not wc_changes and not is_output_json:
+        return "Nothing to commit, working copy clean\n"
+
+    if is_output_json:
+        return {"workingCopy": get_diff_status_json(wc_changes)}
     else:
-        click.echo(
-            (
-                "\nChanges in working copy:\n"
+        return ("Changes in working copy:\n"
                 '  (use "sno commit" to commit)\n'
-                '  (use "sno reset" to discard changes)\n'
-            )
-        )
-        click.echo(get_diff_status_message(wc_changes))
+                '  (use "sno reset" to discard changes)\n\n'
+                + get_diff_status_message(wc_changes))
 
 
-def get_branch_status_message(repo):
-    commit = repo.head.peel(pygit2.Commit)
-
-    branch = repo.branches[repo.head.shorthand]
-    message = [f"On branch {branch.shorthand}"]
-
-    if branch.upstream:
-        upstream_head = branch.upstream.peel(pygit2.Commit)
-        n_ahead, n_behind = repo.ahead_behind(commit.id, upstream_head.id)
-        if n_ahead == n_behind == 0:
-            message += [
-                f"Your branch is up to date with '{branch.upstream.shorthand}'."
-            ]
-        elif n_ahead > 0 and n_behind > 0:
-            message += [
-                f"Your branch and '{branch.upstream.shorthand}' have diverged,",
-                f"and have {n_ahead} and {n_behind} different commits each, respectively.",
-                '  (use "sno pull" to merge the remote branch into yours)',
-            ]
-        elif n_ahead > 0:
-            message += [
-                f"Your branch is ahead of '{branch.upstream.shorthand}' by {n_ahead} {_pc(n_ahead)}.",
-                '  (use "sno push" to publish your local commits)',
-            ]
-        elif n_behind > 0:
-            message += [
-                f"Your branch is behind '{branch.upstream.shorthand}' by {n_behind} {_pc(n_behind)}, "
-                "and can be fast-forwarded.",
-                '  (use "sno pull" to update your local branch)',
-            ]
-
-    return "\n".join(message)
+def get_diff_status_json(wc_changes):
+    if not wc_changes:
+        return {}
+    result = {}
+    for dataset_path, status in wc_changes.items():
+        if sum(status.values()):
+            result[dataset_path] = {
+                "schemaChanges": {} if status["META"] else None,
+                "featureChanges": {
+                    "modified": status["U"],
+                    "new": status["I"],
+                    "deleted": status["D"],
+                }
+            }
+    return result
 
 
 def get_diff_status_message(wc_changes):

--- a/sno/status.py
+++ b/sno/status.py
@@ -8,14 +8,6 @@ from .cli_util import MutexOption
 from .structure import RepositoryStructure
 
 
-EMPTY_REPO_JSON = frozenset({
-    "commit": None,
-    "branch": None,
-    "upstream": None,
-    "workingCopy": None,
-}.items())
-
-
 @click.command()
 @click.pass_context
 @click.option(
@@ -46,7 +38,12 @@ def status(ctx, is_output_json):
 
 
 def get_status_json(repo):
-    output = dict(EMPTY_REPO_JSON)
+    output = {
+        "commit": None,
+        "branch": None,
+        "upstream": None,
+        "workingCopy": None,
+    }
     if not repo.is_empty:
         output.update(get_branch_status_json(repo))
         output.update(get_working_copy_status_json(repo))

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 
 import pytest
@@ -6,28 +7,58 @@ import pytest
 H = pytest.helpers.helpers()
 
 
+def text_status(cli_runner):
+    r = cli_runner.invoke(["status"])
+    assert r.exit_code == 0, r
+    return r.stdout.splitlines()
+
+
+def json_status(cli_runner):
+    r = cli_runner.invoke(["status", "--json"])
+    assert r.exit_code == 0, r
+    return json.loads(r.stdout)
+
+
+def get_commit(jdict):
+    commit = jdict["sno.status/v1"]["commit"]
+    assert commit
+    return commit
+
+
 def test_status(
     data_archive, data_working_copy, geopackage, cli_runner, insert, tmp_path, request
 ):
     with data_working_copy("points") as (path1, wc):
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
+        assert text_status(cli_runner) == [
             "On branch master",
             "",
             "Nothing to commit, working copy clean",
         ]
+        assert json_status(cli_runner) == {
+            "sno.status/v1": {
+                "commit": "2a1b7be",
+                "branch": "master",
+                "upstream": None,
+                "workingCopy": {},
+            }
+        }
 
         r = cli_runner.invoke(["checkout", "HEAD~1"])
         assert r.exit_code == 0, r
 
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
+        assert text_status(cli_runner) == [
             "HEAD detached at 63a9492",
             "",
             "Nothing to commit, working copy clean",
         ]
+        assert json_status(cli_runner) == {
+            "sno.status/v1": {
+                "commit": "63a9492",
+                "branch": None,
+                "upstream": None,
+                "workingCopy": {},
+            }
+        }
 
         r = cli_runner.invoke(["checkout", "master"])
         assert r.exit_code == 0, r
@@ -43,14 +74,26 @@ def test_status(
         r = cli_runner.invoke(["push", "--set-upstream", "myremote", "master"])
         assert r.exit_code == 0, r
 
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
+        assert text_status(cli_runner) == [
             "On branch master",
             "Your branch is up to date with 'myremote/master'.",
             "",
             "Nothing to commit, working copy clean",
         ]
+        jdict = json_status(cli_runner)
+        commit = get_commit(jdict)  # This varies from run to run.
+        assert jdict == {
+            "sno.status/v1": {
+                "commit": commit,
+                "branch": "master",
+                "upstream": {
+                    "branch": "myremote/master",
+                    "ahead": 0,
+                    "behind": 0,
+                },
+                "workingCopy": {},
+            }
+        }
 
     with data_working_copy("points") as (path2, wc):
         db = geopackage(wc)
@@ -66,24 +109,32 @@ def test_status(
 
         H.git_graph(request, "post-fetch")
 
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
+        assert text_status(cli_runner) == [
             "On branch master",
             "Your branch is behind 'myremote/master' by 1 commit, and can be fast-forwarded.",
             '  (use "sno pull" to update your local branch)',
             "",
             "Nothing to commit, working copy clean",
         ]
+        assert json_status(cli_runner) == {
+            "sno.status/v1": {
+                "commit": "2a1b7be",
+                "branch": "master",
+                "upstream": {
+                    "branch": "myremote/master",
+                    "ahead": 0,
+                    "behind": 1,
+                },
+                "workingCopy": {},
+            }
+        }
 
         # local commit
         insert(db, reset_index=100)
 
         H.git_graph(request, "post-commit")
 
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
+        assert text_status(cli_runner) == [
             "On branch master",
             "Your branch and 'myremote/master' have diverged,",
             "and have 1 and 1 different commits each, respectively.",
@@ -91,21 +142,47 @@ def test_status(
             "",
             "Nothing to commit, working copy clean",
         ]
+        jdict = json_status(cli_runner)
+        commit = get_commit(jdict)  # This varies from run to run.
+        assert jdict == {
+            "sno.status/v1": {
+                "commit": commit,
+                "branch": "master",
+                "upstream": {
+                    "branch": "myremote/master",
+                    "ahead": 1,
+                    "behind": 1,
+                },
+                "workingCopy": {},
+            }
+        }
 
         r = cli_runner.invoke(["merge", "myremote/master"])
         assert r.exit_code == 0, r
 
         H.git_graph(request, "post-merge")
 
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
+        assert text_status(cli_runner) == [
             "On branch master",
             "Your branch is ahead of 'myremote/master' by 2 commits.",
             '  (use "sno push" to publish your local commits)',
             "",
             "Nothing to commit, working copy clean",
         ]
+        jdict = json_status(cli_runner)
+        commit = get_commit(jdict)  # This varies from run to run.
+        assert jdict == {
+            "sno.status/v1": {
+                "commit": commit,
+                "branch": "master",
+                "upstream": {
+                    "branch": "myremote/master",
+                    "ahead": 2,
+                    "behind": 0,
+                },
+                "workingCopy": {},
+            }
+        }
 
         # local edits
         with db:
@@ -113,9 +190,7 @@ def test_status(
             db.cursor().execute(f"DELETE FROM {H.POINTS_LAYER} WHERE fid <= 2;")
             db.cursor().execute(f"UPDATE {H.POINTS_LAYER} SET name='test0' WHERE fid <= 5;")
 
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
+        assert text_status(cli_runner) == [
             "On branch master",
             "Your branch is ahead of 'myremote/master' by 2 commits.",
             '  (use "sno push" to publish your local commits)',
@@ -130,6 +205,30 @@ def test_status(
             "    deleted:   2 features",
         ]
 
+        jdict = json_status(cli_runner)
+        commit = get_commit(jdict)  # This varies from run to run.
+        assert jdict == {
+            "sno.status/v1": {
+                "commit": commit,
+                "branch": "master",
+                "upstream": {
+                    "branch": "myremote/master",
+                    "ahead": 2,
+                    "behind": 0,
+                },
+                "workingCopy": {
+                    "nz_pa_points_topo_150k": {
+                        "schemaChanges": None,
+                        "featureChanges": {
+                            "modified": 3,
+                            "new": 1,
+                            "deleted": 2,
+                        }
+                    }
+                }
+            }
+        }
+
 
 def test_status_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / 'wiz.sno'
@@ -139,16 +238,27 @@ def test_status_empty(tmp_path, cli_runner, chdir):
     assert r.exit_code == 0, r
 
     with chdir(repo_path):
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
+        assert text_status(cli_runner) == [
             'Empty repository.',
             '  (use "sno import" to add some data)',
         ]
+
+        assert json_status(cli_runner) == {
+            "sno.status/v1": {
+                "upstream": None,
+                "commit": None,
+                "branch": None,
+                "workingCopy": None
+            }
+        }
 
 
 def test_status_none(tmp_path, cli_runner, chdir):
     with chdir(tmp_path):
         r = cli_runner.invoke(["status"])
+        assert r.exit_code == 2, r
+        assert r.stdout.splitlines()[-1] == 'Error: Current directory is not an existing repository'
+
+        r = cli_runner.invoke(["status", "--json"])
         assert r.exit_code == 2, r
         assert r.stdout.splitlines()[-1] == 'Error: Current directory is not an existing repository'


### PR DESCRIPTION
![](https://media3.giphy.com/media/ZdlSqZuzzMB1JT3nwT/giphy.gif)

Rather than add another "sno status" command with the same logic but which outputs json, I tried to reuse the same logic but at every step, return the information gathered in the local function either in JSON or in text, depending on which is required.

Still TODO (not in this PR):
- Maybe add a repoStatus field that summarizes the state of the entire repo ie empty, detached head, no working copy, working copy but no diff, diff.
- Maybe put the repoStatus in the process exit code.