### PR TITLE
Refactor diff.py so RepositoryStructure needn't contain a commit.

### DIFF
--- a/sno/diff.py
+++ b/sno/diff.py
@@ -480,9 +480,7 @@ def diff(ctx, output_format, output_path, exit_code, args):
                 # this needs a 3-way diff and we don't support them yet
                 raise NotYetImplemented(f"Sorry, 3-way diffs aren't supported yet.")
 
-        all_datasets = {ds.path for ds in base_rs}
-        if target_rs:
-            all_datasets |= {ds.path for ds in target_rs}
+        all_datasets = {ds.path for ds in base_rs} | {ds.path for ds in target_rs}
 
         if paths:
             all_datasets = set(filter(lambda dsp: dsp in paths, all_datasets))


### PR DESCRIPTION
![](https://media3.giphy.com/media/3ohs87F3CQBSdG8c0g/giphy.gif)

A pure refactoring change - things should be the same as before.
However, also written so that - if needed - we can change
RepositoryStructure to not wrap a commit, but only a tree.
More details follow.

I experimented with a change so that RepositoryStructures could
point at any particular tree, not just at any particular commit.
This could be useful for doing diffs against the empty tree, which
could be used to `sno show` the first commit in a repository.
(sno show always delegates to sno diff, and the first commit cannot
be diffed right now since there are no other commits to diff against.)

(Or it could possibly be useful to do arbitrary diffs between
any two repository structures, without reference to their
shared history. I don't know how useful this might be, but git
diff can diff arbitrary trees).

However, leaving the usefulness of that change aside for a moment:

The refactoring required turned out to be a useful
little refactoring on its own, so I've broken it off into its own
change - which you see here. Allowing diffs of trees as well as
commits can be discussed separately.