### PR TITLE
Add basic support for viewing merge conflicts

### DIFF
--- a/sno/diff_output.py
+++ b/sno/diff_output.py
@@ -1,0 +1,343 @@
+import contextlib
+import io
+import json
+import string
+import sys
+import webbrowser
+from pathlib import Path
+
+import click
+
+from . import gpkg
+from .output_util import dump_json_output, resolve_output_path
+
+
+@contextlib.contextmanager
+def diff_output_quiet(**kwargs):
+    """
+    Contextmanager.
+    Yields a callable which can be called with dataset diffs
+    (see `diff_output_text` docstring for more on that)
+
+    Writes nothing to the output. This is useful when you just want to find out
+    whether anything has changed in the diff (you can use the exit code)
+    and don't need output.
+    """
+
+    def _out(dataset, diff):
+        pass
+
+    yield _out
+
+
+@contextlib.contextmanager
+def diff_output_text(*, output_path, **kwargs):
+    """
+    Contextmanager.
+
+    Yields a callable which can be called with dataset diffs.
+    The callable takes two arguments:
+        dataset: A sno.structure.DatasetStructure instance representing
+                 either the old or new version of the dataset.
+        diff:    The sno.diff.Diff instance to serialize
+
+    On exit, writes a human-readable diff to the given output file.
+
+    Certain shortcuts are taken to make the diff human readable,
+    so it may not be suitable as a patch to apply.
+    In particular, geometry WKT is abbreviated and null values are represented
+    by a unicode "␀" character.
+    """
+    fp = resolve_output_path(output_path)
+    pecho = {'file': fp, 'color': fp.isatty()}
+    if isinstance(output_path, Path) and output_path.is_dir():
+        raise click.BadParameter(
+            "Directory is not valid for --output with --text", param_hint="--output"
+        )
+
+    def _out(dataset, diff):
+        path = dataset.path
+        pk_field = dataset.primary_key
+        prefix = f"{path}:"
+        repr_excl = [pk_field]
+
+        for k, (v_old, v_new) in diff["META"].items():
+            click.secho(
+                f"--- {prefix}meta/{k}\n+++ {prefix}meta/{k}", bold=True, **pecho
+            )
+
+            s_old = set(v_old.items())
+            s_new = set(v_new.items())
+
+            diff_add = dict(s_new - s_old)
+            diff_del = dict(s_old - s_new)
+            all_keys = set(diff_del.keys()) | set(diff_add.keys())
+
+            for k in all_keys:
+                if k in diff_del:
+                    click.secho(
+                        repr_row({k: diff_del[k]}, prefix="- ", exclude=repr_excl),
+                        fg="red",
+                        **pecho,
+                    )
+                if k in diff_add:
+                    click.secho(
+                        repr_row({k: diff_add[k]}, prefix="+ ", exclude=repr_excl),
+                        fg="green",
+                        **pecho,
+                    )
+
+        prefix = f"{path}:{pk_field}="
+
+        for k, v_old in diff["D"].items():
+            click.secho(f"--- {prefix}{k}", bold=True, **pecho)
+            click.secho(
+                repr_row(v_old, prefix="- ", exclude=repr_excl), fg="red", **pecho
+            )
+
+        for o in diff["I"]:
+            click.secho(f"+++ {prefix}{o[pk_field]}", bold=True, **pecho)
+            click.secho(
+                repr_row(o, prefix="+ ", exclude=repr_excl), fg="green", **pecho
+            )
+
+        for _, (v_old, v_new) in diff["U"].items():
+            click.secho(
+                f"--- {prefix}{v_old[pk_field]}\n+++ {prefix}{v_new[pk_field]}",
+                bold=True,
+                **pecho,
+            )
+
+            s_old = set(v_old.items())
+            s_new = set(v_new.items())
+
+            diff_add = dict(s_new - s_old)
+            diff_del = dict(s_old - s_new)
+            all_keys = sorted(set(diff_del.keys()) | set(diff_add.keys()))
+
+            for k in all_keys:
+                if k in diff_del:
+                    rk = repr_row({k: diff_del[k]}, prefix="- ", exclude=repr_excl)
+                    if rk:
+                        click.secho(rk, fg="red", **pecho)
+                if k in diff_add:
+                    rk = repr_row({k: diff_add[k]}, prefix="+ ", exclude=repr_excl)
+                    if rk:
+                        click.secho(rk, fg="green", **pecho)
+
+    yield _out
+
+
+def repr_row(row, prefix="", exclude=None):
+    m = []
+    exclude = exclude or set()
+    for k in sorted(row.keys()):
+        if k.startswith("__") or k in exclude:
+            continue
+
+        v = row[k]
+
+        if isinstance(v, bytes):
+            g = gpkg.geom_to_ogr(v)
+            geom_typ = g.GetGeometryName()
+            if g.IsEmpty():
+                v = f"{geom_typ} EMPTY"
+            else:
+                v = f"{geom_typ}(...)"
+            del g
+
+        v = "␀" if v is None else v
+        m.append("{prefix}{k:>40} = {v}".format(k=k, v=v, prefix=prefix))
+
+    return "\n".join(m)
+
+
+@contextlib.contextmanager
+def diff_output_geojson(*, output_path, dataset_count, **kwargs):
+    """
+    Contextmanager.
+
+    Yields a callable which can be called with dataset diffs
+    (see `diff_output_text` docstring for more on that)
+
+    For features already existed but have changed, two features are written to the output:
+    one for the 'deleted' version of the feature, and one for the 'added' version.
+    This is intended for visualising in a map diff.
+
+    On exit, writes the diff as GeoJSON to the given output file.
+    For repos with more than one dataset, the output path must be a directory.
+    In that case:
+        * any .geojson files already in that directory will be deleted
+        * files will be written to `{layer_name}.geojson in the given directory
+
+    If the output file is stdout and isn't piped anywhere,
+    the json is prettified before writing.
+    """
+    if dataset_count > 1:
+        # output_path needs to be a directory
+        if not output_path:
+            raise click.BadParameter(
+                "Need to specify a directory via --output for --geojson with >1 dataset",
+                param_hint="--output",
+            )
+        elif output_path == "-" or output_path.is_file():
+            raise click.BadParameter(
+                "A file is not valid for --output + --geojson with >1 dataset",
+                param_hint="--output",
+            )
+
+        if not output_path.exists():
+            output_path.mkdir()
+        else:
+            for p in output_path.glob("*.geojson"):
+                p.unlink()
+
+    def _out(dataset, diff):
+        if not output_path or output_path == '-':
+            fp = sys.stdout
+        elif output_path.is_dir():
+            fp = (output_path / f"{dataset.name}.geojson").open("w")
+        else:
+            fp = output_path.open("w")
+
+        pk_field = dataset.primary_key
+
+        fc = {"type": "FeatureCollection", "features": []}
+
+        for k, (v_old, v_new) in diff["META"].items():
+            click.secho(
+                f"Warning: meta changes aren't included in GeoJSON output: {k}",
+                fg="yellow",
+                file=sys.stderr,
+            )
+
+        for k, v_old in diff["D"].items():
+            fc["features"].append(_json_row(v_old, "D", pk_field))
+
+        for o in diff["I"]:
+            fc["features"].append(_json_row(o, "I", pk_field))
+
+        for _, (v_old, v_new) in diff["U"].items():
+            fc["features"].append(_json_row(v_old, "U-", pk_field))
+            fc["features"].append(_json_row(v_new, "U+", pk_field))
+
+        dump_json_output(fc, fp)
+
+    yield _out
+
+
+@contextlib.contextmanager
+def diff_output_json(*, output_path, dataset_count, **kwargs):
+    """
+    Contextmanager.
+    Yields a callable which can be called with dataset diffs
+    (see `diff_output_text` docstring for more on that)
+
+    On exit, writes the diff as JSON to the given output file.
+    If the output file is stdout and isn't piped anywhere,
+    the json is prettified first.
+    """
+    if isinstance(output_path, Path):
+        if output_path.is_dir():
+            raise click.BadParameter(
+                "Directory is not valid for --output with --json", param_hint="--output"
+            )
+
+    accumulated = {}
+
+    def _out(dataset, diff):
+        pk_field = dataset.primary_key
+
+        d = {"metaChanges": {}, "featureChanges": []}
+        for k, (v_old, v_new) in diff["META"].items():
+            d["metaChanges"][k] = [v_old, v_new]
+
+        for k, v_old in diff["D"].items():
+            d["featureChanges"].append({'-': _json_row(v_old, "D", pk_field)})
+
+        for o in diff["I"]:
+            d["featureChanges"].append({'+': _json_row(o, "I", pk_field)})
+
+        for _, (v_old, v_new) in diff["U"].items():
+            d["featureChanges"].append(
+                {
+                    '-': _json_row(v_old, "U-", pk_field),
+                    '+': _json_row(v_new, "U+", pk_field),
+                }
+            )
+
+        # sort for reproducibility
+        d["featureChanges"].sort(
+            key=lambda fc: (
+                fc['-']["id"] if '-' in fc else "",
+                fc['+']["id"] if '+' in fc else "",
+            )
+        )
+        accumulated[dataset.path] = d
+
+    yield _out
+
+    dump_json_output({"sno.diff/v1": accumulated}, output_path)
+
+
+def _json_row(row, change, pk_field):
+    f = {
+        "type": "Feature",
+        "geometry": None,
+        "properties": {},
+        "id": f"{change}::{row[pk_field]}",
+    }
+
+    for k in row.keys():
+        v = row[k]
+        if isinstance(v, bytes):
+            g = gpkg.geom_to_ogr(v)
+            f["geometry"] = json.loads(g.ExportToJson())
+        else:
+            f["properties"][k] = v
+
+    return f
+
+
+@contextlib.contextmanager
+def diff_output_html(*, output_path, repo, base, target, dataset_count, **kwargs):
+    """
+    Contextmanager.
+    Yields a callable which can be called with dataset diffs
+    (see `diff_output_text` docstring for more on that)
+
+    On exit, writes an HTML diff to the given output file
+    (defaults to 'DIFF.html' in the repo directory).
+
+    If `-` is given as the output file, the HTML is written to stdout,
+    and no web browser is opened.
+    """
+    if isinstance(output_path, Path):
+        if output_path.is_dir():
+            raise click.BadParameter(
+                "Directory is not valid for --output with --html", param_hint="--output"
+            )
+
+    json_data = io.StringIO()
+    with diff_output_json(
+        output_path=json_data, dataset_count=dataset_count
+    ) as json_writer:
+        yield json_writer
+
+    with open(
+        Path(__file__).resolve().with_name("diff-view.html"), "r", encoding="utf8"
+    ) as ft:
+        template = string.Template(ft.read())
+
+    title = f"{Path(repo.path).name}: {base.short_id} .. {target.short_id if target else 'working-copy'}"
+
+    if not output_path:
+        output_path = Path(repo.path) / "DIFF.html"
+    fo = resolve_output_path(output_path)
+
+    fo.write(
+        template.substitute({"title": title, "geojson_data": json_data.getvalue()})
+    )
+    if fo != sys.stdout:
+        fo.close()
+        webbrowser.open_new(f"file://{output_path.resolve()}")

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -1,7 +1,7 @@
 import click
