### PR TITLE
diff --json: Use feature objects instead of 2-lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.py?
 /data
 /venv
+/pip-wheel-metadata
 
 vendor/curl/**
 !vendor/curl/Makefile

--- a/sno/diff-view.html
+++ b/sno/diff-view.html
@@ -139,7 +139,9 @@
                 layers[dataset] = {}
                 featureMap[dataset] = {}
 
-                for (let [fOld, fNew] of diff.featureChanges) {
+                for (let change of diff.featureChanges) {
+                    const fOld = change['-']
+                    const fNew = change['+']
                     if (fOld && fNew) {
                         fc['updateOld'].push(fOld)
                         fc['updateNew'].push(fNew)
@@ -227,7 +229,9 @@
             // if schema has changed then it'll show up in every single feature
             let oldSchema = null
             let newSchema = null
-            for (let [fOld, fNew] of diff.featureChanges) {
+            for (let change of diff.featureChanges) {
+                const fOld = change['-']
+                const fNew = change['+']
                 if (fOld && !oldSchema) {
                     oldSchema = Object.keys(fOld.properties)
                     oldSchema.splice(0, 0, GEOM)
@@ -296,7 +300,9 @@
                 }
 
                 let tbody = table.createTBody()
-                for (let [fOld, fNew] of diff.featureChanges) {
+                for (let fc of diff.featureChanges) {
+                    let fOld = fc['-']
+                    let fNew = fc['+']
                     let change;
                     if (fOld && fNew) {
                         change = 'update'

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -764,21 +764,24 @@ def diff_output_json(*, output_path, dataset_count, **kwargs):
             d["metaChanges"][k] = [v_old, v_new]
 
         for k, v_old in diff["D"].items():
-            d["featureChanges"].append([_json_row(v_old, "D", pk_field), None])
+            d["featureChanges"].append({'-': _json_row(v_old, "D", pk_field)})
 
         for o in diff["I"]:
-            d["featureChanges"].append([None, _json_row(o, "I", pk_field)])
+            d["featureChanges"].append({'+': _json_row(o, "I", pk_field)})
 
         for _, (v_old, v_new) in diff["U"].items():
             d["featureChanges"].append(
-                [_json_row(v_old, "U-", pk_field), _json_row(v_new, "U+", pk_field)]
+                {
+                    '-': _json_row(v_old, "U-", pk_field),
+                    '+': _json_row(v_new, "U+", pk_field),
+                }
             )
 
         # sort for reproducibility
         d["featureChanges"].sort(
             key=lambda fc: (
-                fc[0]["id"] if fc[0] is not None else "",
-                fc[1]["id"] if fc[1] is not None else "",
+                fc['-']["id"] if '-' in fc else "",
+                fc['+']["id"] if '+' in fc else "",
             )
         )
         accumulated[dataset.path] = d

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -204,9 +204,8 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
                     "nz_pa_points_topo_150k": {
                         "metaChanges": {},
                         "featureChanges": [
-                            [
-                                None,
-                                {
+                            {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "Point",
@@ -221,9 +220,9 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "I::9999",
                                 },
-                            ],
-                            [
-                                {
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "Point",
@@ -241,10 +240,9 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "D::3",
                                 },
-                                None,
-                            ],
-                            [
-                                {
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "Point",
@@ -262,7 +260,7 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "U-::1",
                                 },
-                                {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "Point",
@@ -280,9 +278,9 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "U+::9998",
                                 },
-                            ],
-                            [
-                                {
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "Point",
@@ -300,7 +298,7 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "U-::2",
                                 },
-                                {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "Point",
@@ -318,7 +316,7 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "U+::2",
                                 },
-                            ],
+                            },
                         ],
                     }
                 }
@@ -598,9 +596,8 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
                     "nz_waca_adjustments": {
                         "metaChanges": {},
                         "featureChanges": [
-                            [
-                                None,
-                                {
+                            {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "Polygon",
@@ -622,9 +619,9 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
                                     },
                                     "id": "I::9999999",
                                 },
-                            ],
-                            [
-                                {
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "MultiPolygon",
@@ -694,10 +691,9 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
                                     },
                                     "id": "D::1452332",
                                 },
-                                None,
-                            ],
-                            [
-                                {
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "MultiPolygon",
@@ -761,7 +757,7 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
                                     },
                                     "id": "U-::1424927",
                                 },
-                                {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "MultiPolygon",
@@ -825,9 +821,9 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
                                     },
                                     "id": "U+::9998",
                                 },
-                            ],
-                            [
-                                {
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "MultiPolygon",
@@ -875,7 +871,7 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
                                     },
                                     "id": "U-::1443053",
                                 },
-                                {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": {
                                         "type": "MultiPolygon",
@@ -923,7 +919,7 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
                                     },
                                     "id": "U+::1443053",
                                 },
-                            ],
+                            },
                         ],
                     }
                 }
@@ -1130,9 +1126,8 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
                     "countiestbl": {
                         "metaChanges": {},
                         "featureChanges": [
-                            [
-                                None,
-                                {
+                            {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": None,
                                     "properties": {
@@ -1150,10 +1145,10 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
                                         "Shape_Area": 0.565_449_933_741_451,
                                     },
                                     "id": "I::9999",
-                                },
-                            ],
-                            [
-                                {
+                                }
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": None,
                                     "properties": {
@@ -1171,11 +1166,10 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
                                         "Shape_Leng": 4.876_296_245_235_406,
                                     },
                                     "id": "D::3",
-                                },
-                                None,
-                            ],
-                            [
-                                {
+                                }
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": None,
                                     "properties": {
@@ -1194,7 +1188,7 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "U-::1",
                                 },
-                                {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": None,
                                     "properties": {
@@ -1213,9 +1207,9 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "U+::9998",
                                 },
-                            ],
-                            [
-                                {
+                            },
+                            {
+                                '-': {
                                     "type": "Feature",
                                     "geometry": None,
                                     "properties": {
@@ -1234,7 +1228,7 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "U-::2",
                                 },
-                                {
+                                '+': {
                                     "type": "Feature",
                                     "geometry": None,
                                     "properties": {
@@ -1253,7 +1247,7 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
                                     },
                                     "id": "U+::2",
                                 },
-                            ],
+                            },
                         ],
                     }
                 }
@@ -1300,13 +1294,13 @@ def test_diff_rev_rev(data_archive, cli_runner):
                 ("U-::1095", "U+::1095"),
             }
             change_ids = {
-                ((f[0] or {}).get("id"), (f[1] or {}).get("id"))
+                (f.get('-', {}).get("id"), f.get('+', {}).get("id"))
                 for f in odata[H.POINTS_LAYER]["featureChanges"]
             }
             assert change_ids == CHANGE_IDS
             # this commit _adds_ names
             change_names = {
-                (f[0]["properties"]["name"], f[1]["properties"]["name"])
+                (f['-']["properties"]["name"], f['+']["properties"]["name"])
                 for f in odata[H.POINTS_LAYER]["featureChanges"]
             }
             assert not any(n[0] for n in change_names)
@@ -1326,13 +1320,13 @@ def test_diff_rev_rev(data_archive, cli_runner):
             assert len(odata[H.POINTS_LAYER]["featureChanges"]) == 5
             assert len(odata[H.POINTS_LAYER]["metaChanges"]) == 0
             change_ids = {
-                ((f[0] or {}).get("id"), (f[1] or {}).get("id"))
+                (f.get('-', {}).get("id"), f.get('+', {}).get("id"))
                 for f in odata[H.POINTS_LAYER]["featureChanges"]
             }
             assert change_ids == CHANGE_IDS
             # so names are _removed_
             change_names = {
-                (f[0]["properties"]["name"], f[1]["properties"]["name"])
+                (f['-']["properties"]["name"], f['+']["properties"]["name"])
                 for f in odata[H.POINTS_LAYER]["featureChanges"]
             }
             assert all(n[0] for n in change_names)
@@ -1392,11 +1386,13 @@ def test_diff_rev_wc(data_working_copy, geopackage, cli_runner):
 
         def _extract(diff_json):
             ds = {}
-            for fo, fn in odata["editing"]["featureChanges"]:
-                pk = fo["properties"]["id"] if fo else fn["properties"]["id"]
-                vo = fo["properties"]["value"] if fo else None
-                vn = fn["properties"]["value"] if fn else None
-                ds[pk] = (vo, vn)
+            for f in odata["editing"]["featureChanges"]:
+                old = f.get('-')
+                new = f.get('+')
+                pk = old["properties"]["id"] if old else new["properties"]["id"]
+                v_old = old["properties"]["value"] if old else None
+                v_new = new["properties"]["value"] if new else None
+                ds[pk] = (v_old, v_new)
             return ds
 
         # changes from HEAD (R1 -> WC)


### PR DESCRIPTION
This change is mainly to ensure the future extensibility of the json diff format, before it becomes too difficult to change due to usage.

[Current sno diff output documentation](https://github.com/koordinates/sno/wiki/sno-diff)

Nulls in deletes/inserts are ugly. Also, the old approach of using a 2-list ([old, new])
for each feature change isn't open to future extension.

I replace the 2-lists in the diff output with objects containing `-` and `+` keys. For inserts and deletes only one of the two keys appear.

* `[featureA, null]` --> `{"-": featureA}`
* `[null, featureA]` --> `{"+": featureB}`
* `[featureA, featureB]` --> `{"-": featureA, "+": featureB}`

The `+` and `-` keys were chosen mostly due to length and their prominent use in unified diffs. I also considered `old` and `new`, which has the advantage that it's easier to use as keys in Javascript object literals (`let {old, new} = diff.featureChanges[0]`), but we had an informal internal poll and it was outvoted.