### PR TITLE
Remove pytest.skip() and re-enable 45 tests.

### DIFF
--- a/sno/fsck.py
+++ b/sno/fsck.py
@@ -29,7 +29,7 @@ def _fsck_reset(repo_structure, working_copy, dataset_paths):
             dbcur = db.cursor()
             dbcur.execute("PRAGMA defer_foreign_keys = ON;")
             try:
-                working_copy._drop_triggers(db, table)
+                working_copy._drop_triggers(dbcur, table)
 
                 dbcur.execute("""DELETE FROM ".sno-meta" WHERE table_name=?;""", [table])
                 dbcur.execute("""DELETE FROM ".sno-track" WHERE table_name=?;""", [table])
@@ -121,8 +121,8 @@ def fsck(ctx, reset_datasets, fsck_args):
                     fg="red",
                 )
 
-            q = db.execute(f"SELECT COUNT(*) FROM {gpkg.ident(table)};")
-            wc_count = q[0][0]
+            dbcur.execute(f"SELECT COUNT(*) FROM {gpkg.ident(table)};")
+            wc_count = dbcur.fetchall()[0][0]
             click.echo(f"{wc_count} features in {table}")
             ds_count = dataset.feature_count(fast=False)
             if wc_count != ds_count:
@@ -132,8 +132,8 @@ def fsck(ctx, reset_datasets, fsck_args):
                     fg="red",
                 )
 
-            q = db.execute(f"SELECT COUNT(*) FROM {working_copy.TRACKING_TABLE} WHERE table_name=?;", [table])
-            track_count = q[0][0]
+            dbcur.execute(f"SELECT COUNT(*) FROM {working_copy.TRACKING_TABLE} WHERE table_name=?;", [table])
+            track_count = dbcur.fetchall()[0][0]
             click.echo(f"{track_count} rows marked as changed in working-copy")
 
             wc_diff = working_copy.diff_db_to_tree(dataset)
@@ -189,7 +189,8 @@ def fsck(ctx, reset_datasets, fsck_args):
                             fg="red",
                         )
 
-                    row = db.execute(f"SELECT * FROM {gpkg.ident(table)} WHERE {gpkg.ident(pk)}=?;", [feature[pk]]).fetchone()
+                    dbcur.execute(f"SELECT * FROM {gpkg.ident(table)} WHERE {gpkg.ident(pk)}=?;", [feature[pk]])
+                    row = dbcur.fetchone()
                     if dict(row) != feature:
                         s_old = set(feature.items())
                         s_new = set(dict(row).items())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,7 +157,7 @@ def data_working_copy(request, data_archive, tmp_path_factory, cli_runner):
 
     Context-manager produces a 2-tuple: (repository_path, working_copy_path)
     """
-    raise pytest.skip()
+    # raise pytest.skip()
     from sno.structure import RepositoryStructure
     incr = 0
 
@@ -425,11 +425,14 @@ class TestHelpers:
             pk = "ROWID"
 
         sql = f"SELECT * FROM {table} ORDER BY {pk};"
-        r = db.execute(sql)
-        h = hashlib.sha1()
-        for row in r:
-            h.update("🔸".join(repr(col) for col in row).encode("utf-8"))
-        return h.hexdigest()
+        with db:
+            cur = db.cursor()
+            cur.execute(sql)
+            r = cur.fetchall()
+            h = hashlib.sha1()
+            for row in r:
+                h.update("🔸".join(repr(col) for col in row).encode("utf-8"))
+            return h.hexdigest()
 
     @classmethod
     def git_graph(cls, request, message, count=10, *paths):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,7 +157,6 @@ def data_working_copy(request, data_archive, tmp_path_factory, cli_runner):
 
     Context-manager produces a 2-tuple: (repository_path, working_copy_path)
     """
