### PR TITLE
Expand 'show' command to display patches

### DIFF
--- a/sno/cli.py
+++ b/sno/cli.py
@@ -17,6 +17,7 @@ from . import (
     fsck,
     merge,
     pull,
+    show,
     status,
     query,
     upgrade,
@@ -109,6 +110,7 @@ cli.add_command(checkout.workingcopy_set_path)
 cli.add_command(clone.clone)
 cli.add_command(commit.commit)
 cli.add_command(diff.diff)
+cli.add_command(show.show)
 cli.add_command(fsck.fsck)
 cli.add_command(init.import_gpkg)
 cli.add_command(init.import_table)
@@ -121,13 +123,6 @@ cli.add_command(upgrade.upgrade)
 
 
 # aliases/shortcuts
-
-
-@cli.command()
-@click.pass_context
-def show(ctx):
-    """ Show the current commit """
-    ctx.invoke(log, args=["-1"])
 
 
 @cli.command()

--- a/sno/commit.py
+++ b/sno/commit.py
@@ -20,6 +20,7 @@ from .status import (
     get_diff_status_json,
     diff_status_to_text,
 )
+from .timestamps import to_iso8601_utc, to_iso8601_tz, commit_time_to_text
 from .working_copy import WorkingCopy
 from .structure import RepositoryStructure
 from .cli_util import MutexOption, do_json_option
@@ -200,25 +201,3 @@ def commit_json_to_text(jdict):
     diff = diff_status_to_text(jdict["changes"])
     datetime = commit_time_to_text(jdict["commitTime"], jdict["commitTimeOffset"])
     return f"[{branch} {commit}] {message}\n{diff}\n  Date: {datetime}"
-
-
-def to_iso8601_utc(datetime):
-    """Returns a string like: 2020-03-26T09:10:11Z"""
-    isoformat = datetime.astimezone(timezone.utc).replace(tzinfo=None).isoformat()
-    return f"{isoformat}Z"
-
-
-def to_iso8601_tz(timedelta):
-    """Returns a string like "+05:00" or "-05:00" (ie five hours ahead or behind)."""
-    abs_delta = datetime.utcfromtimestamp(abs(timedelta).seconds).strftime('%H:%M')
-    return f"+{abs_delta}" if abs(timedelta) == timedelta else f"-{abs_delta}"
-
-
-def commit_time_to_text(iso8601z, iso_offset):
-    """
-    Given an isoformat time in UTC, and a isoformat timezone offset,
-    returns the time in a human readable format, for that timezone.
-    """
-    right_time = datetime.fromisoformat(iso8601z.replace("Z", "+00:00"))
-    right_tzinfo = datetime.fromisoformat(iso8601z.replace("Z", iso_offset))
-    return right_time.astimezone(right_tzinfo.tzinfo).strftime("%c %z")

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -558,6 +558,16 @@ def diff(ctx, output_format, output_path, exit_code, args):
 
 @contextlib.contextmanager
 def diff_output_quiet(**kwargs):
+    """
+    Contextmanager.
+    Yields a callable which can be called with dataset diffs
+    (see `diff_output_text` docstring for more on that)
+
+    Writes nothing to the output. This is useful when you just want to find out
+    whether anything has changed in the diff (you can use the exit code)
+    and don't need output.
+    """
+
     def _out(dataset, diff):
         # this isn't a Diff object, it's the interior dataset view
         # so we can't use len()
@@ -681,6 +691,25 @@ def _repr_row(row, prefix="", exclude=None):
 
 @contextlib.contextmanager
 def diff_output_geojson(*, output_path, dataset_count, **kwargs):
+    """
+    Contextmanager.
+
+    Yields a callable which can be called with dataset diffs
+    (see `diff_output_text` docstring for more on that)
+
+    For features already existed but have changed, two features are written to the output:
+    one for the 'deleted' version of the feature, and one for the 'added' version.
+    This is intended for visualising in a map diff.
+
+    On exit, writes the diff as GeoJSON to the given output file.
+    For repos with more than one dataset, the output path must be a directory.
+    In that case:
+        * any .geojson files already in that directory will be deleted
+        * files will be written to `{layer_name}.geojson in the given directory
+
+    If the output file is stdout and isn't piped anywhere,
+    the json is prettified before writing.
+    """
     if dataset_count > 1:
         # output_path needs to be a directory
         if not output_path:
@@ -816,6 +845,17 @@ def _json_row(row, change, pk_field):
 
 @contextlib.contextmanager
 def diff_output_html(*, output_path, repo, base, target, dataset_count, **kwargs):
+    """
+    Contextmanager.
+    Yields a callable which can be called with dataset diffs
+    (see `diff_output_text` docstring for more on that)
+
+    On exit, writes an HTML diff to the given output file
+    (defaults to 'DIFF.html' in the repo directory).
+
+    If `-` is given as the output file, the HTML is written to stdout,
+    and no web browser is opened.
+    """
     if isinstance(output_path, Path):
         if output_path.is_dir():
             raise click.BadParameter(

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -616,7 +616,7 @@ def diff_output_text(*, output_path, **kwargs):
     pecho = {'file': fp, 'color': fp.isatty()}
     if isinstance(output_path, Path) and output_path.is_dir():
         raise click.BadParameter(
-            "Directory is not valid for --output + --text", param_hint="--output"
+            "Directory is not valid for --output with --text", param_hint="--output"
         )
 
     def _out(dataset, diff):
@@ -834,7 +834,7 @@ def diff_output_json(*, output_path, dataset_count, **kwargs):
     if isinstance(output_path, Path):
         if output_path.is_dir():
             raise click.BadParameter(
-                "Directory is not valid for --output + --json", param_hint="--output"
+                "Directory is not valid for --output with --json", param_hint="--output"
             )
 
     accumulated = {}
@@ -909,7 +909,7 @@ def diff_output_html(*, output_path, repo, base, target, dataset_count, **kwargs
     if isinstance(output_path, Path):
         if output_path.is_dir():
             raise click.BadParameter(
-                "Directory is not valid for --output + --html", param_hint="--output"
+                "Directory is not valid for --output with --html", param_hint="--output"
             )
 
     json_data = io.StringIO()

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -934,4 +934,4 @@ def diff_output_html(*, output_path, repo, base, target, dataset_count, **kwargs
     )
     if fo != sys.stdout:
         fo.close()
-        webbrowser.open_new(f"file://{output_path}")
+        webbrowser.open_new(f"file://{output_path.resolve()}")

--- a/sno/show.py
+++ b/sno/show.py
@@ -1,0 +1,148 @@
+import contextlib
+import functools
+import json
+from datetime import datetime, timezone, timedelta
+from io import StringIO
+
+import click
+import pygit2
+
+from .cli_util import MutexOption
+from .exceptions import NotFound, NO_COMMIT
+from .timestamps import to_iso8601_utc, to_iso8601_tz
+from . import diff
+
+
+@click.command()
+@click.pass_context
+@click.option(
+    "--text",
+    "output_format",
+    flag_value="text",
+    default=True,
+    help="Show commit in text format",
+    cls=MutexOption,
+    exclusive_with=["json"],
+)
+@click.option(
+    "--json",
+    "--patch",
+    "-p",
+    "output_format",
+    flag_value="json",
+    help="Show commit in JSON patch format",
+    cls=MutexOption,
+    exclusive_with=["text"],
+)
+@click.argument("refish", default='HEAD', required=False)
+def show(ctx, *, refish, output_format, **kwargs):
+    """
+    Show the given commit, or HEAD
+    """
+    # Ensure we were given a reference to a commit, and not a tree or something
+    repo = ctx.obj.repo
+    try:
+        obj = repo.revparse_single(refish)
+        obj.peel(pygit2.Commit)
+    except (KeyError, pygit2.InvalidSpecError):
+        raise NotFound(f"{refish} is not a commit", exit_code=NO_COMMIT)
+
+    patch_writer = globals()[f"patch_output_{output_format}"]
+
+    return diff.diff_with_writer(
+        ctx, patch_writer, exit_code=False, args=[f"{refish}^..{refish}"],
+    )
+
+
+@contextlib.contextmanager
+def patch_output_text(*, target, output_path, **kwargs):
+    """
+    Contextmanager.
+
+    Arguments:
+        target: a pygit2.Commit instance to show a patch for
+        output_path:   where the output should go; a path, file-like object or '-'
+
+    All other kwargs are passed to sno.diff.diff_output_text.
+
+    Yields a callable which can be called with dataset diffs.
+    The callable takes two arguments:
+        dataset: A sno.structure.DatasetStructure instance representing
+                 either the old or new version of the dataset.
+        diff:    The sno.diff.Diff instance to serialize
+
+    On exit, writes a human-readable patch as text to the given output file.
+
+    This patch may not be apply-able; it is intended for human readability.
+    In particular, geometry WKT is abbreviated and null values are represented
+    by a unicode "␀" character.
+    """
+    commit = target.head_commit
+    fp = diff.resolve_output_path(output_path)
+    pecho = {'file': fp, 'color': fp.isatty()}
+    with diff.diff_output_text(output_path=fp, **kwargs) as diff_writer:
+        author = commit.author
+        author_time_utc = datetime.fromtimestamp(author.time, timezone.utc)
+        author_timezone = timezone(timedelta(minutes=author.offset))
+        author_time_in_author_timezone = author_time_utc.astimezone(author_timezone)
+
+        click.secho(f'commit {commit.hex}', fg='yellow')
+        click.secho(f'Author: {author.name} <{author.email}>', **pecho)
+        click.secho(
+            f'Date:   {author_time_in_author_timezone.strftime("%c %z")}', **pecho
+        )
+        click.secho(**pecho)
+        for line in commit.message.splitlines():
+            click.secho(f'    {line}', **pecho)
+        click.secho(**pecho)
+        yield diff_writer
+
+
+@contextlib.contextmanager
+def patch_output_json(*, target, output_path, **kwargs):
+    """
+    Contextmanager.
+
+    Same arguments and usage as `patch_output_text`; see that docstring for usage.
+
+    On exit, writes the patch as JSON to the given output file.
+    If the output file is stdout and isn't piped anywhere,
+    the json is prettified first.
+
+    The patch JSON contains two top-level keys:
+        "sno.diff/v1": contains a JSON diff. See `sno.diff.diff_output_json` docstring.
+        "sno.patch/v1": contains metadata about the commit this patch represents:
+          {
+            "authorEmail": "joe@example.com",
+            "authorName": "Joe Bloggs",
+            "authorTime": "2020-04-15T01:19:16Z",
+            "authorTimeOffset": "+12:00",
+            "message": "Commit title\n\nThis commit makes some changes\n"
+          }
+
+    authorTime is always returned in UTC, in Z-suffixed ISO8601 format.
+    """
+    buf = StringIO()
+
+    output_path, original_output_path = buf, output_path
+    with diff.diff_output_json(output_path=output_path, **kwargs) as diff_writer:
+        yield diff_writer
+
+    # At this point, the diff_writer has been used, meaning the StringIO has
+    # the diff output in it. Now we can add some patch info
+    buf.seek(0)
+    output = json.load(buf)
+    commit = target.head_commit
+    author = commit.author
+    author_time = datetime.fromtimestamp(author.time, timezone.utc)
+    author_time_offset = timedelta(minutes=author.offset)
+
+    output['sno.patch/v1'] = {
+        'authorName': author.name,
+        'authorEmail': author.email,
+        "authorTime": to_iso8601_utc(author_time),
+        "authorTimeOffset": to_iso8601_tz(author_time_offset),
+        "message": commit.message,
+    }
+
+    diff.dump_json_diff_output(output, original_output_path)

--- a/sno/timestamps.py
+++ b/sno/timestamps.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timezone
+
+
+def to_iso8601_utc(datetime):
+    """
+    Accepts a datetime.datetime object with UTC timezone.
+    Returns a string like: 2020-03-26T09:10:11Z
+    """
+    isoformat = datetime.astimezone(timezone.utc).replace(tzinfo=None).isoformat()
+    return f"{isoformat}Z"
+
+
+def to_iso8601_tz(timedelta):
+    """
+    Accepts a datetime.timedelta object.
+    Returns a string like "+05:00" or "-05:00" (ie five hours ahead or behind).
+    """
+    abs_delta = datetime.utcfromtimestamp(abs(timedelta).seconds).strftime('%H:%M')
+    return f"+{abs_delta}" if abs(timedelta) == timedelta else f"-{abs_delta}"
+
+
+def commit_time_to_text(iso8601z, iso_offset):
+    """
+    Given an isoformat time in UTC, and a isoformat timezone offset,
+    returns the time in a human readable format, for that timezone.
+    """
+    right_time = datetime.fromisoformat(iso8601z.replace("Z", "+00:00"))
+    right_tzinfo = datetime.fromisoformat(iso8601z.replace("Z", iso_offset))
+    return right_time.astimezone(right_tzinfo.tzinfo).strftime("%c %z")

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -22,17 +22,3 @@ def test_log(data_archive, cli_runner):
             "",
             "    Import from nz-pa-points-topo-150k.gpkg",
         ]
-
-
-def test_show(data_archive, cli_runner):
-    """ review commit history """
-    with data_archive("points"):
-        r = cli_runner.invoke(["show"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
-            "commit 2a1b7be8bdef32aea1510668e3edccbc6d454852",
-            "Author: Robert Coup <robert@coup.net.nz>",
-            "Date:   Thu Jun 20 15:28:33 2019 +0100",
-            "",
-            "    Improve naming on Coromandel East coast",
-        ]


### PR DESCRIPTION
`sno show` already exists, but takes no options and actually just displays a text log entry for the given commit. This PR expands it to work much more like `git show`.


Shows a commit (default `HEAD`) as a patch, in either text
(a la `git show`) or JSON (with `--json`).

HTML and 'quiet' output could be added in future.

# To do

* [x] add tests

# Output

The patch is a diff plus some meta-information. The diff
is just the same as the `sno diff` output for the relevant
commit.

In text mode, the meta-information is the same as what
git show outputs:

```
commit ad9797ea83000864c2ab98c421d2d5256a12db8f
Author: Craig de Stigter <craig@destigter.nz>
Date:   Wed Apr 15 13:19:16 2020 +1200

    commit

<diff output follows>
```

In JSON mode, the metadata is added to the top level JSON object
so that the patch is also a diff. It looks like:

```json
{
  "sno.diff/v1": {...},
  "sno.patch/v1": {
    "authorName": "Craig de Stigter",
    "authorEmail": "craig@destigter.nz",
    "authorTime": "2020-04-15T01:19:16Z",
    "authorTimeOffset": "+12:00",
    "message": "commit"
  }
}
```

