### PR TITLE
Add exit codes that indicate what went wrong

### DIFF
--- a/sno/branch.py
+++ b/sno/branch.py
@@ -5,6 +5,7 @@ import click
 import pygit2
 
 from .cli_util import do_json_option
+from .exceptions import InvalidOperation
 from .exec import execvp
 
 
@@ -33,7 +34,7 @@ def branch(ctx, do_json, args):
     if sargs & {"-d", "--delete", "-D"}:
         branch = repo.head.shorthand
         if branch in sargs:
-            raise click.ClickException(
+            raise InvalidOperation(
                 f"Cannot delete the branch '{branch}' which you are currently on."
             )
 

--- a/sno/checkout.py
+++ b/sno/checkout.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import click
 import pygit2
 
+from .exceptions import InvalidOperation, NotFound, NO_WORKING_COPY
 from .structure import RepositoryStructure
 from .working_copy import WorkingCopy
 
@@ -66,7 +67,7 @@ def checkout(ctx, branch, fmt, force, path, datasets, refish):
     wc = repo_structure.working_copy
     if wc:
         if path is not None:
-            raise click.ClickException(
+            raise InvalidOperation(
                 f"This repository already has a working copy at: {wc.path}",
             )
 
@@ -221,7 +222,7 @@ def restore(ctx, source, pathspec):
     repo_structure = RepositoryStructure(repo)
     working_copy = repo_structure.working_copy
     if not working_copy:
-        raise click.ClickException("You don't have a working copy")
+        raise NotFound("You don't have a working copy", exit_code=NO_WORKING_COPY)
 
     head_commit = repo.head.peel(pygit2.Commit)
 
@@ -246,7 +247,7 @@ def workingcopy_set_path(ctx, new):
 
     repo_cfg = repo.config
     if "sno.workingcopy.path" not in repo_cfg:
-        raise click.ClickException("No working copy? Try `sno checkout`")
+        raise NotFound("No working copy? Try `sno checkout`", exit_code=NO_WORKING_COPY)
 
     new = Path(new)
     # TODO: This doesn't seem to do anything?

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -13,7 +13,6 @@ from . import (
     clone,
     commit,
     diff,
-    exceptions,
     init,
     fsck,
     merge,
@@ -24,9 +23,6 @@ from . import (
 )
 from .context import Context
 from .exec import execvp
-
-
-click.exceptions.UsageError.exit_code = exceptions.INVALID_ARGUMENT
 
 
 def print_version(ctx, param, value):

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -13,6 +13,7 @@ from . import (
     clone,
     commit,
     diff,
+    exceptions,
     init,
     fsck,
     merge,
@@ -23,6 +24,9 @@ from . import (
 )
 from .context import Context
 from .exec import execvp
+
+
+click.exceptions.UsageError.exit_code = exceptions.INVALID_ARGUMENT
 
 
 def print_version(ctx, param, value):

--- a/sno/commit.py
+++ b/sno/commit.py
@@ -155,7 +155,8 @@ def get_commit_message(repo, wc_changes, quiet=False):
         subprocess.check_call(editor_cmd, shell=True)
     except subprocess.CalledProcessError as e:
         raise SubprocessError(
-            f"There was a problem with the editor '{editor}': {e}"
+            f"There was a problem with the editor '{editor}': {e}",
+            called_process_error=e,
         ) from e
 
     with open(commit_editmsg, "rt", encoding="utf-8") as f:

--- a/sno/context.py
+++ b/sno/context.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
-import click
 import pygit2
+
+from .exceptions import NotFound, NO_REPOSITORY
 
 
 class Context(object):
@@ -41,11 +42,12 @@ class Context(object):
 
         if not self._repo or not self._repo.is_bare:
             if self.has_repo_path:
-                raise click.BadParameter(
-                    "Not an existing repository", param_hint="--repo"
-                )
+                message = "Not an existing repository"
+                param_hint = "repo"
             else:
-                raise click.UsageError(
-                    "Current directory is not an existing repository"
-                )
+                message = "Current directory is not an existing repository"
+                param_hint = None
+
+            raise NotFound(message, exit_code=NO_REPOSITORY, param_hint=param_hint)
+
         return self._repo

--- a/sno/core.py
+++ b/sno/core.py
@@ -1,7 +1,5 @@
-import os
-
 import pygit2
-from click import ClickException
+from .exceptions import NotFound, NO_USER
 
 
 def walk_tree(top, path="", topdown=True):
@@ -99,4 +97,4 @@ def check_git_user(repo=None):
 
     msg.append("\n(sno uses the same credentials and configuration as git)")
 
-    raise ClickException("\n".join(msg))
+    raise NotFound("\n".join(msg), exit_code=NO_USER)

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -20,6 +20,7 @@ from .exceptions import (
     NotYetImplemented,
     NotFound,
     NO_WORKING_COPY,
+    NO_COMMIT,
     UNCATEGORIZED_ERROR,
 )
 
@@ -442,14 +443,18 @@ def diff(ctx, output_format, output_path, exit_code, args):
                     commit_target = repo.revparse_single(commit_parts[2] or "HEAD")
                     L.debug("commit_target=%s", commit_target.id)
                 except KeyError:
-                    raise click.BadParameter("Invalid commit spec", param_hint="commit")
+                    raise NotFound(
+                        "Invalid commit spec", param_hint="commit", exit_code=NO_COMMIT
+                    )
                 else:
                     path_list.pop(0)
             else:
                 try:
                     commit_base = repo.revparse_single(commit_parts[0])
                 except KeyError:
-                    raise click.BadParameter("Invalid commit spec", param_hint="commit")
+                    raise NotFound(
+                        "Invalid commit spec", param_hint="commit", exit_code=NO_COMMIT
+                    )
                 else:
                     path_list.pop(0)
 

--- a/sno/exceptions.py
+++ b/sno/exceptions.py
@@ -1,7 +1,15 @@
 import click
 
 # Exit codes
-INVALID_ARGUMENT = 10
+
+SUCCESS = 0
+SUCCESS_WITH_FLAG = 1
+
+INVALID_ARGUMENT = 2
+
+# We could use 1 for this, except in --exit-code mode.
+# So we always use 11 for consistency.
+UNCATEGORIZED_ERROR = 11
 
 INVALID_OPERATION = 20
 
@@ -14,12 +22,12 @@ NO_BRANCH = 43
 NO_CHANGES = 44
 NO_WORKING_COPY = 45
 NO_USER = 46
-NO_IMPORT_SOURCE = 47
-NO_TABLE = 48
+NO_COMMIT = 47
+NO_IMPORT_SOURCE = 48
+NO_TABLE = 49
 
-SUBPROCESS_ERROR = 50
-
-UNCATEGORIZED_ERROR = 99
+SUBPROCESS_ERROR_FLAG = 128
+DEFAULT_SUBPROCESS_ERROR = 129
 
 
 class BaseException(click.ClickException):
@@ -66,4 +74,18 @@ class NotFound(BaseException):
 
 
 class SubprocessError(BaseException):
-    exit_code = SUBPROCESS_ERROR
+    exit_code = DEFAULT_SUBPROCESS_ERROR
+
+    def __init__(
+        self,
+        message,
+        exit_code=None,
+        param=None,
+        param_hint=None,
+        called_process_error=None,
+    ):
+        super(SubprocessError, self).__init__(
+            message, exit_code=exit_code, param=param, param_hint=param_hint
+        )
+        if called_process_error and not exit_code:
+            self.exit_code = SUBPROCESS_ERROR_FLAG + called_process_error.return_code

--- a/sno/exceptions.py
+++ b/sno/exceptions.py
@@ -1,0 +1,69 @@
+import click
+
+# Exit codes
+INVALID_ARGUMENT = 10
+
+INVALID_OPERATION = 20
+
+NOT_YET_IMPLEMENTED = 30
+
+NOT_FOUND = 40
+NO_REPOSITORY = 41
+NO_DATA = 42
+NO_BRANCH = 43
+NO_CHANGES = 44
+NO_WORKING_COPY = 45
+NO_USER = 46
+NO_IMPORT_SOURCE = 47
+NO_TABLE = 48
+
+SUBPROCESS_ERROR = 50
+
+UNCATEGORIZED_ERROR = 99
+
+
+class BaseException(click.ClickException):
+    """
+    A ClickException that can easily be constructed with any exit code,
+    and which can also optionally give a hint about which param lead to
+    the problem.
+    Providing a param hint or not can be done for any type of error -
+    an unparseable import path and an import path that points to a
+    corrupted database might both provide the same hint, but be
+    considered completely different types of errors.
+    """
+
+    exit_code = UNCATEGORIZED_ERROR
+
+    def __init__(self, message, exit_code=None, param=None, param_hint=None):
+        super(BaseException, self).__init__(message)
+
+        if exit_code is not None:
+            self.exit_code = exit_code
+
+        self.param_hint = None
+        if param_hint is not None:
+            self.param_hint = param_hint
+        elif param is not None:
+            self.param_hint = param.get_error_hint(None)
+
+    def format_message(self):
+        if self.param_hint is not None:
+            return f"Invalid value for {self.param_hint}: {self.message}"
+        return self.message
+
+
+class InvalidOperation(BaseException):
+    exit_code = INVALID_OPERATION
+
+
+class NotYetImplemented(BaseException):
+    exit_code = NOT_YET_IMPLEMENTED
+
+
+class NotFound(BaseException):
+    exit_code = NOT_FOUND
+
+
+class SubprocessError(BaseException):
+    exit_code = SUBPROCESS_ERROR

--- a/sno/fsck.py
+++ b/sno/fsck.py
@@ -5,7 +5,8 @@ import click
 import pygit2
 from osgeo import gdal
 
-from . import core, gpkg
+from . import gpkg
+from .exceptions import NotFound, NO_WORKING_COPY
 from .structure import RepositoryStructure
 
 
@@ -87,8 +88,9 @@ def fsck(ctx, reset_datasets, fsck_args):
 
     working_copy_path = repo.config["sno.workingcopy.path"]
     if not os.path.isfile(working_copy_path):
-        raise click.ClickException(
-            click.style(f"Working copy missing: {working_copy_path}", fg="red")
+        raise NotFound(
+            click.style(f"Working copy missing: {working_copy_path}", fg="red"),
+            exit_code=NO_WORKING_COPY,
         )
     working_copy = rs.working_copy
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -119,10 +119,7 @@ class ImportGPKG:
     def __init__(self, source, table=None):
         self.source = source
         self.table = table
-        try:
-            self.db = gpkg.db(self.source)
-        except Exception:
-            raise RuntimeError("aaaaaaargh")
+        self.db = gpkg.db(self.source)
 
     def __str__(self):
         s = f"GeoPackage: {self.source}"

--- a/sno/init.py
+++ b/sno/init.py
@@ -14,6 +14,13 @@ from sno import is_windows
 from . import gpkg, checkout, structure
 from .core import check_git_user
 from .cli_util import do_json_option
+from .exceptions import (
+    InvalidOperation,
+    NotFound,
+    INVALID_ARGUMENT,
+    NO_IMPORT_SOURCE,
+    NO_TABLE,
+)
 
 
 @click.command("import-gpkg", hidden=True)
@@ -88,7 +95,8 @@ class ImportPath(click.Path):
         prefix = prefix.upper()
         if prefix not in self.prefixes:
             self.fail(
-                f'invalid prefix: "{prefix}" (choose from {", ".join(self.prefixes)})'
+                f'invalid prefix: "{prefix}" (choose from {", ".join(self.prefixes)})',
+                exit_code=INVALID_ARGUMENT,
             )
 
         # resolve GPKG:~/foo.gpkg and GPKG:~me/foo.gpkg
@@ -99,6 +107,9 @@ class ImportPath(click.Path):
         path = super().convert(value, param, ctx)
         return (prefix, path, suffix)
 
+    def fail(self, message, param=None, ctx=None, exit_code=NO_IMPORT_SOURCE):
+        raise NotFound(message, exit_code=exit_code)
+
 
 class ImportGPKG:
     """ GeoPackage Import Source """
@@ -108,7 +119,10 @@ class ImportGPKG:
     def __init__(self, source, table=None):
         self.source = source
         self.table = table
-        self.db = gpkg.db(self.source)
+        try:
+            self.db = gpkg.db(self.source)
+        except Exception:
+            raise RuntimeError("aaaaaaargh")
 
     def __str__(self):
         s = f"GeoPackage: {self.source}"
@@ -124,8 +138,9 @@ class ImportGPKG:
             if not dbcur.execute(sql).fetchone():
                 raise ValueError("gpkg_contents table doesn't exist")
         except (ValueError, apsw.SQLError) as e:
-            raise ValueError(
-                f"'{self.source}' doesn't appear to be a valid GeoPackage"
+            raise NotFound(
+                f"'{self.source}' doesn't appear to be a valid GeoPackage",
+                exit_code=NO_IMPORT_SOURCE,
             ) from e
 
         if self.table:
@@ -136,8 +151,9 @@ class ImportGPKG:
                     table_name=?
                     AND data_type IN ('features', 'attributes', 'aspatial');"""
             if not dbcur.execute(sql, (self.table,)).fetchone():
-                raise ValueError(
-                    f"Feature/Attributes table '{self.table}' not found in gpkg_contents"
+                raise NotFound(
+                    f"Feature/Attributes table '{self.table}' not found in gpkg_contents",
+                    exit_code=NO_TABLE,
                 )
 
     def get_table_list(self):
@@ -333,8 +349,9 @@ def import_table(ctx, source, directory, do_list, do_json, version, method):
 
     try:
         source_loader.check()
-    except ValueError as e:
-        raise click.BadParameter(str(e), param_hint="source") from e
+    except NotFound as e:
+        e.param_hint = "source"
+        raise
 
     if do_list:
         source_loader.print_table_list(do_json=do_json)
@@ -408,8 +425,9 @@ def init(ctx, import_from, do_checkout, directory):
 
         try:
             source_loader.check()
-        except ValueError as e:
-            raise click.BadParameter(str(e), param_hint="import_from") from e
+        except NotFound as e:
+            e.param_hint = "import_from"
+            raise
 
         if not import_table:
             import_table = source_loader.prompt_for_table("Select a table to import")
@@ -424,7 +442,7 @@ def init(ctx, import_from, do_checkout, directory):
 
     repo_path = Path(directory).resolve()
     if any(repo_path.iterdir()):
-        raise click.BadParameter(f'"{repo_path}" isn\'t empty', param_hint="directory")
+        raise InvalidOperation(f'"{repo_path}" isn\'t empty', param_hint="directory")
 
     # Create the repository
     repo = pygit2.init_repository(str(repo_path), bare=True)

--- a/sno/pull.py
+++ b/sno/pull.py
@@ -1,7 +1,7 @@
 import click
-import pygit2
 
 from . import merge
+from .exceptions import NotFound, NO_BRANCH
 
 
 @click.command()
@@ -39,11 +39,12 @@ def pull(ctx, ff, ff_only, repository, refspecs):
     if repository is None:
         # matches git-pull behaviour
         if repo.head_is_detached:
-            raise click.UsageError(
+            raise NotFound(
                 (
                     "You are not currently on a branch. "
                     "Please specify which branch you want to merge with."
-                )
+                ),
+                exit_code=NO_BRANCH,
             )
 
         # git-fetch:

--- a/sno/query.py
+++ b/sno/query.py
@@ -1,17 +1,16 @@
 import datetime
 import json
 import logging
-import os
 import re
 import sys
 import time
 import types
 
 import click
-import pygit2
 from osgeo import ogr
 
 from . import structure
+from .exceptions import NotFound
 
 
 L = logging.getLogger("sno.query")
@@ -62,9 +61,7 @@ def query(ctx, path, command, params):
     try:
         dataset.get_spatial_index(dataset.name)
     except OSError:
-        raise click.ClickException(
-            "No spatial index found. Run `sno query {path} index`"
-        )
+        raise NotFound("No spatial index found. Run `sno query {path} index`")
 
     if command == "get":
         USAGE = "get PK"

--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -7,11 +7,11 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-import click
 import pygit2
 from osgeo import gdal
 
 from . import gpkg, diff
+from .exceptions import InvalidOperation
 
 L = logging.getLogger("sno.working_copy")
 
@@ -763,7 +763,7 @@ class WorkingCopy_GPKG_1(WorkingCopyGPKG):
             dbcur.execute(f"SELECT COUNT(*) FROM {self.TRACKING_TABLE};")
             is_dirty = dbcur.fetchone()[0]
             if is_dirty and not force:
-                raise click.ClickException(
+                raise InvalidOperation(
                     "You have uncommitted changes in your working copy. Commit or use --force to discard."
                 )
 

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -3,6 +3,8 @@ import subprocess
 
 import pytest
 
+from sno.exceptions import NO_REPOSITORY
+
 
 H = pytest.helpers.helpers()
 
@@ -146,14 +148,14 @@ def test_branches_empty(tmp_path, cli_runner, chdir):
 def test_branches_none(tmp_path, cli_runner, chdir):
     with chdir(tmp_path):
         r = cli_runner.invoke(["branch"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NO_REPOSITORY, r
         assert (
             r.stdout.splitlines()[-1]
             == "Error: Current directory is not an existing repository"
         )
 
         r = cli_runner.invoke(["branch", "--json"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NO_REPOSITORY, r
         assert (
             r.stdout.splitlines()[-1]
             == "Error: Current directory is not an existing repository"

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -13,6 +13,8 @@ from sno.commit import FALLBACK_EDITOR
 from sno.structure import RepositoryStructure
 from sno.working_copy import WorkingCopy
 
+from sno.exceptions import INVALID_ARGUMENT, NO_CHANGES, NO_DATA, NO_REPOSITORY
+
 
 H = pytest.helpers.helpers()
 
@@ -75,7 +77,7 @@ def test_commit(archive, layer, data_working_copy, geopackage, cli_runner, reque
     with data_working_copy(archive) as (repo_dir, wc_path):
         # empty
         r = cli_runner.invoke(["commit", "-m", "test-commit-empty"])
-        assert r.exit_code == 1, r
+        assert r.exit_code == NO_CHANGES, r
         assert r.stdout.splitlines() == ["Error: No changes to commit"]
 
         # empty
@@ -182,7 +184,7 @@ def test_commit_message(
 
         # E: empty
         r = cli_runner.invoke(["commit", "--allow-empty", "-m", ""])
-        assert r.exit_code == 1, r
+        assert r.exit_code == INVALID_ARGUMENT, r
 
         # file
         f_commit_message = str(tmp_path / "commit-message.txt")
@@ -198,7 +200,7 @@ def test_commit_message(
         r = cli_runner.invoke(
             ["commit", "--allow-empty", "-F", f_commit_message, "-m", "foo"]
         )
-        assert r.exit_code == 2, r
+        assert r.exit_code == INVALID_ARGUMENT, r
         assert "exclusive" in r.stdout
 
         # multiple
@@ -282,7 +284,7 @@ def test_empty(tmp_path, cli_runner, chdir):
     assert r.exit_code == 0, r
     with chdir(repo_path):
         r = cli_runner.invoke(["commit", "--allow-empty"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NO_DATA, r
         assert "Empty repository" in r.stdout
 
     # empty dir
@@ -290,5 +292,5 @@ def test_empty(tmp_path, cli_runner, chdir):
     empty_path.mkdir()
     with chdir(empty_path):
         r = cli_runner.invoke(["commit", "--allow-empty"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NO_REPOSITORY, r
         assert "not an existing repository" in r.stdout

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -7,6 +7,7 @@ import pytest
 
 import pygit2
 from sno.diff import Diff
+from sno.exceptions import NOT_YET_IMPLEMENTED
 
 
 H = pytest.helpers.helpers()
@@ -1645,15 +1646,15 @@ def test_diff_3way(data_working_copy, geopackage, cli_runner, insert, request):
 
         # changes <> master (commit <> commit) diff should fail
         r = cli_runner.invoke(["diff", "--quiet", f"{m_commit_id}..{b_commit_id}"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NOT_YET_IMPLEMENTED, r
         assert "3-way diffs aren't supported" in r.stdout
 
         # same the other way around
         r = cli_runner.invoke(["diff", "--quiet", f"{b_commit_id}..{m_commit_id}"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NOT_YET_IMPLEMENTED, r
         assert "3-way diffs aren't supported" in r.stdout
 
         # diff against working copy should fail too
         r = cli_runner.invoke(["diff", "--quiet", b_commit_id])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NOT_YET_IMPLEMENTED, r
         assert "3-way diffs aren't supported" in r.stdout

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3,6 +3,8 @@ import subprocess
 
 import pytest
 
+from sno.exceptions import NO_REPOSITORY
+
 
 H = pytest.helpers.helpers()
 
@@ -245,14 +247,14 @@ def test_status_empty(tmp_path, cli_runner, chdir):
 def test_status_none(tmp_path, cli_runner, chdir):
     with chdir(tmp_path):
         r = cli_runner.invoke(["status"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NO_REPOSITORY, r
         assert (
             r.stdout.splitlines()[-1]
             == "Error: Current directory is not an existing repository"
         )
 
         r = cli_runner.invoke(["status", "--json"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == NO_REPOSITORY, r
         assert (
             r.stdout.splitlines()[-1]
             == "Error: Current directory is not an existing repository"

--- a/tests/test_workingcopy.py
+++ b/tests/test_workingcopy.py
@@ -8,6 +8,7 @@ import pygit2
 
 import sno.checkout
 from sno.working_copy import WorkingCopy
+from sno.exceptions import INVALID_ARGUMENT, INVALID_OPERATION
 
 
 H = pytest.helpers.helpers()
@@ -155,7 +156,7 @@ def test_checkout_branch(data_working_copy, geopackage, cli_runner, tmp_path):
 
         # creating a new branch with existing name errors
         r = cli_runner.invoke(["checkout", "-b", "master"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == INVALID_ARGUMENT, r
         assert r.stdout.splitlines()[-1].endswith(
             "A branch named 'master' already exists."
         )
@@ -268,7 +269,7 @@ def test_switch_branch(data_working_copy, geopackage, cli_runner, tmp_path):
             assert db.changes() == 1
 
         r = cli_runner.invoke(["switch", "foo"])
-        assert r.exit_code == 1, r
+        assert r.exit_code == INVALID_OPERATION, r
         assert "Error: You have uncommitted changes in your working copy." in r.stdout
 
         r = cli_runner.invoke(["switch", "foo", "--discard-changes"])
@@ -384,7 +385,7 @@ def test_working_copy_reset(
 
             # this should error
             r = cli_runner.invoke(["checkout", "HEAD"])
-            assert r.exit_code == 1, r
+            assert r.exit_code == INVALID_OPERATION, r
 
             cur.execute("""SELECT COUNT(*) FROM ".sno-track";""")
             change_count = cur.fetchone()[0]
@@ -468,7 +469,7 @@ def test_workingcopy_set_path(data_working_copy, cli_runner, tmp_path):
         repo = pygit2.Repository(str(repo_path))
 
         r = cli_runner.invoke(["workingcopy-set-path", "/thingz.gpkg"])
-        assert r.exit_code == 2, r
+        assert r.exit_code == INVALID_ARGUMENT, r
 
         # relative path 1
         new_path = Path("new-thingz.gpkg")
@@ -658,14 +659,14 @@ def test_delete_branch(data_working_copy, cli_runner):
     with data_working_copy("points") as (repo_path, wc):
         # prevent deleting the current branch
         r = cli_runner.invoke(["branch", "-d", "master"])
-        assert r.exit_code == 1, r
+        assert r.exit_code == INVALID_OPERATION, r
         assert "Cannot delete" in r.stdout
 
         r = cli_runner.invoke(["checkout", "-b", "test"])
         assert r.exit_code == 0, r
 
         r = cli_runner.invoke(["branch", "-d", "test"])
-        assert r.exit_code == 1, r
+        assert r.exit_code == INVALID_OPERATION, r
 
         r = cli_runner.invoke(["checkout", "master"])
         assert r.exit_code == 0, r


### PR DESCRIPTION
![](https://media0.giphy.com/media/sWn2JKhoVxpwk/giphy.gif)

Useful for any app built on top of sno - until now, any error caused an exit code of either 1 or 2 (except in `sno diff --exit-code` where all errors caused exit code 2).

See exceptions.py for a list of exit codes so far. More can be added later as needed.

INVALID_ARGUMENT = 10

INVALID_OPERATION = 20

NOT_YET_IMPLEMENTED = 30

NOT_FOUND = 40
NO_REPOSITORY = 41
NO_DATA = 42
NO_BRANCH = 43
NO_CHANGES = 44
NO_WORKING_COPY = 45
NO_USER = 46
NO_IMPORT_SOURCE = 47
NO_TABLE = 48

SUBPROCESS_ERROR = 50

UNCATEGORIZED_ERROR = 99
