### PR TITLE
Fix sno merge so that when a conflict is found, it doesn't crash.

### DIFF
--- a/sno/merge.py
+++ b/sno/merge.py
@@ -1,6 +1,7 @@
 import click
 import pygit2
 
+from .exceptions import NotYetImplemented
 from .structure import RepositoryStructure
 
 
@@ -67,9 +68,12 @@ def merge(ctx, ff, ff_only, commit):
         )
         if merge_index.conflicts:
             print("Merge conflicts!")
-            for path, (ancestor, ours, theirs) in merge_index.conflicts:
-                print(f"Conflict: {path:60} {ancestor} | {ours} | {theirs}")
-            ctx.exit(1)
+            repo_structure = RepositoryStructure(repo)
+            for (ancestor, ours, theirs) in merge_index.conflicts:
+                dataset = repo_structure.get_for_index_entry(ours)
+                pk = dataset.index_entry_to_pk(ours)
+                print(f"Conflict: {dataset.path}:{pk}")
+            raise NotYetImplemented("Sorry, merging conflicts isn't supported yet")
 
         print("No conflicts!")
         merge_tree_id = merge_index.write_tree(repo)

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -111,6 +111,10 @@ class RepositoryStructure:
                         # examine inside this directory
                         to_examine.append((te_path, o))
 
+    def get_for_index_entry(self, index_entry):
+        dataset_path = index_entry.path.split(r"/.sno-table/", maxsplit=1)[0]
+        return self.get(dataset_path)
+
     @property
     def id(self):
         if self._commit is not None:
@@ -715,6 +719,12 @@ class Dataset1(DatasetStructure):
         schema = self.get_meta_item("sqlite_table_info")
         field = next(f for f in schema if f["name"] == self.primary_key)
         return field["type"]
+
+    def index_entry_to_pk(self, index_entry):
+        feature_path = index_entry.path.split("/.sno-table/", maxsplit=1)[1]
+        if feature_path.startswith("meta/"):
+            return 'meta'
+        return self.decode_pk(os.path.basename(feature_path))
 
     def encode_pk(self, pk):
         pk_enc = msgpack.packb(pk, use_bin_type=True)  # encode pk value via msgpack


### PR DESCRIPTION
![](https://media1.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

We still don't support actually merging when there are conflicts, but this change enables showing a list of the conflicting features and saying
"Sorry, merging conflicts isn't supported yet"

rather than crashing.