-import pygit2
 
-from .exceptions import NotYetImplemented
+from .diff_output import repr_row
+from .exceptions import InvalidOperation, NotYetImplemented
 from .structure import RepositoryStructure
 
 
@@ -34,22 +34,25 @@ def merge(ctx, ff, ff_only, commit):
             "Conflicting parameters: --no-ff & --ff-only", param_hint="--ff-only"
         )
 
-    c_base = repo[repo.head.target]
+    c_ours = repo[repo.head.target]
 
     # accept ref-ish things (refspec, branch, commit)
-    c_head, r_head = repo.resolve_refish(commit)
+    c_theirs, r_theirs = repo.resolve_refish(commit)
 
-    print(f"Merging {c_head.id} to {c_base.id} ...")
-    merge_base = repo.merge_base(c_base.oid, c_head.oid)
-    print(f"Found merge base: {merge_base}")
+    print(f"Merging {c_theirs.id} to {c_ours.id} ...")
+    merge_base_id = repo.merge_base(c_theirs.id, c_ours.id)
+    print(f"Found merge base: {merge_base_id}")
+
+    if not merge_base_id:
+        raise InvalidOperation(f"Commits {c_theirs.id} and {c_ours.id} aren't related.")
 
     # We're up-to-date if we're trying to merge our own common ancestor.
-    if merge_base == c_head.oid:
+    if merge_base_id == c_theirs.id:
         print("Already merged!")
         return
 
     # We're fastforwardable if we're our own common ancestor.
-    can_ff = merge_base == c_base.id
+    can_ff = merge_base_id == c_ours.id
 
     if ff_only and not can_ff:
         print("Can't resolve as a fast-forward merge and --ff-only specified")
@@ -57,39 +60,40 @@ def merge(ctx, ff, ff_only, commit):
 
     if can_ff and ff:
         # do fast-forward merge
-        repo.head.set_target(c_head.id, "merge: Fast-forward")
-        commit_id = c_head.id
+        repo.head.set_target(c_theirs.id, "merge: Fast-forward")
+        commit_id = c_theirs.id
         print("Fast-forward")
     else:
-        ancestor_tree = repo[merge_base].tree
-
+        c_ancestor = repo[merge_base_id]
         merge_index = repo.merge_trees(
-            ancestor=ancestor_tree, ours=c_base.tree, theirs=c_head.tree
+            ancestor=c_ancestor.tree, ours=c_ours.tree, theirs=c_theirs.tree
         )
         if merge_index.conflicts:
-            print("Merge conflicts!")
-            repo_structure = RepositoryStructure(repo)
-            for (ancestor, ours, theirs) in merge_index.conflicts:
-                dataset = repo_structure.get_for_index_entry(ours)
-                pk = dataset.index_entry_to_pk(ours)
-                print(f"Conflict: {dataset.path}:{pk}")
-            raise NotYetImplemented("Sorry, merging conflicts isn't supported yet")
+            handle_merge_conflicts(
+                repo,
+                merge_index,
+                ancestor=(c_ancestor, "ancestor"),
+                ours=(c_ours, "HEAD"),
+                theirs=(c_theirs, commit),
+            )
+        else:
+            print("No conflicts!")
+            merge_tree_id = merge_index.write_tree(repo)
+            print(f"Merge tree: {merge_tree_id}")
 
-        print("No conflicts!")
-        merge_tree_id = merge_index.write_tree(repo)
-        print(f"Merge tree: {merge_tree_id}")
-
-        user = repo.default_signature
-        merge_message = "Merge '{}'".format(r_head.shorthand if r_head else c_head.id)
-        commit_id = repo.create_commit(
-            repo.head.name,
-            user,
-            user,
-            merge_message,
-            merge_tree_id,
-            [c_base.oid, c_head.oid],
-        )
-        print(f"Merge commit: {commit_id}")
+            user = repo.default_signature
+            merge_message = "Merge '{}'".format(
+                r_theirs.shorthand if r_theirs else c_theirs.id
+            )
+            commit_id = repo.create_commit(
+                repo.head.name,
+                user,
+                user,
+                merge_message,
+                merge_tree_id,
+                [c_ours.oid, c_theirs.oid],
+            )
+            print(f"Merge commit: {commit_id}")
 
     # update our working copy
     repo_structure = RepositoryStructure(repo)
@@ -97,3 +101,120 @@ def merge(ctx, ff, ff_only, commit):
     click.echo(f"Updating {wc.path} ...")
     commit = repo[commit_id]
     return wc.reset(commit, repo_structure)
