### PR TITLE
Allow diffs against the empty tree

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,6 +364,8 @@ class TestHelpers:
     }
     POINTS_HEAD_SHA = "2a1b7be8bdef32aea1510668e3edccbc6d454852"
     POINTS_HEAD1_SHA = "63a9492dd785b1f04dfc446330fa017f9459db4f"
+    POINTS_HEAD_TREE_SHA = "81f330e76b854e7448523307ff78bd6b83cadf21"
+    POINTS_HEAD1_TREE_SHA = "007ee9ab7f00b70a4199120cb274753c28e8ab92"
     POINTS_ROWCOUNT = 2143
 
     # Test Dataset (gpkg-polygons / polygons)


### PR DESCRIPTION
![](https://media2.giphy.com/media/vkaUCUov0KY9O/giphy.gif)

Right now `sno diff` only works between commits. This means there is no way to diff the first commit against the empty repository.

Fixes #44.

This change makes it so a RepositoryStructure can be a commit, or a tree - since the commit is mostly not used except as a way to get a particular tree.
This means getting a diff from the first commit to the empty repository can be done as follows:

`sno diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904...HEAD`

where `4b825dc642cb6eb9a060e54bf8d69288fbee4904` is the hash of the empty repository.

This is not very easy to remember, but we could still build upon this change to make any of the following:
- Make `sno show` show this diff if you sno show the first commit. This works in git.
- Make an alias for the empty tree, eg `sno diff EMPTY...HEAD`
- Make `HEAD^` etc an alias for the empty tree if they would otherwise refer to the commit before the first commit.

Small change, but structural change: will wait for rcoup@ to review to make sure this makes sense to him.