### PR TITLE
JSON syntax highlighting for all current JSON-output commands

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ msgpack==0.6.2            # via -r requirements/requirements.in
 psycopg2-binary==2.8.4    # via -r requirements/requirements.in
 pycparser==2.19           # via cffi
 #pygit2==1.1.0             # via -r requirements/requirements.in
+pygments==2.6.1           # via -r requirements/requirements.in
 rtree==0.9.4              # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ ptyprocess==0.6.0         # via pexpect
 py-cpuinfo==5.0.0         # via -r requirements/test.txt, pytest-benchmark
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pycparser==2.19           # via -r requirements/../requirements.txt, -r requirements/test.txt, cffi
-pygments==2.5.2           # via ipython
+pygments==2.6.1           # via -r requirements/../requirements.txt, -r requirements/test.txt, ipython
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-benchmark[aspect]==3.2.3  # via -r requirements/test.txt
 pytest-cov==2.8.1         # via -r requirements/test.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -5,3 +5,4 @@ pygit2==1.1.0
 Rtree~=0.9.4
 apsw-wheels~=3.30.1.post3
 certifi
+Pygments

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,6 +26,7 @@ psycopg2-binary==2.8.4    # via -r requirements/../requirements.txt
 py-cpuinfo==5.0.0         # via pytest-benchmark
 py==1.8.1                 # via pytest
 pycparser==2.19           # via -r requirements/../requirements.txt, cffi
+pygments==2.6.1           # via -r requirements/../requirements.txt
 pyparsing==2.4.6          # via packaging
 pytest-benchmark[aspect]==3.2.3  # via -r requirements/test.in
 pytest-cov==2.8.1         # via -r requirements/test.in

--- a/sno/branch.py
+++ b/sno/branch.py
@@ -1,4 +1,3 @@
-import json
 import sys
 
 import click
@@ -7,6 +6,7 @@ import pygit2
 from .cli_util import do_json_option
 from .exceptions import InvalidOperation
 from .exec import execvp
+from .output_util import dump_json_output
 
 
 @click.command(context_settings=dict(ignore_unknown_options=True))
@@ -26,7 +26,7 @@ def branch(ctx, do_json, args):
             raise click.UsageError(
                 "Illegal usage: 'sno branch --json' only supports listing branches."
             )
-        json.dump(list_branches_json(repo), sys.stdout, indent=2)
+        dump_json_output(list_branches_json(repo), sys.stdout)
         return
 
     # git's branch protection behaviour doesn't apply if it's a bare repository

--- a/sno/commit.py
+++ b/sno/commit.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 import shlex
@@ -14,6 +13,7 @@ from . import is_windows
 from .core import check_git_user
 from .diff import Diff
 from .exceptions import NotFound, SubprocessError, NO_CHANGES, NO_DATA, NO_WORKING_COPY