+
+
+def _get_commit(commit_or_tuple):
+    """Given either a commit or a tuple (commit, label), returns the commit"""
+    if type(commit_or_tuple) is tuple:
+        return commit_or_tuple[0]
+    return commit_or_tuple
+
+
+def _get_commit_label(commit_or_tuple):
+    """Given either a commit or a tuple (commit, label), returns a label for the commit"""
+    if type(commit_or_tuple) is tuple:
+        commit = commit_or_tuple[0]
+        label = commit_or_tuple[1]
+        if label != commit.id.hex:
+            label = f"{label} ({commit.id.hex})"
+        return label
+    else:
+        return commit_or_tuple.id.hex
+
+
+def _safe_get_dataset_for_index_entry(repo_structure, index_entry):
+    """Gets the dataset that a pygit2.IndexEntry refers to, or None"""
+    try:
+        return repo_structure.get_for_index_entry(index_entry)
+    except KeyError:
+        return None
+
+
+def _get_pk_for_index_entry(dataset, index_entry):
+    """Uses a dataset to decode the primary key that a pygit2.IndexEntry refers to"""
+    return dataset.index_entry_to_pk(index_entry)
+
+
+def _safe_get_feature(dataset, pk):
+    """Gets the dataset's feature with a particular primary key, or None"""
+    try:
+        _, feature = dataset.get_feature(pk)
+        return feature
+    except KeyError:
+        return None
+
+
+def first_true(iterable):
+    return next(filter(None, iterable))
+
+
+def handle_merge_conflicts(
+    repo, merge_index, ancestor, ours, theirs,
+):
+    """
+    Prints merge conflicts and fails, since resolving merge conflicts is not yet supported.
+
+    repo - a pygit2.Repository
+    merge_index - a pygit2.Index containing the attempted merge and merge conflicts.
+    ancestor, ours, theirs - each is either a pygit2.Commit or tuple (pygit2.Commit, label) -
+        where label is a name of the commit that the user would recognize in this context.
+
+    """
+    print("Merge conflicts!")
+    # All of the following are 3-tuples of the form (ancestor, ours, theirs)
+    commit_args3 = (ancestor, ours, theirs)
+    commits3 = tuple(_get_commit(arg) for arg in commit_args3)
+    labels3 = tuple(_get_commit_label(arg) for arg in commit_args3)
+    repo_structures3 = tuple(RepositoryStructure(repo, commit=c) for c in commits3)
+
+    conflict_pks = {}
+    for index_entries3 in merge_index.conflicts:
+        datasets3 = tuple(
+            _safe_get_dataset_for_index_entry(*x)
+            for x in zip(repo_structures3, index_entries3)
+        )
+        dataset = first_true(datasets3)
+        dataset_path = dataset.path
+        if None in datasets3:
+            for i in range(3):
+                presence = "present" if datasets3[i] is not None else "absent"
+                print(f"{labels3[i]}: {dataset_path} is {presence}")
+            raise NotYetImplemented(
+                "Sorry, resolving conflicts where datasets are added or removed isn't supported yet"
+            )
+
+        pks3 = tuple(
+            _get_pk_for_index_entry(*x) for x in zip(datasets3, index_entries3)
+        )
+        if "META" in pks3:
+            raise NotYetImplemented(
+                "Sorry, resolving conflicts in metadata isn't supported yet"
+            )
+        pk = first_true(pks3)
+        if pks3.count(pk) != 3:
+            for i in range(3):
+                print(f"{labels3[i]}: {dataset_path}:{pks3[i]}")
+            raise NotYetImplemented(
+                "Sorry, resolving conflicts where primary keys have changed isn't supported yet"
+            )
+        conflict_pks.setdefault(dataset_path, [])
+        conflict_pks[dataset_path].append(pk)
+
+    prefixes3 = ("- ", "+ ", "+ ")
+    big_prefixes3 = ("---", "+++", "+++")
+    cols3 = ("red", "green", "green")
+
+    for dataset_path, pks in conflict_pks.items():
+        datasets = tuple(rs[dataset_path] for rs in repo_structures3)
+        for pk in sorted(pks):
+            features3 = tuple(_safe_get_feature(d, pk) for d in datasets)
+            click.secho(f"=========== {dataset_path}:{pk} ==========", bold=True)
+            for i in range(3):
+                click.secho(f"{big_prefixes3[i]} {labels3[i]}")
+                if features3[i] is not None:
+                    click.secho(
+                        repr_row(features3[i], prefix=prefixes3[i]), fg=cols3[i]
+                    )
+            click.secho()
+
+    raise NotYetImplemented("Sorry, merging conflicts isn't supported yet")

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -735,7 +735,7 @@ class Dataset1(DatasetStructure):
     def index_entry_to_pk(self, index_entry):
         feature_path = index_entry.path.split("/.sno-table/", maxsplit=1)[1]
         if feature_path.startswith("meta/"):
-            return 'meta'
+            return 'META'
         return self.decode_pk(os.path.basename(feature_path))
 
     def encode_pk(self, pk):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,76 +345,102 @@ def helpers():
 
 
 class TestHelpers:
+
     # Test Dataset (gpkg-points / points)
-    POINTS_LAYER = "nz_pa_points_topo_150k"
-    POINTS_LAYER_PK = "fid"
-    POINTS_INSERT = f"""
-        INSERT INTO {POINTS_LAYER}
-                        (fid, geom, t50_fid, name_ascii, macronated, name)
-                    VALUES
-                        (:fid, GeomFromEWKT(:geom), :t50_fid, :name_ascii, :macronated, :name);
-    """
-    POINTS_RECORD = {
-        "fid": 9999,
-        "geom": "POINT(0 0)",
-        "t50_fid": 9_999_999,
-        "name_ascii": "Te Motu-a-kore",
-        "macronated": False,
-        "name": "Te Motu-a-kore",
-    }
-    POINTS_HEAD_SHA = "2a1b7be8bdef32aea1510668e3edccbc6d454852"
-    POINTS_HEAD1_SHA = "63a9492dd785b1f04dfc446330fa017f9459db4f"
-    POINTS_HEAD_TREE_SHA = "81f330e76b854e7448523307ff78bd6b83cadf21"
-    POINTS_HEAD1_TREE_SHA = "007ee9ab7f00b70a4199120cb274753c28e8ab92"
-    POINTS_ROWCOUNT = 2143
+    class POINTS:
+        LAYER = "nz_pa_points_topo_150k"
+        LAYER_PK = "fid"
+        INSERT = f"""
+            INSERT INTO {LAYER}
+                            (fid, geom, t50_fid, name_ascii, macronated, name)
+                        VALUES
+                            (:fid, GeomFromEWKT(:geom), :t50_fid, :name_ascii, :macronated, :name);
+        """
+        RECORD = {
+            "fid": 9999,
+            "geom": "POINT(0 0)",
+            "t50_fid": 9_999_999,
+            "name_ascii": "Te Motu-a-kore",
+            "macronated": False,
+            "name": "Te Motu-a-kore",
+        }
+        HEAD_SHA = "2a1b7be8bdef32aea1510668e3edccbc6d454852"
+        HEAD1_SHA = "63a9492dd785b1f04dfc446330fa017f9459db4f"
+        HEAD_TREE_SHA = "81f330e76b854e7448523307ff78bd6b83cadf21"
+        HEAD1_TREE_SHA = "007ee9ab7f00b70a4199120cb274753c28e8ab92"
+        ROWCOUNT = 2143
+        TEXT_FIELD = "name"
+        SAMPLE_PKS = list(range(1, 11))
 
     # Test Dataset (gpkg-polygons / polygons)
-    POLYGONS_LAYER = "nz_waca_adjustments"
-    POLYGONS_LAYER_PK = "id"
-    POLYGONS_INSERT = f"""
-        INSERT INTO {POLYGONS_LAYER}
-                        (id, geom, date_adjusted, survey_reference, adjusted_nodes)
-                    VALUES
-                        (:id, GeomFromEWKT(:geom), :date_adjusted, :survey_reference, :adjusted_nodes);
-    """
-    POLYGONS_RECORD = {
-        "id": 9_999_999,
-        "geom": "POLYGON((0 0, 0 0.001, 0.001 0.001, 0.001 0, 0 0))",
-        "date_adjusted": "2019-07-05T13:04:00+01:00",
-        "survey_reference": "Null Island™ 🗺",
-        "adjusted_nodes": 123,
-    }
-    POLYGONS_HEAD_SHA = "1fb58eb54237c6e7bfcbd7ea65dc999a164b78ec"
-    POLYGONS_ROWCOUNT = 228
+    class POLYGONS:
+        LAYER = "nz_waca_adjustments"
+        LAYER_PK = "id"
+        INSERT = f"""
+            INSERT INTO {LAYER}
+                            (id, geom, date_adjusted, survey_reference, adjusted_nodes)
+                        VALUES
+                            (:id, GeomFromEWKT(:geom), :date_adjusted, :survey_reference, :adjusted_nodes);
+        """
+        RECORD = {
+            "id": 9_999_999,
+            "geom": "POLYGON((0 0, 0 0.001, 0.001 0.001, 0.001 0, 0 0))",
+            "date_adjusted": "2019-07-05T13:04:00+01:00",
+            "survey_reference": "Null Island™ 🗺",
+            "adjusted_nodes": 123,
+        }
+        HEAD_SHA = "1fb58eb54237c6e7bfcbd7ea65dc999a164b78ec"
+        ROWCOUNT = 228
+        TEXT_FIELD = "survey_reference"
+        SAMPLE_PKS = [
+            1424927,
+            1443053,
+            1452332,
+            1456853,
+            1456912,
+            1457297,
+            1457355,
+            1457612,
+            1457636,
+            1458553,
+        ]
 
     # Test Dataset (gpkg-spec / table)
