### PR TITLE
Proj: fix data path access

### DIFF
--- a/sno/__init__.py
+++ b/sno/__init__.py
@@ -59,13 +59,14 @@ else:
 # GDAL Data
 if not is_windows:
     os.environ["GDAL_DATA"] = os.path.join(prefix, "share", "gdal")
-    os.environ["PROJ_DATA"] = os.path.join(prefix, "share", "proj")
+    os.environ["PROJ_LIB"] = os.path.join(prefix, "share", "proj")
 
 # GDAL Error Handling
-from osgeo import gdal, ogr
+from osgeo import gdal, ogr, osr
 
 gdal.UseExceptions()
 ogr.UseExceptions()
+osr.UseExceptions()
 
 # Libgit2 TLS CA Certificates
 # We build libgit2 to prefer the OS certificate store on Windows/macOS, but Linux doesn't have one.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+from pathlib import Path
 
 import click
 import pygit2
@@ -216,3 +217,20 @@ def test_check_user_config(git_user_config, monkeypatch, data_archive, tmp_path)
         pygit2.option(
             pygit2.GIT_OPT_SET_SEARCH_PATH, pygit2.GIT_CONFIG_LEVEL_GLOBAL, prev_home
         )
+
+
+def test_gdal_proj_data():
+    import sno  # noqa
+    from osgeo import gdal, osr
+
+    # GDAL_DATA
+    assert "GDAL_DATA" in os.environ
+    assert gdal.GetConfigOption("GDAL_DATA") == os.environ["GDAL_DATA"]
+    assert (Path(gdal.GetConfigOption("GDAL_DATA")) / "gdalvrt.xsd").exists()
+
+    # PROJ_LIB
+    assert "PROJ_LIB" in os.environ
+    osr = osr.SpatialReference()
+    osr.ImportFromEPSG(4167)
+    assert osr.ExportToWkt()
+    assert (Path(os.environ["PROJ_LIB"]) / "nzgd2kgrid0005.gsb").exists()


### PR DESCRIPTION
- Enable exceptions from `osgeo.osr` module
- Add a test that hits `proj.db` (doesn't verify installer layout, but is better than nothing).