+from .output_util import dump_json_output
 from .status import (
     get_branch_status_message,
     get_diff_status_message,
@@ -108,7 +108,7 @@ def commit(ctx, message, message_file, allow_empty, do_json):
     new_commit = repo.head.peel(pygit2.Commit)
     jdict = commit_obj_to_json(new_commit, repo, wc_changes)
     if do_json:
-        json.dump(jdict, sys.stdout, indent=2)
+        dump_json_output(jdict, sys.stdout)
     else:
         click.echo(commit_json_to_text(jdict))
 

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -757,10 +757,8 @@ def diff_output_geojson(*, output_path, dataset_count, **kwargs):
                 p.unlink()
 
     def _out(dataset, diff):
-        json_params = {}
         if not output_path or output_path == '-':
             fp = sys.stdout
-            json_params = {"indent": 2, "sort_keys": True}
         elif output_path.is_dir():
             fp = (output_path / f"{dataset.name}.geojson").open("w")
         else:
@@ -787,7 +785,7 @@ def diff_output_geojson(*, output_path, dataset_count, **kwargs):
             fc["features"].append(_json_row(v_old, "U-", pk_field))
             fc["features"].append(_json_row(v_new, "U+", pk_field))
 
-        json.dump(fc, fp, **json_params)
+        dump_json_output(fc, fp)
 
     yield _out
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -21,6 +21,7 @@ from .exceptions import (
     NO_IMPORT_SOURCE,
     NO_TABLE,
 )
+from .output_util import dump_json_output
 
 
 @click.command("import-gpkg", hidden=True)
@@ -172,7 +173,7 @@ class ImportGPKG:
     def print_table_list(self, do_json=False):
         table_list = self.get_table_list()
         if do_json:
-            json.dump({"sno.tables/v1": table_list}, sys.stdout, indent=2)
+            dump_json_output({"sno.tables/v1": table_list}, sys.stdout)
         else:
             click.secho(f"GeoPackage tables in '{Path(self.source).name}':", bold=True)
             for table_name, identifier in table_list.items():

--- a/sno/output_util.py
+++ b/sno/output_util.py
@@ -1,0 +1,43 @@
+import io
+import json
+import sys
+
+
+def dump_json_output(output, output_path):
+    """
+    Dumps the output to JSON in the output file.
+    """
+
+    pretty = (not output_path) or output_path == "-"
+    fp = resolve_output_path(output_path)
+
+    json_params = {}
+    if pretty:
+        json_params.update({"indent": 2, "sort_keys": True})
+    if pretty and sys.stdout.isatty():
+        # Add syntax highlighting
+        from pygments import highlight
+        from pygments.lexers import JsonLexer
+        from pygments.formatters import TerminalFormatter
+
+        dumped = json.dumps(output, **json_params)
+        highlighted = highlight(dumped.encode(), JsonLexer(), TerminalFormatter())
+        fp.write(highlighted)
+    else:
+        json.dump(output, fp, **json_params)
+
+
+def resolve_output_path(output_path):
+    """
+    Takes a path-ish thing, and returns the appropriate writable file-like object.
+    The path-ish thing could be:
+      * a pathlib.Path object
+      * a file-like object
+      * the string '-' or None (both will return sys.stdout)
+    """
+    if isinstance(output_path, io.IOBase):
+        return output_path
+    elif (not output_path) or output_path == "-":
+        return sys.stdout
+    else:
+        return output_path.open("w")

--- a/sno/output_util.py
+++ b/sno/output_util.py
@@ -3,12 +3,12 @@ import json
 import sys
 
 
-def dump_json_output(output, output_path):
+def dump_json_output(output, output_path, pretty=True):
     """
     Dumps the output to JSON in the output file.
     """
 
-    pretty = (not output_path) or output_path == "-"
+    pretty = (not output_path) or output_path == "-" or output_path == sys.stdout
     fp = resolve_output_path(output_path)
 
     json_params = {}

--- a/sno/output_util.py
+++ b/sno/output_util.py
@@ -8,7 +8,6 @@ def dump_json_output(output, output_path, pretty=True):
     Dumps the output to JSON in the output file.
     """
 
-    pretty = (not output_path) or output_path == "-" or output_path == sys.stdout
     fp = resolve_output_path(output_path)
 
     json_params = {}

--- a/sno/show.py
+++ b/sno/show.py
@@ -1,5 +1,4 @@
 import contextlib
-import functools
 import json
 from datetime import datetime, timezone, timedelta
 from io import StringIO
@@ -9,6 +8,7 @@ import pygit2
 
 from .cli_util import MutexOption
 from .exceptions import NotFound, NO_COMMIT
+from .output_util import dump_json_output, resolve_output_path
 from .timestamps import to_iso8601_utc, to_iso8601_tz
 from . import diff
 
@@ -78,7 +78,7 @@ def patch_output_text(*, target, output_path, **kwargs):
     by a unicode "␀" character.
     """
     commit = target.head_commit
-    fp = diff.resolve_output_path(output_path)
+    fp = resolve_output_path(output_path)
     pecho = {'file': fp, 'color': fp.isatty()}
     with diff.diff_output_text(output_path=fp, **kwargs) as diff_writer:
         author = commit.author
@@ -145,4 +145,4 @@ def patch_output_json(*, target, output_path, **kwargs):
         "message": commit.message,
     }
 
-    diff.dump_json_diff_output(output, original_output_path)
+    dump_json_output(output, original_output_path)

--- a/sno/status.py
+++ b/sno/status.py
@@ -1,10 +1,10 @@
-import json
 import sys
 
 import click
 import pygit2
 
 from .cli_util import do_json_option
+from .output_util import dump_json_output
 from .structure import RepositoryStructure
 
 
@@ -16,7 +16,7 @@ def status(ctx, do_json):
     repo = ctx.obj.repo
     jdict = get_status_json(repo)
     if do_json:
-        json.dump(jdict, sys.stdout, indent=2)
+        dump_json_output(jdict, sys.stdout)
     else:
         click.echo(status_to_text(jdict))
 


### PR DESCRIPTION
Produces syntax-highlighted JSON output for all JSON-output commands.

Adds a dependency on [Pygments](https://pypi.org/project/Pygments/).

Note: This also turns on indented JSON in all circumstances (previously the `diff`/`show` commands produced compact JSON with `--output FILENAME`.) I suspect indented/pretty is what's desired in most situations.

The syntax highlighting is disabled when output is not a TTY; e.g. when redirected to another command, or sent to a file with `--output FILENAME`. However, the indentation is still enabled.

### Examples of output

`sno branch --json`:

<img width="752" alt="Screen Shot 2020-04-20 at 3 07 36 PM" src="https://user-images.githubusercontent.com/32112/79710299-b3f73d80-8318-11ea-85a9-049a221a2ca8.png">

`sno diff --json HEAD`:

<img width="860" alt="Screen Shot 2020-04-20 at 3 08 35 PM" src="https://user-images.githubusercontent.com/32112/79710339-d2f5cf80-8318-11ea-9da5-dbe70dbddb5a.png">