-
-    TABLE_LAYER = "countiestbl"
-    TABLE_LAYER_PK = "OBJECTID"
-    TABLE_INSERT = f"""
-        INSERT INTO {TABLE_LAYER}
-                        (OBJECTID, NAME, STATE_NAME, STATE_FIPS, CNTY_FIPS, FIPS, AREA, POP1990, POP2000, POP90_SQMI, Shape_Leng, Shape_Area)
-                    VALUES
-                        (:OBJECTID, :NAME, :STATE_NAME, :STATE_FIPS, :CNTY_FIPS, :FIPS, :AREA, :POP1990, :POP2000, :POP90_SQMI, :Shape_Leng, :Shape_Area);
-    """
-    TABLE_RECORD = {
-        "OBJECTID": 9999,
-        "NAME": "Lake of the Gruffalo",
-        "STATE_NAME": "Minnesota",
-        "STATE_FIPS": "27",
-        "CNTY_FIPS": "077",
-        "FIPS": "27077",
-        "AREA": 1784.0634,
-        "POP1990": 4076,
-        "POP2000": 4651,
-        "POP90_SQMI": 2,
-        "Shape_Leng": 4.055_459_982_439_92,
-        "Shape_Area": 0.565_449_933_741_451,
-    }
-    TABLE_HEAD_SHA = "03622015ea5a82bc75228de052d9c84bc6f41667"
+    class TABLE:
+        LAYER = "countiestbl"
+        LAYER_PK = "OBJECTID"
+        INSERT = f"""
+            INSERT INTO {LAYER}
+                            (OBJECTID, NAME, STATE_NAME, STATE_FIPS, CNTY_FIPS, FIPS, AREA, POP1990, POP2000, POP90_SQMI, Shape_Leng, Shape_Area)
+                        VALUES
+                            (:OBJECTID, :NAME, :STATE_NAME, :STATE_FIPS, :CNTY_FIPS, :FIPS, :AREA, :POP1990, :POP2000, :POP90_SQMI, :Shape_Leng, :Shape_Area);
+        """
+        RECORD = {
+            "OBJECTID": 9999,
+            "NAME": "Lake of the Gruffalo",
+            "STATE_NAME": "Minnesota",
+            "STATE_FIPS": "27",
+            "CNTY_FIPS": "077",
+            "FIPS": "27077",
+            "AREA": 1784.0634,
+            "POP1990": 4076,
+            "POP2000": 4651,
+            "POP90_SQMI": 2,
+            "Shape_Leng": 4.055_459_982_439_92,
+            "Shape_Area": 0.565_449_933_741_451,
+        }
+        HEAD_SHA = "03622015ea5a82bc75228de052d9c84bc6f41667"
+        ROWCOUNT = 3141
+        TEXT_FIELD = "NAME"
+        SAMPLE_PKS = list(range(1, 11))
 
     @classmethod
