### PR TITLE
commit: fix crash in an empty repository 

### DIFF
--- a/sno/commit.py
+++ b/sno/commit.py
@@ -54,6 +54,11 @@ def commit(ctx, message, message_file, allow_empty):
     """ Record changes to the repository """
     repo = ctx.obj.repo
 
+    if repo.is_empty:
+        raise click.UsageError(
+            'Empty repository.\n  (use "sno import" to add some data)'
+        )
+
     check_git_user(repo)
 
     commit = repo.head.peel(pygit2.Commit)

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -271,3 +271,23 @@ def test_commit_message(
         )
         print(last_message())
         assert last_message() == "sqwark 🐧"
+
+
+def test_empty(tmp_path, cli_runner, chdir):
+    repo_path = tmp_path / "one.sno"
+
+    # empty repo
+    r = cli_runner.invoke(["init", repo_path])
+    assert r.exit_code == 0, r
+    with chdir(repo_path):
+        r = cli_runner.invoke(["commit", "--allow-empty"])
+        assert r.exit_code == 2, r
+        assert "Empty repository" in r.stdout
+
+    # empty dir
+    empty_path = tmp_path / "two"
+    empty_path.mkdir()
+    with chdir(empty_path):
+        r = cli_runner.invoke(["commit", "--allow-empty"])
+        assert r.exit_code == 2, r
+        assert "not an existing repository" in r.stdout


### PR DESCRIPTION
Check for empty repository upfront.

[Fixes #30]