-    # raise pytest.skip()
     from sno.structure import RepositoryStructure
     incr = 0
 

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -102,10 +102,11 @@ def test_commit(archive, layer, data_working_copy, geopackage, cli_runner, reque
         tree = repo.head.peel(pygit2.Tree)
         assert dataset.get_feature_path(pk_del) not in tree
 
-        change_count = cur.execute(
+        cur.execute(
             f"SELECT COUNT(*) FROM {wc.TRACKING_TABLE} WHERE table_name=?;",
             [layer]
-        )[0][0]
+        )
+        change_count = cur.fetchone()[0]
         assert change_count == 0, f"Changes still listed in {dataset.TRACKING_TABLE}"
 
         wc = WorkingCopy.open(repo)

--- a/tests/test_fsck.py
+++ b/tests/test_fsck.py
@@ -5,6 +5,7 @@ H = pytest.helpers.helpers()
 
 
 def test_fsck(data_working_copy, geopackage, cli_runner):
+    raise pytest.skip()  # apsw.BusyError: BusyError: database is locked
     with data_working_copy("points") as (repo, wc):
         db = geopackage(wc)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -393,9 +393,10 @@ def test_import_existing_wc(data_archive, data_working_copy, geopackage, cli_run
         assert H.row_count(db, "nz_waca_adjustments") > 0
 
         head_tree = repo.head.peel(pygit2.Tree)
-        wc_tree_id = db.execute(
-            """SELECT value FROM ".sno-meta" WHERE table_name='*' AND key='tree';"""
-        ).fetchone()[0]
+        with db:
+            dbcur = db.cursor()
+            dbcur.execute("""SELECT value FROM ".sno-meta" WHERE table_name='*' AND key='tree';""")
+            wc_tree_id = dbcur.fetchone()[0]
         assert wc_tree_id == head_tree.hex
         assert wc.assert_db_tree_match(head_tree)
 
@@ -408,7 +409,8 @@ def test_import_existing_wc(data_archive, data_working_copy, geopackage, cli_run
         with db:
             dbcur = db.cursor()
             dbcur.execute("DELETE FROM nz_waca_adjustments WHERE rowid IN (SELECT rowid FROM nz_waca_adjustments ORDER BY id LIMIT 10);")
-            assert dbcur.rowcount == 10
+            dbcur.execute("SELECT changes()")
+            assert dbcur.fetchone()[0] == 10
 
         with data_archive("gpkg-polygons") as source_path, chdir(repo_path):
             r = cli_runner.invoke(
@@ -419,9 +421,10 @@ def test_import_existing_wc(data_archive, data_working_copy, geopackage, cli_run
         assert H.row_count(db, "waca2") > 0
 
         head_tree = repo.head.peel(pygit2.Tree)
-        wc_tree_id = db.execute(
-            """SELECT value FROM ".sno-meta" WHERE table_name='*' AND key='tree';"""
-        ).fetchone()[0]
+        with db:
+            dbcur = db.cursor()
+            dbcur.execute("""SELECT value FROM ".sno-meta" WHERE table_name='*' AND key='tree';""")
+            wc_tree_id = dbcur.fetchone()[0]
         assert wc_tree_id == head_tree.hex
         assert wc.assert_db_tree_match(head_tree)
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -162,8 +162,8 @@ def test_merge_true(
 
         # check the database state
         num_inserts = len(insert.inserted_fids)
-        r = dbcur.execute(
+        dbcur.execute(
             f"SELECT COUNT(*) FROM {layer} WHERE {pk_field} IN ({','.join(['?']*num_inserts)});",
             insert.inserted_fids,
         )
-        assert r[0][0] == num_inserts
+        assert dbcur.fetchone()[0] == num_inserts


### PR DESCRIPTION
![](https://media1.giphy.com/media/112XuxmYwdt54c/giphy.gif)

Fixture data_working_copy had a pytest.skip() that was disabling 53 tests.
By removing this and fixing some simple Python Database API bugs, I was able to get 45 of the tests to pass. For the remaining 8 tests (only 3 test functions, some are parameterized) I have re-applied the skip individually.

The changes I made yesterday in status.py also had some formatting issues that caused test failures for some disabled tests - fixed this also.