-    def last_change_time(cls, db, table=POINTS_LAYER):
+    def metadata(cls, l):
+        metadatas = (cls.POINTS, cls.POLYGONS, cls.TABLE)
+        return next((m for m in metadatas if m.LAYER == l or m.__name__ == l))
+
+    @classmethod
+    def last_change_time(cls, db, table=POINTS.LAYER):
         """
         Get the last change time from the GeoPackage DB.
         This is the same as the commit time.
@@ -532,6 +558,18 @@ class TestHelpers:
             assert gpkg_extent == (None, None, None, None)
 
 
+def _find_layer(db):
+    H = pytest.helpers.helpers()
+    return (
+        db.cursor()
+        .execute(
+            "SELECT table_name FROM gpkg_contents WHERE table_name IN (?,?,?) LIMIT 1",
+            [H.POINTS.LAYER, H.POLYGONS.LAYER, H.TABLE.LAYER],
+        )
+        .fetchone()[0]
+    )
+
+
 @pytest.fixture
 def insert(request, cli_runner):
     H = pytest.helpers.helpers()
@@ -540,34 +578,13 @@ def insert(request, cli_runner):
         if reset_index is not None:
             func.index = reset_index
 
-        if layer is None:
-            # autodetect
-            layer = (
-                db.cursor()
-                .execute(
-                    "SELECT table_name FROM gpkg_contents WHERE table_name IN (?,?,?) LIMIT 1",
-                    [H.POINTS_LAYER, H.POLYGONS_LAYER, H.TABLE_LAYER],
-                )
-                .fetchone()[0]
-            )
+        layer = layer or _find_layer(db)
 
-        if layer == H.POINTS_LAYER:
-            rec = H.POINTS_RECORD.copy()
-            pk_field = H.POINTS_LAYER_PK
-            sql = H.POINTS_INSERT
-            pk_start = 98000
-        elif layer == H.POLYGONS_LAYER:
-            rec = H.POLYGONS_RECORD.copy()
-            pk_field = H.POLYGONS_LAYER_PK
-            sql = H.POLYGONS_INSERT
-            pk_start = 98000
-        elif layer == H.TABLE_LAYER:
-            rec = H.TABLE_RECORD.copy()
-            pk_field = H.TABLE_LAYER_PK
-            sql = H.TABLE_INSERT
-            pk_start = 98000
-        else:
-            raise NotImplementedError(f"Layer {layer}")
+        metadata = H.metadata(layer)
+        rec = metadata.RECORD.copy()
+        pk_field = metadata.LAYER_PK
+        sql = metadata.INSERT
+        pk_start = 98000
 
         # th
         new_pk = pk_start + func.index
@@ -592,5 +609,32 @@ def insert(request, cli_runner):
 
     func.index = 0
     func.inserted_fids = []
+
+    return func
+
+
+@pytest.fixture
+def update(request, cli_runner):
+    H = pytest.helpers.helpers()
+
+    def func(db, pk, update_str, layer=None, commit=True):
+        layer = layer or _find_layer(db)
+        metadata = H.metadata(layer)
+        pk_field = metadata.LAYER_PK
+        text_field = metadata.TEXT_FIELD
+
+        with db:
+            sql = f"""UPDATE {layer} SET {text_field} = :update_str WHERE {pk_field} = {pk}"""
+            db.cursor().execute(sql, {"update_str": update_str})
+            assert db.changes() == 1
+
+        if commit:
+            r = cli_runner.invoke(["commit", "-m", f"commit-update-{pk}", "--json"])
+            assert r.exit_code == 0, r
+
+            commit_id = json.loads(r.stdout)["sno.commit/v1"]["commit"]
+            return commit_id
+        else:
+            return pk
 
     return func

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -20,29 +20,29 @@ H = pytest.helpers.helpers()
 
 
 def edit_points(dbcur):
-    dbcur.execute(H.POINTS_INSERT, H.POINTS_RECORD)
+    dbcur.execute(H.POINTS.INSERT, H.POINTS.RECORD)
     assert dbcur.getconnection().changes() == 1
-    dbcur.execute(f"UPDATE {H.POINTS_LAYER} SET fid=9998 WHERE fid=1;")
+    dbcur.execute(f"UPDATE {H.POINTS.LAYER} SET fid=9998 WHERE fid=1;")
     assert dbcur.getconnection().changes() == 1
-    dbcur.execute(f"UPDATE {H.POINTS_LAYER} SET name='test' WHERE fid=2;")
+    dbcur.execute(f"UPDATE {H.POINTS.LAYER} SET name='test' WHERE fid=2;")
     assert dbcur.getconnection().changes() == 1
-    dbcur.execute(f"DELETE FROM {H.POINTS_LAYER} WHERE fid IN (3,30,31,32,33);")
+    dbcur.execute(f"DELETE FROM {H.POINTS.LAYER} WHERE fid IN (3,30,31,32,33);")
     assert dbcur.getconnection().changes() == 5
     pk_del = 3
     return pk_del
 
 
 def edit_polygons_pk(dbcur):
-    dbcur.execute(H.POLYGONS_INSERT, H.POLYGONS_RECORD)
+    dbcur.execute(H.POLYGONS.INSERT, H.POLYGONS.RECORD)
     assert dbcur.getconnection().changes() == 1
-    dbcur.execute(f"UPDATE {H.POLYGONS_LAYER} SET id=9998 WHERE id=1424927;")
+    dbcur.execute(f"UPDATE {H.POLYGONS.LAYER} SET id=9998 WHERE id=1424927;")
     assert dbcur.getconnection().changes() == 1
     dbcur.execute(
-        f"UPDATE {H.POLYGONS_LAYER} SET survey_reference='test' WHERE id=1443053;"
+        f"UPDATE {H.POLYGONS.LAYER} SET survey_reference='test' WHERE id=1443053;"
     )
     assert dbcur.getconnection().changes() == 1
     dbcur.execute(
-        f"DELETE FROM {H.POLYGONS_LAYER} WHERE id IN (1452332, 1456853, 1456912, 1457297, 1457355);"
+        f"DELETE FROM {H.POLYGONS.LAYER} WHERE id IN (1452332, 1456853, 1456912, 1457297, 1457355);"
     )
     assert dbcur.getconnection().changes() == 5
     pk_del = 1452332
@@ -50,13 +50,13 @@ def edit_polygons_pk(dbcur):
 
 
 def edit_table(dbcur):
-    dbcur.execute(H.TABLE_INSERT, H.TABLE_RECORD)
+    dbcur.execute(H.TABLE.INSERT, H.TABLE.RECORD)
     assert dbcur.getconnection().changes() == 1
-    dbcur.execute(f"UPDATE {H.TABLE_LAYER} SET OBJECTID=9998 WHERE OBJECTID=1;")
+    dbcur.execute(f"UPDATE {H.TABLE.LAYER} SET OBJECTID=9998 WHERE OBJECTID=1;")
     assert dbcur.getconnection().changes() == 1
-    dbcur.execute(f"UPDATE {H.TABLE_LAYER} SET name='test' WHERE OBJECTID=2;")
+    dbcur.execute(f"UPDATE {H.TABLE.LAYER} SET name='test' WHERE OBJECTID=2;")
     assert dbcur.getconnection().changes() == 1
-    dbcur.execute(f"DELETE FROM {H.TABLE_LAYER} WHERE OBJECTID IN (3,30,31,32,33);")
+    dbcur.execute(f"DELETE FROM {H.TABLE.LAYER} WHERE OBJECTID IN (3,30,31,32,33);")
     assert dbcur.getconnection().changes() == 5
     pk_del = 3
     return pk_del
@@ -65,9 +65,9 @@ def edit_table(dbcur):
 @pytest.mark.parametrize(
     "archive,layer",
     [
-        pytest.param("points", H.POINTS_LAYER, id="points"),
-        pytest.param("polygons", H.POLYGONS_LAYER, id="polygons_pk"),
-        pytest.param("table", H.TABLE_LAYER, id="table"),
+        pytest.param("points", H.POINTS.LAYER, id="points"),
+        pytest.param("polygons", H.POLYGONS.LAYER, id="polygons_pk"),
+        pytest.param("table", H.TABLE.LAYER, id="table"),
     ],
 )
 def test_commit(archive, layer, data_working_copy, geopackage, cli_runner, request):
@@ -138,7 +138,7 @@ def test_tag(data_working_copy, cli_runner):
         repo = pygit2.Repository(str(repo_dir))
         assert "refs/tags/version1" in repo.references
         ref = repo.lookup_reference_dwim("version1")
-        assert ref.target.hex == H.POINTS_HEAD_SHA
+        assert ref.target.hex == H.POINTS.HEAD_SHA
 
 
 def test_commit_message(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -13,7 +13,7 @@ GPKG_IMPORTS = (
             "gpkg-points", "nz-pa-points-topo-150k.gpkg", "POINTS", id="points"
         ),
         pytest.param(
-            "gpkg-polygons", "nz-waca-adjustments.gpkg", "POLYGONS", id="polygons-pk",
+            "gpkg-polygons", "nz-waca-adjustments.gpkg", "POLYGONS", id="polygons"
         ),
     ],
 )
@@ -34,8 +34,9 @@ def test_e2e(
     insert,
     request,
 ):
-    table = getattr(H, f"{table_ref}_LAYER")
-    row_count = getattr(H, f"{table_ref}_ROWCOUNT")
+    metadata = H.metadata(table_ref)
+    table = metadata.LAYER
+    row_count = metadata.ROWCOUNT
 
     repo_path = tmp_path / "myproject.sno"
     repo_path.mkdir()

--- a/tests/test_fsck.py
+++ b/tests/test_fsck.py
@@ -13,12 +13,12 @@ def test_fsck(data_working_copy, geopackage, cli_runner):
         assert r.exit_code == 0, r
 
         # introduce a feature mismatch
-        assert H.row_count(db, H.POINTS_LAYER) == H.POINTS_ROWCOUNT
+        assert H.row_count(db, H.POINTS.LAYER) == H.POINTS.ROWCOUNT
         assert H.row_count(db, ".sno-track") == 0
 
         with db:
             dbcur = db.cursor()
-            dbcur.execute(f"UPDATE {H.POINTS_LAYER} SET name='fred' WHERE fid=1;")
+            dbcur.execute(f"UPDATE {H.POINTS.LAYER} SET name='fred' WHERE fid=1;")
             dbcur.execute("""DELETE FROM ".sno-track" WHERE pk='1';""")
 
         r = cli_runner.invoke(["fsck"])
@@ -27,7 +27,7 @@ def test_fsck(data_working_copy, geopackage, cli_runner):
         r = cli_runner.invoke(["fsck", "--reset-dataset=nz_pa_points_topo_150k"])
         assert r.exit_code == 0, r
 
-        assert H.row_count(db, H.POINTS_LAYER) == H.POINTS_ROWCOUNT
+        assert H.row_count(db, H.POINTS.LAYER) == H.POINTS.ROWCOUNT
         assert H.row_count(db, ".sno-track") == 0
 
         r = cli_runner.invoke(["fsck"])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,12 +20,12 @@ GPKG_IMPORTS = (
     "archive,gpkg,table",
     [
         pytest.param(
-            "gpkg-points", "nz-pa-points-topo-150k.gpkg", H.POINTS_LAYER, id="points"
+            "gpkg-points", "nz-pa-points-topo-150k.gpkg", H.POINTS.LAYER, id="points"
         ),
         pytest.param(
             "gpkg-polygons",
             "nz-waca-adjustments.gpkg",
-            H.POLYGONS_LAYER,
+            H.POLYGONS.LAYER,
             id="polygons-pk",
         ),
         pytest.param(
@@ -441,7 +441,7 @@ def test_import_existing_wc(
             r = cli_runner.invoke(
                 [
                     "import",
-                    f"GPKG:{source_path / 'nz-waca-adjustments.gpkg'}:{H.POLYGONS_LAYER}",
+                    f"GPKG:{source_path / 'nz-waca-adjustments.gpkg'}:{H.POLYGONS.LAYER}",
                 ]
             )
             assert r.exit_code == 0, r
@@ -478,7 +478,7 @@ def test_import_existing_wc(
             r = cli_runner.invoke(
                 [
                     "import",
-                    f"GPKG:{source_path / 'nz-waca-adjustments.gpkg'}:{H.POLYGONS_LAYER}",
+                    f"GPKG:{source_path / 'nz-waca-adjustments.gpkg'}:{H.POLYGONS.LAYER}",
                     "waca2",
                 ]
             )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -23,8 +23,8 @@ def indexed_dataset(data_archive, cli_runner):
 @pytest.mark.parametrize(
     "archive,table",
     [
-        pytest.param("points", H.POINTS_LAYER, id="points"),
-        pytest.param("polygons", H.POLYGONS_LAYER, id="polygons"),
+        pytest.param("points", H.POINTS.LAYER, id="points"),
+        pytest.param("polygons", H.POLYGONS.LAYER, id="polygons"),
     ],
 )
 def test_build_spatial_index(archive, table, data_archive, cli_runner):
@@ -40,8 +40,8 @@ def test_build_spatial_index(archive, table, data_archive, cli_runner):
 
 
 def test_query_cli_get(indexed_dataset, cli_runner):
-    with indexed_dataset("points", H.POINTS_LAYER):
-        r = cli_runner.invoke(["query", H.POINTS_LAYER, "get", "1"])
+    with indexed_dataset("points", H.POINTS.LAYER):
+        r = cli_runner.invoke(["query", H.POINTS.LAYER, "get", "1"])
         assert r.exit_code == 0, r
 
         assert json.loads(r.stdout) == {
@@ -58,8 +58,8 @@ def test_query_cli_get(indexed_dataset, cli_runner):
 
 
 def test_query_cli_geo_nearest(indexed_dataset, cli_runner):
-    with indexed_dataset("points", H.POINTS_LAYER):
-        r = cli_runner.invoke(["query", H.POINTS_LAYER, "geo-nearest", "177,-38"])
+    with indexed_dataset("points", H.POINTS.LAYER):
+        r = cli_runner.invoke(["query", H.POINTS.LAYER, "geo-nearest", "177,-38"])
         assert r.exit_code == 0, r
 
         data = json.loads(r.stdout)
@@ -78,7 +78,7 @@ def test_query_cli_geo_nearest(indexed_dataset, cli_runner):
         }
         assert data[0] == EXPECTED
 
-        r = cli_runner.invoke(["query", H.POINTS_LAYER, "geo-nearest", "177,-38", "4"])
+        r = cli_runner.invoke(["query", H.POINTS.LAYER, "geo-nearest", "177,-38", "4"])
         assert r.exit_code == 0, r
         data = json.loads(r.stdout)
         assert isinstance(data, list)
@@ -87,9 +87,9 @@ def test_query_cli_geo_nearest(indexed_dataset, cli_runner):
 
 
 def test_query_cli_geo_count(indexed_dataset, cli_runner):
-    with indexed_dataset("points", H.POINTS_LAYER):
+    with indexed_dataset("points", H.POINTS.LAYER):
         r = cli_runner.invoke(
-            ["query", H.POINTS_LAYER, "geo-count", "177,-38,177.1,-37.9"]
+            ["query", H.POINTS.LAYER, "geo-count", "177,-38,177.1,-37.9"]
         )
         assert r.exit_code == 0, r
 
@@ -99,9 +99,9 @@ def test_query_cli_geo_count(indexed_dataset, cli_runner):
 def test_query_cli_geo_intersects(indexed_dataset, cli_runner):
     x0, y0, x1, y1 = 177, -38, 177.1, -37.9
 
-    with indexed_dataset("points", H.POINTS_LAYER):
+    with indexed_dataset("points", H.POINTS.LAYER):
         r = cli_runner.invoke(
-            ["query", H.POINTS_LAYER, "geo-intersects", f"{x0},{y0},{x1},{y1}"]
+            ["query", H.POINTS.LAYER, "geo-intersects", f"{x0},{y0},{x1},{y1}"]
         )
         assert r.exit_code == 0, r
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -36,7 +36,7 @@ def test_clone(working_copy, data_archive, tmp_path, cli_runner, chdir, geopacka
         assert repo.is_bare
         assert not repo.is_empty
         assert repo.head.name == "refs/heads/master"
-        assert repo.head.peel(pygit2.Commit).hex == H.POINTS_HEAD_SHA
+        assert repo.head.peel(pygit2.Commit).hex == H.POINTS.HEAD_SHA
 
         branch = repo.branches.local[repo.head.shorthand]
         assert branch.is_head()
@@ -51,7 +51,7 @@ def test_clone(working_copy, data_archive, tmp_path, cli_runner, chdir, geopacka
         if working_copy:
             assert wc.exists() and wc.is_file()
 
-            table = H.POINTS_LAYER
+            table = H.POINTS.LAYER
             assert repo.config["sno.workingcopy.version"] == "1"
             assert repo.config["sno.workingcopy.path"] == wc.name
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -181,9 +181,9 @@ def test_status(
         # local edits
         with db:
             insert(db, commit=False)
-            db.cursor().execute(f"DELETE FROM {H.POINTS_LAYER} WHERE fid <= 2;")
+            db.cursor().execute(f"DELETE FROM {H.POINTS.LAYER} WHERE fid <= 2;")
             db.cursor().execute(
-                f"UPDATE {H.POINTS_LAYER} SET name='test0' WHERE fid <= 5;"
+                f"UPDATE {H.POINTS.LAYER} SET name='test0' WHERE fid <= 5;"
             )
 
         assert text_status(cli_runner) == [
@@ -195,7 +195,7 @@ def test_status(
             '  (use "sno commit" to commit)',
             '  (use "sno reset" to discard changes)',
             "",
-            f"  {H.POINTS_LAYER}/",
+            f"  {H.POINTS.LAYER}/",
             "    modified:  3 features",
             "    new:       1 feature",
             "    deleted:   2 features",

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -18,12 +18,12 @@ GPKG_IMPORTS = (
     "archive,source_gpkg,table",
     [
         pytest.param(
-            "gpkg-points", "nz-pa-points-topo-150k.gpkg", H.POINTS_LAYER, id="points"
+            "gpkg-points", "nz-pa-points-topo-150k.gpkg", H.POINTS.LAYER, id="points"
         ),
         pytest.param(
             "gpkg-polygons",
             "nz-waca-adjustments.gpkg",
-            H.POLYGONS_LAYER,
+            H.POLYGONS.LAYER,
             id="polygons-pk",
         ),
         pytest.param(
@@ -95,7 +95,7 @@ def _import_check(repo_path, table, source_gpkg, geopackage):
     GPKG_IMPORTS[1]
     + [
         pytest.param(
-            "gpkg-points", "nz-pa-points-topo-150k.gpkg", H.POINTS_LAYER, id="empty"
+            "gpkg-points", "nz-pa-points-topo-150k.gpkg", H.POINTS.LAYER, id="empty"
         ),
     ],
 )
@@ -299,8 +299,8 @@ def test_import_multiple(
     assert repo.is_empty
 
     LAYERS = (
-        ("gpkg-points", "nz-pa-points-topo-150k.gpkg", H.POINTS_LAYER),
-        ("gpkg-polygons", "nz-waca-adjustments.gpkg", H.POLYGONS_LAYER),
+        ("gpkg-points", "nz-pa-points-topo-150k.gpkg", H.POINTS.LAYER),
+        ("gpkg-polygons", "nz-waca-adjustments.gpkg", H.POLYGONS.LAYER),
     )
 
     datasets = []
@@ -409,7 +409,7 @@ def test_write_feature_performance(
 def test_fast_import(
     import_version, iter_func, data_archive, tmp_path, cli_runner, chdir, monkeypatch
 ):
-    table = H.POINTS_LAYER
+    table = H.POINTS.LAYER
     with data_archive("gpkg-points") as data:
         # list tables
         repo_path = tmp_path / "data.sno"

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -8,9 +8,9 @@ H = pytest.helpers.helpers()
 @pytest.mark.parametrize(
     "archive,layer",
     [
-        pytest.param("points0.snow", H.POINTS_LAYER, id="points"),
-        pytest.param("polygons0.snow", H.POLYGONS_LAYER, id="polygons-pk"),
-        pytest.param("table0.snow", H.TABLE_LAYER, id="table"),
+        pytest.param("points0.snow", H.POINTS.LAYER, id="points"),
+        pytest.param("polygons0.snow", H.POLYGONS.LAYER, id="polygons-pk"),
+        pytest.param("table0.snow", H.TABLE.LAYER, id="table"),
     ],
 )
 def test_upgrade(archive, layer, data_archive, cli_runner, tmp_path, chdir):
@@ -25,7 +25,7 @@ def test_upgrade(archive, layer, data_archive, cli_runner, tmp_path, chdir):
         r = cli_runner.invoke(["log"])
         assert r.exit_code == 0, r
 
-        if layer == H.POINTS_LAYER:
+        if layer == H.POINTS.LAYER:
             assert r.stdout.splitlines() == [
                 "commit a91ac9bf11cf6a07647fdc8700dbcfab95685804",
                 "Author: Robert Coup <robert@coup.net.nz>",

--- a/tests/test_workingcopy.py
+++ b/tests/test_workingcopy.py
@@ -17,11 +17,11 @@ H = pytest.helpers.helpers()
 @pytest.mark.parametrize(
     "archive,table,commit_sha",
     [
-        pytest.param("points", H.POINTS_LAYER, H.POINTS_HEAD_SHA, id="points"),
+        pytest.param("points", H.POINTS.LAYER, H.POINTS.HEAD_SHA, id="points"),
         pytest.param(
-            "polygons", H.POLYGONS_LAYER, H.POLYGONS_HEAD_SHA, id="polygons-pk"
+            "polygons", H.POLYGONS.LAYER, H.POLYGONS.HEAD_SHA, id="polygons-pk"
         ),
-        pytest.param("table", H.TABLE_LAYER, H.TABLE_HEAD_SHA, id="table"),
+        pytest.param("table", H.TABLE.LAYER, H.TABLE.HEAD_SHA, id="table"),
     ],
 )
 def test_checkout_workingcopy(
@@ -71,12 +71,12 @@ def test_checkout_detached(data_working_copy, cli_runner, geopackage):
         assert H.last_change_time(db) == "2019-06-20T14:28:33.000000Z"
 
         # checkout the previous commit
-        r = cli_runner.invoke(["checkout", H.POINTS_HEAD1_SHA[:8]])
+        r = cli_runner.invoke(["checkout", H.POINTS.HEAD1_SHA[:8]])
         assert r.exit_code == 0, r
         assert H.last_change_time(db) == "2019-06-11T11:03:58.000000Z"
 
         repo = pygit2.Repository(str(repo_dir))
-        assert repo.head.target.hex == H.POINTS_HEAD1_SHA
+        assert repo.head.target.hex == H.POINTS.HEAD1_SHA
         assert repo.head_is_detached
         assert repo.head.name == "HEAD"
 
@@ -103,49 +103,49 @@ def test_checkout_references(data_working_copy, cli_runner, geopackage, tmp_path
         # checkout the HEAD commit
         r = cli_runner.invoke(["checkout", "HEAD"])
         assert r.exit_code == 0, r
-        assert r_head() == ("refs/heads/master", H.POINTS_HEAD_SHA)
+        assert r_head() == ("refs/heads/master", H.POINTS.HEAD_SHA)
         assert not repo.head_is_detached
         assert H.last_change_time(db) == "2019-06-20T14:28:33.000000Z"
 
         # checkout the HEAD-but-1 commit
         r = cli_runner.invoke(["checkout", "HEAD~1"])
         assert r.exit_code == 0, r
-        assert r_head() == ("HEAD", H.POINTS_HEAD1_SHA)
+        assert r_head() == ("HEAD", H.POINTS.HEAD1_SHA)
         assert repo.head_is_detached
         assert H.last_change_time(db) == "2019-06-11T11:03:58.000000Z"
 
         # checkout the master HEAD via branch-name
         r = cli_runner.invoke(["checkout", "master"])
         assert r.exit_code == 0, r
-        assert r_head() == ("refs/heads/master", H.POINTS_HEAD_SHA)
+        assert r_head() == ("refs/heads/master", H.POINTS.HEAD_SHA)
         assert not repo.head_is_detached
         assert H.last_change_time(db) == "2019-06-20T14:28:33.000000Z"
 
         # checkout a short-sha commit
-        r = cli_runner.invoke(["checkout", H.POINTS_HEAD1_SHA[:8]])
+        r = cli_runner.invoke(["checkout", H.POINTS.HEAD1_SHA[:8]])
         assert r.exit_code == 0, r
-        assert r_head() == ("HEAD", H.POINTS_HEAD1_SHA)
+        assert r_head() == ("HEAD", H.POINTS.HEAD1_SHA)
         assert repo.head_is_detached
         assert H.last_change_time(db) == "2019-06-11T11:03:58.000000Z"
 
         # checkout the master HEAD via refspec
         r = cli_runner.invoke(["checkout", "refs/heads/master"])
         assert r.exit_code == 0, r
-        assert r_head() == ("refs/heads/master", H.POINTS_HEAD_SHA)
+        assert r_head() == ("refs/heads/master", H.POINTS.HEAD_SHA)
         assert not repo.head_is_detached
         assert H.last_change_time(db) == "2019-06-20T14:28:33.000000Z"
 
         # checkout the tag
         r = cli_runner.invoke(["checkout", "version1"])
         assert r.exit_code == 0, r
-        assert r_head() == ("HEAD", H.POINTS_HEAD_SHA)
+        assert r_head() == ("HEAD", H.POINTS.HEAD_SHA)
         assert repo.head_is_detached
         assert H.last_change_time(db) == "2019-06-20T14:28:33.000000Z"
 
         # checkout the remote branch
         r = cli_runner.invoke(["checkout", "myremote/master"])
         assert r.exit_code == 0, r
-        assert r_head() == ("HEAD", H.POINTS_HEAD_SHA)
+        assert r_head() == ("HEAD", H.POINTS.HEAD_SHA)
         assert repo.head_is_detached
         assert H.last_change_time(db) == "2019-06-20T14:28:33.000000Z"
 
@@ -175,32 +175,32 @@ def test_checkout_branch(data_working_copy, geopackage, cli_runner, tmp_path):
         repo = pygit2.Repository(str(repo_path))
         assert repo.head.name == "refs/heads/foo"
         assert "foo" in repo.branches
-        assert repo.head.peel(pygit2.Commit).hex == H.POINTS_HEAD_SHA
+        assert repo.head.peel(pygit2.Commit).hex == H.POINTS.HEAD_SHA
 
         # make some changes
         db = geopackage(wc)
         with db:
             cur = db.cursor()
-            cur.execute(H.POINTS_INSERT, H.POINTS_RECORD)
+            cur.execute(H.POINTS.INSERT, H.POINTS.RECORD)
             assert db.changes() == 1
 
         r = cli_runner.invoke(["commit", "-m", "test1"])
         assert r.exit_code == 0, r
 
-        assert repo.head.peel(pygit2.Commit).hex != H.POINTS_HEAD_SHA
+        assert repo.head.peel(pygit2.Commit).hex != H.POINTS.HEAD_SHA
 
         r = cli_runner.invoke(["checkout", "master"])
         assert r.exit_code == 0, r
 
         assert repo.head.name == "refs/heads/master"
-        assert repo.head.peel(pygit2.Commit).hex == H.POINTS_HEAD_SHA
+        assert repo.head.peel(pygit2.Commit).hex == H.POINTS.HEAD_SHA
 
         # new branch from remote
         r = cli_runner.invoke(["checkout", "-b", "test99", "myremote/master"])
         assert r.exit_code == 0, r
         assert repo.head.name == "refs/heads/test99"
         assert "test99" in repo.branches
-        assert repo.head.peel(pygit2.Commit).hex == H.POINTS_HEAD_SHA
+        assert repo.head.peel(pygit2.Commit).hex == H.POINTS.HEAD_SHA
         branch = repo.branches["test99"]
         assert branch.upstream_name == "refs/remotes/myremote/master"
 
@@ -231,41 +231,41 @@ def test_switch_branch(data_working_copy, geopackage, cli_runner, tmp_path):
         repo = pygit2.Repository(str(repo_path))
         assert repo.head.name == "refs/heads/foo"
         assert "foo" in repo.branches
-        assert repo.head.peel(pygit2.Commit).hex == H.POINTS_HEAD_SHA
+        assert repo.head.peel(pygit2.Commit).hex == H.POINTS.HEAD_SHA
 
         # make some changes
         db = geopackage(wc)
         with db:
             cur = db.cursor()
 
-            cur.execute(H.POINTS_INSERT, H.POINTS_RECORD)
+            cur.execute(H.POINTS.INSERT, H.POINTS.RECORD)
             assert db.changes() == 1
 
-            cur.execute(f"UPDATE {H.POINTS_LAYER} SET fid=30000 WHERE fid=3;")
+            cur.execute(f"UPDATE {H.POINTS.LAYER} SET fid=30000 WHERE fid=3;")
             assert db.changes() == 1
 
         r = cli_runner.invoke(["commit", "-m", "test1"])
         assert r.exit_code == 0, r
 
         new_commit = repo.head.peel(pygit2.Commit).hex
-        assert new_commit != H.POINTS_HEAD_SHA
+        assert new_commit != H.POINTS.HEAD_SHA
 
         r = cli_runner.invoke(["switch", "master"])
         assert r.exit_code == 0, r
 
-        assert H.row_count(db, H.POINTS_LAYER) == H.POINTS_ROWCOUNT
+        assert H.row_count(db, H.POINTS.LAYER) == H.POINTS.ROWCOUNT
 
         assert repo.head.name == "refs/heads/master"
-        assert repo.head.peel(pygit2.Commit).hex == H.POINTS_HEAD_SHA
+        assert repo.head.peel(pygit2.Commit).hex == H.POINTS.HEAD_SHA
 
         # make some changes
         with db:
             cur = db.cursor()
 
-            cur.execute(H.POINTS_INSERT, H.POINTS_RECORD)
+            cur.execute(H.POINTS.INSERT, H.POINTS.RECORD)
             assert db.changes() == 1
 
-            cur.execute(f"UPDATE {H.POINTS_LAYER} SET fid=40000 WHERE fid=4;")
+            cur.execute(f"UPDATE {H.POINTS.LAYER} SET fid=40000 WHERE fid=4;")
             assert db.changes() == 1
 
         r = cli_runner.invoke(["switch", "foo"])
@@ -275,7 +275,7 @@ def test_switch_branch(data_working_copy, geopackage, cli_runner, tmp_path):
         r = cli_runner.invoke(["switch", "foo", "--discard-changes"])
         assert r.exit_code == 0, r
 
-        assert H.row_count(db, H.POINTS_LAYER) == H.POINTS_ROWCOUNT + 1
+        assert H.row_count(db, H.POINTS.LAYER) == H.POINTS.ROWCOUNT + 1
 
         assert repo.head.name == "refs/heads/foo"
         assert repo.head.peel(pygit2.Commit).hex == new_commit
@@ -285,19 +285,19 @@ def test_switch_branch(data_working_copy, geopackage, cli_runner, tmp_path):
         assert r.exit_code == 0, r
         assert repo.head.name == "refs/heads/test99"
         assert "test99" in repo.branches
-        assert repo.head.peel(pygit2.Commit).hex == H.POINTS_HEAD_SHA
+        assert repo.head.peel(pygit2.Commit).hex == H.POINTS.HEAD_SHA
         branch = repo.branches["test99"]
         assert branch.upstream_name == "refs/remotes/myremote/master"
 
-        assert H.row_count(db, H.POINTS_LAYER) == H.POINTS_ROWCOUNT
+        assert H.row_count(db, H.POINTS.LAYER) == H.POINTS.ROWCOUNT
 
 
 @pytest.mark.parametrize(
     "archive,layer",
     [
-        pytest.param("points", H.POINTS_LAYER, id="points"),
-        pytest.param("polygons", H.POLYGONS_LAYER, id="polygons-pk"),
-        pytest.param("table", H.TABLE_LAYER, id="table"),
+        pytest.param("points", H.POINTS.LAYER, id="points"),
+        pytest.param("polygons", H.POLYGONS.LAYER, id="polygons-pk"),
+        pytest.param("table", H.TABLE.LAYER, id="table"),
     ],
 )
 @pytest.mark.parametrize(
@@ -316,17 +316,17 @@ def test_working_copy_reset(
     We can do this via `sno reset` or `sno checkout --force HEAD`
     """
     raise pytest.skip()  # apsw.SQLError: SQLError: Safety level may not be changed inside a transaction
-    if layer == H.POINTS_LAYER:
-        pk_field = H.POINTS_LAYER_PK
-        rec = H.POINTS_RECORD
-        sql = H.POINTS_INSERT
+    if layer == H.POINTS.LAYER:
+        pk_field = H.POINTS.LAYER_PK
+        rec = H.POINTS.RECORD
+        sql = H.POINTS.INSERT
         del_pk = 5
         upd_field = "t50_fid"
         upd_field_value = 888_888
         upd_pk_range = (10, 15)
         id_chg_pk = 20
-    elif layer == H.POLYGONS_LAYER:
-        pk_field = H.POLYGONS_LAYER_PK
+    elif layer == H.POLYGONS.LAYER:
+        pk_field = H.POLYGONS.LAYER_PK
         rec = H.POLYGONS_RECORD
         sql = H.POLYGONS_INSERT
         del_pk = 1_456_912
@@ -334,8 +334,8 @@ def test_working_copy_reset(
         upd_field_value = "test"
         upd_pk_range = (1_459_750, 1_460_312)
         id_chg_pk = 1_460_583
-    elif layer == H.TABLE_LAYER:
-        pk_field = H.TABLE_LAYER_PK
+    elif layer == H.TABLE.LAYER:
+        pk_field = H.TABLE.LAYER_PK
         rec = H.TABLE_RECORD
         sql = H.TABLE_INSERT
         del_pk = 5
@@ -457,7 +457,7 @@ def test_geopackage_locking_edit(
             sno.working_copy.WorkingCopy_GPKG_1, "write_features", _wrap
         )
 
-        r = cli_runner.invoke(["checkout", H.POINTS_HEAD1_SHA])
+        r = cli_runner.invoke(["checkout", H.POINTS.HEAD1_SHA])
         assert r.exit_code == 0, r
         assert is_checked
 
@@ -503,17 +503,17 @@ def test_workingcopy_set_path(data_working_copy, cli_runner, tmp_path):
 
 @pytest.mark.parametrize(
     "source",
-    [pytest.param([], id="head"), pytest.param(["-s", H.POINTS_HEAD_SHA], id="prev"),],
+    [pytest.param([], id="head"), pytest.param(["-s", H.POINTS.HEAD_SHA], id="prev"),],
 )
 @pytest.mark.parametrize(
     "pathspec", [pytest.param([], id="all"), pytest.param(["bob"], id="exclude"),],
 )
 def test_restore(source, pathspec, data_working_copy, cli_runner, geopackage):
     with data_working_copy("points", force_new=True) as (repo_dir, wc):
-        layer = H.POINTS_LAYER
-        pk_field = H.POINTS_LAYER_PK
-        rec = H.POINTS_RECORD
-        sql = H.POINTS_INSERT
+        layer = H.POINTS.LAYER
+        pk_field = H.POINTS.LAYER_PK
+        rec = H.POINTS.RECORD
+        sql = H.POINTS.INSERT
         del_pk = 5
         upd_field = "t50_fid"
         upd_field_value = 888_888
@@ -526,15 +526,15 @@ def test_restore(source, pathspec, data_working_copy, cli_runner, geopackage):
         # make some changes
         with db:
             cur = db.cursor()
-            cur.execute(f"UPDATE {H.POINTS_LAYER} SET fid=30000 WHERE fid=300;")
+            cur.execute(f"UPDATE {H.POINTS.LAYER} SET fid=30000 WHERE fid=300;")
             assert db.changes() == 1
 
         r = cli_runner.invoke(["commit", "-m", "test1"])
         assert r.exit_code == 0, r
 
         new_commit = repo.head.peel(pygit2.Commit).hex
-        assert new_commit != H.POINTS_HEAD_SHA
-        print(f"Original commit={H.POINTS_HEAD_SHA} New commit={new_commit}")
+        assert new_commit != H.POINTS.HEAD_SHA
+        print(f"Original commit={H.POINTS.HEAD_SHA} New commit={new_commit}")
 
         with db:
             cur = db.cursor()
@@ -608,7 +608,7 @@ def test_restore(source, pathspec, data_working_copy, cli_runner, geopackage):
         if source:
             assert changes_post == ["300", "30000"]
 
-            if head_sha != H.POINTS_HEAD_SHA:
+            if head_sha != H.POINTS.HEAD_SHA:
                 print(f"E: Bad Tree? {head_sha}")
 
             cur.execute(f"SELECT {pk_field} FROM {layer} WHERE {pk_field} = 300;")


### PR DESCRIPTION
![](https://media1.giphy.com/media/7FgDCnVUXgEJJiT68U/giphy-downsized-medium.gif)

Allows for viewing a merge conflict as long as the conflicting datasets exist in all three versions (ancestor, ours, theirs), and no metadata is changed, and the primary keys of the conflicting features don't change. 

![image](https://user-images.githubusercontent.com/7425442/79814915-88855900-83d3-11ea-9ffa-af6e563fe483.png)

Still TODO: show which fields in features conflict, and allow for resolving conflicts by accepting or discarding the various changes.