### PR TITLE
Very basic support for resolving merge conflicts.

### DIFF
--- a/sno/checkout.py
+++ b/sno/checkout.py
@@ -13,7 +13,9 @@ from .working_copy import WorkingCopy
 @click.pass_context
 @click.option("branch", "-b", help="Name for new branch")
 @click.option("fmt", "--format", type=click.Choice(["GPKG"]), default="GPKG")
-@click.option("--force", "-f", is_flag=True)
+@click.option(
+    "--force", "-f", is_flag=True, help="Discard current working copy if necessary"
+)
 @click.option("--path", type=click.Path(writable=True, dir_okay=False))
 @click.option("datasets", "--dataset", "-d", multiple=True)
 @click.argument("refish", default=None, required=False)

--- a/sno/conflicts.py
+++ b/sno/conflicts.py
@@ -1,0 +1,244 @@
+import sys
+from collections import namedtuple
+
+import click
+
+from .diff_output import repr_row
+from .exceptions import InvalidOperation, NotYetImplemented
+from .structure import RepositoryStructure
+
+
+CommitWithReference = namedtuple("CommitWithReference", ("commit", "reference"))
+
+
+def first_true(iterable):
+    """Returns the value from the iterable that is truthy."""
+    return next(filter(None, iterable))
+
+
+def is_interactive_terminal():
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        return True
+    elif sys.stdin.isatty() and not sys.stdout.isatty():
+        raise InvalidOperation(
+            "Redirecting stdout but not stdin breaks the interactive prompts"
+        )
+    return False
+
+
+def interactive_pause(prompt):
+    """Like click.pause() but waits for the Enter key specifically."""
+    click.prompt(prompt, prompt_suffix="", default="", show_default=False)
+
+
+def is_empty_stream(stream):
+    if stream.seekable():
+        pos = stream.tell()
+        if stream.read(1) == "":
+            return True
+        stream.seek(pos)
+    return False
+
+
+def _get_long_label(commit, reference):
+    """Given a commit and a reference (can be None), returns a label"""
+    if reference is not None:
+        return f'"{reference.shorthand}" ({commit.id.hex})'
+    else:
+        return f"({commit.id.hex})"
+
+
+def _safe_get_dataset_for_index_entry(repo_structure, index_entry):
+    """Gets the dataset that a pygit2.IndexEntry refers to, or None"""
+    try:
+        return repo_structure.get_for_index_entry(index_entry)
+    except KeyError:
+        return None
+
+
+def _get_pk_for_index_entry(dataset, index_entry):
+    """Uses a dataset to decode the primary key that a pygit2.IndexEntry refers to"""
+    return dataset.index_entry_to_pk(index_entry)
+
+
+def _safe_get_feature(dataset, pk):
+    """Gets the dataset's feature with a particular primary key, or None"""
+    try:
+        _, feature = dataset.get_feature(pk)
+        return feature
+    except KeyError:
+        return None
+
+
+# We have three versions of lots of objects - the 3 versions are ancestor, ours, theirs.
+# This namedtuple helps us keep track of them all.
+AncestorOursTheirs = namedtuple("AncestorOursTheirs", ("ancestor", "ours", "theirs"))
+
+AncestorOursTheirs.names = AncestorOursTheirs._fields
+AncestorOursTheirs.chars = tuple(n[0] for n in AncestorOursTheirs.names)
+
+
+def aot(*args):
+    """Creates an AncestorOursTheirs - from 3 positional args, an array, a tuple, or a generator."""
+    if len(args) == 1:
+        return AncestorOursTheirs(*tuple(args[0]))
+    else:
+        return AncestorOursTheirs(*args)
+
+
+def resolve_merge_conflicts(repo, merge_index, ancestor, ours, theirs, dry_run=False):
+    """
+    Supports resolution of basic merge conflicts, fails in more complex unsupported cases.
+
+    repo - a pygit2.Repository
+    merge_index - a pygit2.Index containing the attempted merge and merge conflicts.
+    ancestor, ours, theirs - each is a either a pygit2.Commit, or a CommitWithReference.
+    """
+
+    # We have three versions of lots of objects - ancestor, ours, theirs.
+    args3 = aot(ancestor, ours, theirs)
+    commits3 = aot(getattr(arg, "commit", arg) for arg in args3)
+    refs3 = aot(getattr(arg, "reference", None) for arg in args3)
+    labels3 = aot(_get_long_label(*x) for x in zip(commits3, refs3))
+    repo_structures3 = aot(RepositoryStructure(repo, commit=c) for c in commits3)
+
+    conflict_pks = {}
+    for index_entries in merge_index.conflicts:
+        datasets = aot(
+            _safe_get_dataset_for_index_entry(*x)
+            for x in zip(repo_structures3, index_entries)
+        )
+        dataset = first_true(datasets)
+        dataset_path = dataset.path
+        if None in datasets:
+            for i in range(3):
+                presence = "present" if datasets[i] is not None else "absent"
+                click.echo(f"{labels3[i]}: {dataset_path} is {presence}")
+            raise NotYetImplemented(
+                "Sorry, resolving conflicts where datasets are added or removed isn't supported yet"
+            )
+
+        pks3 = aot(_get_pk_for_index_entry(*x) for x in zip(datasets, index_entries))
+        if "META" in pks3:
+            click.echo(f"Merge conflict found in metadata for {dataset_path}")
+            raise NotYetImplemented(
+                "Sorry, resolving conflicts in metadata isn't supported yet"
+            )
+        pk = first_true(pks3)
+        if pks3.count(pk) != 3:
+            click.echo(
+                f"Merge conflict found where primary keys have changed in {dataset_path}"
+            )
+            for i in range(3):
+                click.echo(f"{labels3[i]}: {dataset_path}:{pks3[i]}")
+            raise NotYetImplemented(
+                "Sorry, resolving conflicts where primary keys have changed isn't supported yet"
+            )
+        conflict_pks.setdefault(dataset_path, [])
+        conflict_pks[dataset_path].append(pk)
+
+    num_conflicts = sum(len(pk_list) for pk_list in conflict_pks.values())
+    click.echo(f"\nFound {num_conflicts} conflicting features:")
+    for dataset_path, pks in conflict_pks.items():
+        click.echo(f"{len(pks)} in {dataset_path}")
+    click.echo()
+
+    # Check for dirty working copy before continuing - we don't want to fail after interactive part.
+    ours_rs = repo_structures3.ours
+    ours_rs.working_copy.reset(commits3.ours, ours_rs)
+
+    # At this point, the failure should be dealt with so we can start resolving conflicts interactively.
+    # We don't want to fail during conflict resolution, since then we would lose all the user's work.
+    # TODO: Support other way(s) of resolving conflicts.
+    empty_input = False
+    if dry_run:
+        click.echo("Printing conflicts but not resolving due to --dry-run")
+    elif is_interactive_terminal():
+        interactive_pause(
+            "Press enter to begin resolving merge conflicts, or Ctrl+C to abort at any time..."
+        )
+    elif is_empty_stream(sys.stdin):
+        click.echo(
+            "Printing conflicts but not resolving - run from an interactive terminal to resolve"
+        )
+        empty_input = True
+
+    # For each conflict, print and maybe resolve it.
+    for dataset_path, pks in sorted(conflict_pks.items()):
+        datasets3 = aot(rs[dataset_path] for rs in repo_structures3)
+        ours_ds = datasets3.ours
+        for pk in sorted(pks):
+            feature_name = f"{dataset_path}:{ours_ds.primary_key}={pk}"
+            features3 = aot(_safe_get_feature(d, pk) for d in datasets)
+            print_conflict(feature_name, features3, labels3)
+
+            if not (dry_run or empty_input):
+                index_path = f"{dataset_path}/{ours_ds.get_feature_path(pk)}"
+                resolve_conflict_interactive(feature_name, merge_index, index_path)
+
+    if dry_run:
+        return None
+    elif empty_input:
+        raise InvalidOperation("Use an interactive terminal to resolve merge conflicts")
+
+    # Conflicts are resolved, time to commit
+    assert not merge_index.conflicts
+    merge_tree_id = merge_index.write_tree(repo)
+    click.echo(f"Merge tree: {merge_tree_id}")
+
+    user = repo.default_signature
+    merge_message = "Merge '{}'".format(
+        refs3.theirs.shorthand if refs3.theirs else commits3.theirs.id.hex
+    )
+    commit_id = repo.create_commit(
+        repo.head.name,
+        user,
+        user,
+        merge_message,
+        merge_tree_id,
+        [commits3.ours.id, commits3.theirs.id],
+    )
+    click.echo(f"Merge commit: {commit_id}")
+    return commit_id
+
+
+_prefixes3 = ("- ", "+ ", "+ ")
+_big_prefixes3 = ("---", "+++", "+++")
+_cols3 = ("red", "green", "green")
+
+
+def print_conflict(feature_label, features3, labels3):
+    """
+    Prints 3 versions of a feature.
+    feature_label - the name of the feature.
+    features3 - AncestorOursTheirs tuple containing three versions of a feature.
+    labels3 - AncestorOursTheirs tuple containing the label for each version.
+    """
+    click.secho(f"\n=========== {feature_label} ==========", bold=True)
+    for i in range(3):
+        click.secho(
+            f"{_big_prefixes3[i]} {AncestorOursTheirs.names[i]:>9}: {labels3[i]}"
+        )
+        if features3[i] is not None:
+            click.secho(repr_row(features3[i], prefix=_prefixes3[i]), fg=_cols3[i])
+
+
+_aot_choice = click.Choice(choices=AncestorOursTheirs.chars)
+
+
+def resolve_conflict_interactive(feature_name, merge_index, index_path):
+    """
+    Resolves the conflict at merge_index.conflicts[index_path] by asking
+    the user version they prefer - ancestor, ours or theirs.
+    merge_index - a pygit2.Index with conflicts.
+    index_path - a path where merge_index has a conflict.
+    feature_name - the name of the feature at index_path.
+    """
+    char = click.prompt(
+        f"For {feature_name} accept which version - ancestor, ours or theirs",
+        type=_aot_choice,
+    )
+    choice = AncestorOursTheirs.chars.index(char)
+    index_entries3 = merge_index.conflicts[index_path]
+    del merge_index.conflicts[index_path]
+    merge_index.add(index_entries3[choice])

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import click
 
 from .diff_output import repr_row
@@ -23,9 +26,10 @@ from .structure import RepositoryStructure
         "or the merge can be resolved as a fast-forward."
     ),
 )
+@click.option("--force", "-f", is_flag=True)
 @click.argument("commit", required=True, metavar="COMMIT")
 @click.pass_context
-def merge(ctx, ff, ff_only, commit):
+def merge(ctx, ff, ff_only, force, commit):
     """ Incorporates changes from the named commits (usually other branch heads) into the current branch. """
     repo = ctx.obj.repo
 
@@ -34,52 +38,52 @@ def merge(ctx, ff, ff_only, commit):
             "Conflicting parameters: --no-ff & --ff-only", param_hint="--ff-only"
         )
 
-    c_ours = repo[repo.head.target]
-
     # accept ref-ish things (refspec, branch, commit)
     c_theirs, r_theirs = repo.resolve_refish(commit)
+    c_ours, r_ours = repo.resolve_refish("HEAD")
 
-    print(f"Merging {c_theirs.id} to {c_ours.id} ...")
+    click.echo(f"Merging {c_theirs.id} to {c_ours.id} ...")
     merge_base_id = repo.merge_base(c_theirs.id, c_ours.id)
-    print(f"Found merge base: {merge_base_id}")
+    click.echo(f"Found merge base: {merge_base_id}")
 
     if not merge_base_id:
         raise InvalidOperation(f"Commits {c_theirs.id} and {c_ours.id} aren't related.")
 
     # We're up-to-date if we're trying to merge our own common ancestor.
     if merge_base_id == c_theirs.id:
-        print("Already merged!")
+        click.echo("Already merged!")
         return
 
     # We're fastforwardable if we're our own common ancestor.
     can_ff = merge_base_id == c_ours.id
 
     if ff_only and not can_ff:
-        print("Can't resolve as a fast-forward merge and --ff-only specified")
+        click.echo("Can't resolve as a fast-forward merge and --ff-only specified")
         ctx.exit(1)
 
     if can_ff and ff:
         # do fast-forward merge
         repo.head.set_target(c_theirs.id, "merge: Fast-forward")
         commit_id = c_theirs.id
-        print("Fast-forward")
+        click.echo("Fast-forward")
     else:
         c_ancestor = repo[merge_base_id]
         merge_index = repo.merge_trees(
             ancestor=c_ancestor.tree, ours=c_ours.tree, theirs=c_theirs.tree
         )
         if merge_index.conflicts:
-            handle_merge_conflicts(
+            commit_id = resolve_merge_conflicts(
                 repo,
                 merge_index,
-                ancestor=(c_ancestor, "ancestor"),
-                ours=(c_ours, "HEAD"),
-                theirs=(c_theirs, commit),
+                ancestor=(c_ancestor, None),
+                ours=(c_ours, r_ours),
+                theirs=(c_theirs, r_theirs),
+                force=force,
             )
         else:
-            print("No conflicts!")
+            click.echo("No conflicts!")
             merge_tree_id = merge_index.write_tree(repo)
-            print(f"Merge tree: {merge_tree_id}")
+            click.echo(f"Merge tree: {merge_tree_id}")
 
             user = repo.default_signature
             merge_message = "Merge '{}'".format(
@@ -91,35 +95,24 @@ def merge(ctx, ff, ff_only, commit):
                 user,
                 merge_message,
                 merge_tree_id,
-                [c_ours.oid, c_theirs.oid],
+                [c_ours.id, c_theirs.id],
             )
-            print(f"Merge commit: {commit_id}")
+            click.echo(f"Merge commit: {commit_id}")
 
     # update our working copy
     repo_structure = RepositoryStructure(repo)
     wc = repo_structure.working_copy
     click.echo(f"Updating {wc.path} ...")
     commit = repo[commit_id]
-    return wc.reset(commit, repo_structure)
+    return wc.reset(commit, repo_structure, force=force)
 
 
-def _get_commit(commit_or_tuple):
-    """Given either a commit or a tuple (commit, label), returns the commit"""
-    if type(commit_or_tuple) is tuple:
-        return commit_or_tuple[0]
-    return commit_or_tuple
-
-
-def _get_commit_label(commit_or_tuple):
-    """Given either a commit or a tuple (commit, label), returns a label for the commit"""
-    if type(commit_or_tuple) is tuple:
-        commit = commit_or_tuple[0]
-        label = commit_or_tuple[1]
-        if label != commit.id.hex:
-            label = f"{label} ({commit.id.hex})"
-        return label
+def _get_long_label(commit, ref):
+    """Given a commit and a reference (can be None), returns a label"""
+    if ref is not None:
+        return f"\"{ref.shorthand}\" ({commit.id.hex})"
     else:
-        return commit_or_tuple.id.hex
+        return f"({commit.id.hex})"
 
 
 def _safe_get_dataset_for_index_entry(repo_structure, index_entry):
@@ -148,23 +141,26 @@ def first_true(iterable):
     return next(filter(None, iterable))
 
 
-def handle_merge_conflicts(
-    repo, merge_index, ancestor, ours, theirs,
-):
+def _interactive_pause(prompt):
+    click.prompt(prompt, prompt_suffix="", default="", show_default=False)
+
+
+def resolve_merge_conflicts(repo, merge_index, ancestor, ours, theirs, force=False):
     """
-    Prints merge conflicts and fails, since resolving merge conflicts is not yet supported.
+    Supports resolution of basic merge conflicts, fails in more complex unsupported cases.
 
     repo - a pygit2.Repository
     merge_index - a pygit2.Index containing the attempted merge and merge conflicts.
-    ancestor, ours, theirs - each is either a pygit2.Commit or tuple (pygit2.Commit, label) -
-        where label is a name of the commit that the user would recognize in this context.
-
+    ancestor, ours, theirs - each is a tuple (pygit2.Commit, pygit2.Reference), such
+    as might be obtained from Repository.resolve_refish. The reference can be None.
     """
-    print("Merge conflicts!")
+
+    ANCESTOR, OURS, THEIRS = 0, 1, 2
     # All of the following are 3-tuples of the form (ancestor, ours, theirs)
     commit_args3 = (ancestor, ours, theirs)
-    commits3 = tuple(_get_commit(arg) for arg in commit_args3)
-    labels3 = tuple(_get_commit_label(arg) for arg in commit_args3)
+    commits3 = tuple(arg[0] for arg in commit_args3)
+    refs3 = tuple(arg[1] for arg in commit_args3)
+    labels3 = tuple(_get_long_label(*arg) for arg in commit_args3)
     repo_structures3 = tuple(RepositoryStructure(repo, commit=c) for c in commits3)
 
     conflict_pks = {}
@@ -178,7 +174,7 @@ def handle_merge_conflicts(
         if None in datasets3:
             for i in range(3):
                 presence = "present" if datasets3[i] is not None else "absent"
-                print(f"{labels3[i]}: {dataset_path} is {presence}")
+                click.echo(f"{labels3[i]}: {dataset_path} is {presence}")
             raise NotYetImplemented(
                 "Sorry, resolving conflicts where datasets are added or removed isn't supported yet"
             )
@@ -187,34 +183,121 @@ def handle_merge_conflicts(
             _get_pk_for_index_entry(*x) for x in zip(datasets3, index_entries3)
         )
         if "META" in pks3:
+            click.echo(f"Merge conflict found in metadata for {dataset_path}")
             raise NotYetImplemented(
                 "Sorry, resolving conflicts in metadata isn't supported yet"
             )
         pk = first_true(pks3)
         if pks3.count(pk) != 3:
+            click.echo(
+                f"Merge conflict found where primary keys have changed in {dataset_path}"
+            )
             for i in range(3):
-                print(f"{labels3[i]}: {dataset_path}:{pks3[i]}")
+                click.echo(f"{labels3[i]}: {dataset_path}:{pks3[i]}")
             raise NotYetImplemented(
                 "Sorry, resolving conflicts where primary keys have changed isn't supported yet"
             )
         conflict_pks.setdefault(dataset_path, [])
         conflict_pks[dataset_path].append(pk)
 
-    prefixes3 = ("- ", "+ ", "+ ")
-    big_prefixes3 = ("---", "+++", "+++")
-    cols3 = ("red", "green", "green")
+    num_conflicts = sum(len(pk_list) for pk_list in conflict_pks.values())
+    click.echo(f"\nFound {num_conflicts} conflicting features:")
+    for dataset_path, pks in conflict_pks.items():
+        click.echo(f"{len(pks)} in {dataset_path}")
+    click.echo()
 
+    # Check for dirty working copy before continuing - we don't want to fail after interactive part.
+    ours_rs = repo_structures3[OURS]
+    ours_rs.working_copy.reset(commits3[OURS], ours_rs, force=force)
+
+    # At this point, the failure should be dealt with so we can start resolving conflicts interactively.
+    # We don't want to fail during conflict resolution, since then we would lose all the user's work.
+    # TODO: Support other way(s) of resolving conflicts.
+    if sys.stdout.isatty():
+        _interactive_pause(
+            "Press enter to begin resolving merge conflicts, or Ctrl+C to abort at any time..."
+        )
+    else:
+        click.echo(
+            "Printing conflicts but not resolving - merge conflicts must be resolved in an interactive terminal"
+        )
+
+    # For each conflict, print and maybe resolve it.
     for dataset_path, pks in conflict_pks.items():
         datasets = tuple(rs[dataset_path] for rs in repo_structures3)
+        ours_ds = datasets[OURS]
         for pk in sorted(pks):
+            feature_name = f"{dataset_path}:{pk}"
             features3 = tuple(_safe_get_feature(d, pk) for d in datasets)
-            click.secho(f"=========== {dataset_path}:{pk} ==========", bold=True)
-            for i in range(3):
-                click.secho(f"{big_prefixes3[i]} {labels3[i]}")
-                if features3[i] is not None:
-                    click.secho(
-                        repr_row(features3[i], prefix=prefixes3[i]), fg=cols3[i]
-                    )
-            click.secho()
+            print_conflict(feature_name, features3, labels3)
 
-    raise NotYetImplemented("Sorry, merging conflicts isn't supported yet")
+            if sys.stdout.isatty():
+                index_path = os.path.join(dataset_path, ours_ds.get_feature_path(pk))
+                resolve_conflict_interactive(feature_name, merge_index, index_path)
+
+    if not sys.stdout.isatty():
+        raise InvalidOperation(
+            "Merge conflicts must be resolved in an interactive terminal"
+        )
+
+    # Conflicts are resolved, time to commit
+    assert not merge_index.conflicts
+    merge_tree_id = merge_index.write_tree(repo)
+    click.echo(f"Merge tree: {merge_tree_id}")
+
+    user = repo.default_signature
+    merge_message = "Merge '{}'".format(
+        refs3[THEIRS].shorthand if refs3[THEIRS] else refs3[THEIRS].id.hex
+    )
+    commit_id = repo.create_commit(
+        repo.head.name,
+        user,
+        user,
+        merge_message,
+        merge_tree_id,
+        [commits3[OURS].id, commits3[THEIRS].id],
+    )
+    click.echo(f"Merge commit: {commit_id}")
+    return commit_id
+
+
+_version_names3 = ("ancestor", "ours", "theirs")
+_prefixes3 = ("- ", "+ ", "+ ")
+_big_prefixes3 = ("---", "+++", "+++")
+_cols3 = ("red", "green", "green")
+
+
+def print_conflict(feature_label, features3, labels3):
+    """
+    Prints 3 versions of a feature.
+    feature_label - the name of the feature.
+    features3 - tuple of 3 versions of the feature (ancestor, ours, theirs)
+    labels3 - labels for each version.
+    """
+    click.secho(f"\n=========== {feature_label} ==========", bold=True)
+    for i in range(3):
+        click.secho(f"{_big_prefixes3[i]} {_version_names3[i]:>9}: {labels3[i]}")
+        if features3[i] is not None:
+            click.secho(repr_row(features3[i], prefix=_prefixes3[i]), fg=_cols3[i])
+
+
+_version_chars3 = ("a", "o", "t")
+_version_chars_choice = click.Choice(choices=_version_chars3)
+
+
+def resolve_conflict_interactive(feature_name, merge_index, index_path):
+    """
+    Resolves the conflict at merge_index.conflicts[index_path] by asking
+    the user version they prefer - ancestor, ours or theirs.
+    merge_index - a pygit2.Index with conflicts.
+    index_path - a path where merge_index has a conflict.
+    feature_name - the name of the feature at index_path.
+    """
+    char = click.prompt(
+        f"For {feature_name} accept which version - ancestor, ours or theirs",
+        type=_version_chars_choice,
+    )
+    choice = _version_chars3.index(char)
+    index_entries3 = merge_index.conflicts[index_path]
+    del merge_index.conflicts[index_path]
+    merge_index.add(index_entries3[choice])

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -1,10 +1,7 @@
-import os
-import sys
-
 import click
 
-from .diff_output import repr_row
-from .exceptions import InvalidOperation, NotYetImplemented
+from .conflicts import resolve_merge_conflicts, CommitWithReference
+from .exceptions import InvalidOperation
 from .structure import RepositoryStructure
 
 
@@ -26,10 +23,14 @@ from .structure import RepositoryStructure
         "or the merge can be resolved as a fast-forward."
     ),
 )
-@click.option("--force", "-f", is_flag=True)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Don't perform a merge - just show what would be done",
+)
 @click.argument("commit", required=True, metavar="COMMIT")
 @click.pass_context
-def merge(ctx, ff, ff_only, force, commit):
+def merge(ctx, ff, ff_only, dry_run, commit):
     """ Incorporates changes from the named commits (usually other branch heads) into the current branch. """
     repo = ctx.obj.repo
 
@@ -43,31 +44,33 @@ def merge(ctx, ff, ff_only, force, commit):
     c_ours, r_ours = repo.resolve_refish("HEAD")
 
     click.echo(f"Merging {c_theirs.id} to {c_ours.id} ...")
-    merge_base_id = repo.merge_base(c_theirs.id, c_ours.id)
-    click.echo(f"Found merge base: {merge_base_id}")
+    ancestor_id = repo.merge_base(c_theirs.id, c_ours.id)
+    click.echo(f"Found common ancestor: {ancestor_id}")
 
-    if not merge_base_id:
+    if not ancestor_id:
         raise InvalidOperation(f"Commits {c_theirs.id} and {c_ours.id} aren't related.")
 
     # We're up-to-date if we're trying to merge our own common ancestor.
-    if merge_base_id == c_theirs.id:
+    if ancestor_id == c_theirs.id:
         click.echo("Already merged!")
         return
 
     # We're fastforwardable if we're our own common ancestor.
-    can_ff = merge_base_id == c_ours.id
+    can_ff = ancestor_id == c_ours.id
 
     if ff_only and not can_ff:
-        click.echo("Can't resolve as a fast-forward merge and --ff-only specified")
-        ctx.exit(1)
+        raise InvalidOperation(
+            "Can't resolve as a fast-forward merge and --ff-only specified"
+        )
 
     if can_ff and ff:
         # do fast-forward merge
-        repo.head.set_target(c_theirs.id, "merge: Fast-forward")
+        click.echo(f"Can fast-forward to {c_theirs.id}")
+        if not dry_run:
+            repo.head.set_target(c_theirs.id, "merge: Fast-forward")
         commit_id = c_theirs.id
-        click.echo("Fast-forward")
     else:
-        c_ancestor = repo[merge_base_id]
+        c_ancestor = repo[ancestor_id]
         merge_index = repo.merge_trees(
             ancestor=c_ancestor.tree, ours=c_ours.tree, theirs=c_theirs.tree
         )
@@ -75,10 +78,10 @@ def merge(ctx, ff, ff_only, force, commit):
             commit_id = resolve_merge_conflicts(
                 repo,
                 merge_index,
-                ancestor=(c_ancestor, None),
-                ours=(c_ours, r_ours),
-                theirs=(c_theirs, r_theirs),
-                force=force,
+                ancestor=c_ancestor,
+                ours=CommitWithReference(c_ours, r_ours),
+                theirs=CommitWithReference(c_theirs, r_theirs),
+                dry_run=dry_run,
             )
         else:
             click.echo("No conflicts!")
@@ -89,215 +92,21 @@ def merge(ctx, ff, ff_only, force, commit):
             merge_message = "Merge '{}'".format(
                 r_theirs.shorthand if r_theirs else c_theirs.id
             )
-            commit_id = repo.create_commit(
-                repo.head.name,
-                user,
-                user,
-                merge_message,
-                merge_tree_id,
-                [c_ours.id, c_theirs.id],
-            )
-            click.echo(f"Merge commit: {commit_id}")
+            if not dry_run:
+                commit_id = repo.create_commit(
+                    repo.head.name,
+                    user,
+                    user,
+                    merge_message,
+                    merge_tree_id,
+                    [c_ours.id, c_theirs.id],
+                )
+                click.echo(f"Merge commit: {commit_id}")
 
-    # update our working copy
-    repo_structure = RepositoryStructure(repo)
-    wc = repo_structure.working_copy
-    click.echo(f"Updating {wc.path} ...")
-    commit = repo[commit_id]
-    return wc.reset(commit, repo_structure, force=force)
-
-
-def _get_long_label(commit, ref):
-    """Given a commit and a reference (can be None), returns a label"""
-    if ref is not None:
-        return f"\"{ref.shorthand}\" ({commit.id.hex})"
-    else:
-        return f"({commit.id.hex})"
-
-
-def _safe_get_dataset_for_index_entry(repo_structure, index_entry):
-    """Gets the dataset that a pygit2.IndexEntry refers to, or None"""
-    try:
-        return repo_structure.get_for_index_entry(index_entry)
-    except KeyError:
-        return None
-
-
-def _get_pk_for_index_entry(dataset, index_entry):
-    """Uses a dataset to decode the primary key that a pygit2.IndexEntry refers to"""
-    return dataset.index_entry_to_pk(index_entry)
-
-
-def _safe_get_feature(dataset, pk):
-    """Gets the dataset's feature with a particular primary key, or None"""
-    try:
-        _, feature = dataset.get_feature(pk)
-        return feature
-    except KeyError:
-        return None
-
-
-def first_true(iterable):
-    return next(filter(None, iterable))
-
-
-def _interactive_pause(prompt):
-    click.prompt(prompt, prompt_suffix="", default="", show_default=False)
-
-
-def resolve_merge_conflicts(repo, merge_index, ancestor, ours, theirs, force=False):
-    """
-    Supports resolution of basic merge conflicts, fails in more complex unsupported cases.
-
-    repo - a pygit2.Repository
-    merge_index - a pygit2.Index containing the attempted merge and merge conflicts.
-    ancestor, ours, theirs - each is a tuple (pygit2.Commit, pygit2.Reference), such
-    as might be obtained from Repository.resolve_refish. The reference can be None.
-    """
-
-    ANCESTOR, OURS, THEIRS = 0, 1, 2
-    # All of the following are 3-tuples of the form (ancestor, ours, theirs)
-    commit_args3 = (ancestor, ours, theirs)
-    commits3 = tuple(arg[0] for arg in commit_args3)
-    refs3 = tuple(arg[1] for arg in commit_args3)
-    labels3 = tuple(_get_long_label(*arg) for arg in commit_args3)
-    repo_structures3 = tuple(RepositoryStructure(repo, commit=c) for c in commits3)
-
-    conflict_pks = {}
-    for index_entries3 in merge_index.conflicts:
-        datasets3 = tuple(
-            _safe_get_dataset_for_index_entry(*x)
-            for x in zip(repo_structures3, index_entries3)
-        )
-        dataset = first_true(datasets3)
-        dataset_path = dataset.path
-        if None in datasets3:
-            for i in range(3):
-                presence = "present" if datasets3[i] is not None else "absent"
-                click.echo(f"{labels3[i]}: {dataset_path} is {presence}")
-            raise NotYetImplemented(
-                "Sorry, resolving conflicts where datasets are added or removed isn't supported yet"
-            )
-
-        pks3 = tuple(
-            _get_pk_for_index_entry(*x) for x in zip(datasets3, index_entries3)
-        )
-        if "META" in pks3:
-            click.echo(f"Merge conflict found in metadata for {dataset_path}")
-            raise NotYetImplemented(
-                "Sorry, resolving conflicts in metadata isn't supported yet"
-            )
-        pk = first_true(pks3)
-        if pks3.count(pk) != 3:
-            click.echo(
-                f"Merge conflict found where primary keys have changed in {dataset_path}"
-            )
-            for i in range(3):
-                click.echo(f"{labels3[i]}: {dataset_path}:{pks3[i]}")
-            raise NotYetImplemented(
-                "Sorry, resolving conflicts where primary keys have changed isn't supported yet"
-            )
-        conflict_pks.setdefault(dataset_path, [])
-        conflict_pks[dataset_path].append(pk)
-
-    num_conflicts = sum(len(pk_list) for pk_list in conflict_pks.values())
-    click.echo(f"\nFound {num_conflicts} conflicting features:")
-    for dataset_path, pks in conflict_pks.items():
-        click.echo(f"{len(pks)} in {dataset_path}")
-    click.echo()
-
-    # Check for dirty working copy before continuing - we don't want to fail after interactive part.
-    ours_rs = repo_structures3[OURS]
-    ours_rs.working_copy.reset(commits3[OURS], ours_rs, force=force)
-
-    # At this point, the failure should be dealt with so we can start resolving conflicts interactively.
-    # We don't want to fail during conflict resolution, since then we would lose all the user's work.
-    # TODO: Support other way(s) of resolving conflicts.
-    if sys.stdout.isatty():
-        _interactive_pause(
-            "Press enter to begin resolving merge conflicts, or Ctrl+C to abort at any time..."
-        )
-    else:
-        click.echo(
-            "Printing conflicts but not resolving - merge conflicts must be resolved in an interactive terminal"
-        )
-
-    # For each conflict, print and maybe resolve it.
-    for dataset_path, pks in conflict_pks.items():
-        datasets = tuple(rs[dataset_path] for rs in repo_structures3)
-        ours_ds = datasets[OURS]
-        for pk in sorted(pks):
-            feature_name = f"{dataset_path}:{pk}"
-            features3 = tuple(_safe_get_feature(d, pk) for d in datasets)
-            print_conflict(feature_name, features3, labels3)
-
-            if sys.stdout.isatty():
-                index_path = os.path.join(dataset_path, ours_ds.get_feature_path(pk))
-                resolve_conflict_interactive(feature_name, merge_index, index_path)
-
-    if not sys.stdout.isatty():
-        raise InvalidOperation(
-            "Merge conflicts must be resolved in an interactive terminal"
-        )
-
-    # Conflicts are resolved, time to commit
-    assert not merge_index.conflicts
-    merge_tree_id = merge_index.write_tree(repo)
-    click.echo(f"Merge tree: {merge_tree_id}")
-
-    user = repo.default_signature
-    merge_message = "Merge '{}'".format(
-        refs3[THEIRS].shorthand if refs3[THEIRS] else refs3[THEIRS].id.hex
-    )
-    commit_id = repo.create_commit(
-        repo.head.name,
-        user,
-        user,
-        merge_message,
-        merge_tree_id,
-        [commits3[OURS].id, commits3[THEIRS].id],
-    )
-    click.echo(f"Merge commit: {commit_id}")
-    return commit_id
-
-
-_version_names3 = ("ancestor", "ours", "theirs")
-_prefixes3 = ("- ", "+ ", "+ ")
-_big_prefixes3 = ("---", "+++", "+++")
-_cols3 = ("red", "green", "green")
-
-
-def print_conflict(feature_label, features3, labels3):
-    """
-    Prints 3 versions of a feature.
-    feature_label - the name of the feature.
-    features3 - tuple of 3 versions of the feature (ancestor, ours, theirs)
-    labels3 - labels for each version.
-    """
-    click.secho(f"\n=========== {feature_label} ==========", bold=True)
-    for i in range(3):
-        click.secho(f"{_big_prefixes3[i]} {_version_names3[i]:>9}: {labels3[i]}")
-        if features3[i] is not None:
-            click.secho(repr_row(features3[i], prefix=_prefixes3[i]), fg=_cols3[i])
-
-
-_version_chars3 = ("a", "o", "t")
-_version_chars_choice = click.Choice(choices=_version_chars3)
-
-
-def resolve_conflict_interactive(feature_name, merge_index, index_path):
-    """
-    Resolves the conflict at merge_index.conflicts[index_path] by asking
-    the user version they prefer - ancestor, ours or theirs.
-    merge_index - a pygit2.Index with conflicts.
-    index_path - a path where merge_index has a conflict.
-    feature_name - the name of the feature at index_path.
-    """
-    char = click.prompt(
-        f"For {feature_name} accept which version - ancestor, ours or theirs",
-        type=_version_chars_choice,
-    )
-    choice = _version_chars3.index(char)
-    index_entries3 = merge_index.conflicts[index_path]
-    del merge_index.conflicts[index_path]
-    merge_index.add(index_entries3[choice])
+    if not dry_run:
+        # update our working copy
+        repo_structure = RepositoryStructure(repo)
+        wc = repo_structure.working_copy
+        click.echo(f"Updating {wc.path} ...")
+        commit = repo[commit_id]
+        wc.reset(commit, repo_structure)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -348,6 +348,7 @@ class TestHelpers:
 
     # Test Dataset (gpkg-points / points)
     class POINTS:
+        ARCHIVE = "points"
         LAYER = "nz_pa_points_topo_150k"
         LAYER_PK = "fid"
         INSERT = f"""
@@ -374,6 +375,7 @@ class TestHelpers:
 
     # Test Dataset (gpkg-polygons / polygons)
     class POLYGONS:
+        ARCHIVE = "polygons"
         LAYER = "nz_waca_adjustments"
         LAYER_PK = "id"
         INSERT = f"""
@@ -407,6 +409,7 @@ class TestHelpers:
 
     # Test Dataset (gpkg-spec / table)
     class TABLE:
+        ARCHIVE = "table"
         LAYER = "countiestbl"
         LAYER_PK = "OBJECTID"
         INSERT = f"""

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -2,7 +2,7 @@ import pytest
 
 import pygit2
 
-from sno.exceptions import NOT_YET_IMPLEMENTED
+from sno.exceptions import INVALID_OPERATION
 
 H = pytest.helpers.helpers()
 
@@ -215,7 +215,7 @@ def test_merge_conflicts(
 
         r = cli_runner.invoke(["merge", "alternate"])
 
-        assert r.exit_code == NOT_YET_IMPLEMENTED, r
+        assert r.exit_code == INVALID_OPERATION, r
         assert "conflict" in r.stdout
         assert base_commit_id in r.stdout
         assert alternate_commit_id in r.stdout

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -138,10 +138,9 @@ def test_merge_true(
 
         # fastforward merge should fail
         r = cli_runner.invoke(["merge", "--ff-only", "changes"])
-        assert r.exit_code == 1, r
+        assert r.exit_code == INVALID_OPERATION, r
         assert (
-            r.stdout.splitlines()[-1]
-            == "Can't resolve as a fast-forward merge and --ff-only specified"
+            "Can't resolve as a fast-forward merge and --ff-only specified" in r.stderr
         )
 
         r = cli_runner.invoke(["merge", "--ff", "changes"])
@@ -169,26 +168,18 @@ def test_merge_true(
 
 
 @pytest.mark.parametrize(
-    "archive,layer,sample_pks",
+    "data",
     [
-        pytest.param("points", H.POINTS.LAYER, H.POINTS.SAMPLE_PKS, id="points"),
-        pytest.param(
-            "polygons", H.POLYGONS.LAYER, H.POLYGONS.SAMPLE_PKS, id="polygons"
-        ),
-        pytest.param("table", H.TABLE.LAYER, H.TABLE.SAMPLE_PKS, id="table"),
+        pytest.param(H.POINTS, id="points",),
+        pytest.param(H.POLYGONS, id="polygons",),
+        pytest.param(H.TABLE, id="table"),
     ],
 )
 def test_merge_conflicts(
-    archive,
-    layer,
-    sample_pks,
-    data_working_copy,
-    geopackage,
-    cli_runner,
-    update,
-    request,
+    data, data_working_copy, geopackage, cli_runner, update, request,
 ):
-    with data_working_copy(archive) as (repo_path, wc):
+    sample_pks = data.SAMPLE_PKS
+    with data_working_copy(data.ARCHIVE) as (repo_path, wc):
         repo = pygit2.Repository(str(repo_path))
         base_commit_id = repo.head.target.hex
 
@@ -221,12 +212,35 @@ def test_merge_conflicts(
         assert alternate_commit_id in r.stdout
         assert master_commit_id in r.stdout
 
+        assert "Use an interactive terminal to resolve merge conflicts" in r.stderr
+
+        def feature_name(pk):
+            return f"{data.LAYER}:{data.LAYER_PK}={pk}"
+
         # Only modified in alternate:
-        assert f"{layer}:{sample_pks[0]}" not in r.stdout
+        assert feature_name(sample_pks[0]) not in r.stdout
         # Modified exactly the same in both branches:
-        assert f"{layer}:{sample_pks[1]}" not in r.stdout
+        assert feature_name(sample_pks[1]) not in r.stdout
         # These two are merge conflicts:
-        assert f"{layer}:{sample_pks[2]}" in r.stdout
-        assert f"{layer}:{sample_pks[3]}" in r.stdout
+        assert feature_name(sample_pks[2]) in r.stdout
+        assert feature_name(sample_pks[3]) in r.stdout
         # Only modified in master
-        assert f"{layer}:{sample_pks[3]}" in r.stdout
+        assert feature_name(sample_pks[4]) not in r.stdout
+
+        r = cli_runner.invoke(["merge", "alternate"], input="o\nt\n")
+        assert r.exit_code == 0, r
+        assert repo.head.target.hex != alternate_commit_id
+        assert repo.head.target.hex != master_commit_id
+
+        r = cli_runner.invoke(["diff", master_commit_id])
+        assert r.exit_code == 0, r
+
+        # Diff merged in from alternate automatically
+        assert feature_name(sample_pks[0]) in r.stdout
+        # Diff merged in from alternate explicitly with "t" for theirs
+        assert feature_name(sample_pks[3]) in r.stdout
+
+        # The other features are not changed by the merge
+        assert feature_name(sample_pks[1]) not in r.stdout
+        assert feature_name(sample_pks[2]) not in r.stdout
+        assert feature_name(sample_pks[4]) not in r.stdout


### PR DESCRIPTION
![](https://media1.giphy.com/media/xTiTnqEbrWfX7xA9TW/giphy.gif)

Allows users to resolve a merge conflict, provided -
- they do it in one go, while `sno merge` is running
- they do it in an interactive terminal (ie, not from a script)
- the only merge conflicts are features, not metadata or schemas
- they resolve each feature one by one
- they are happy for the resolution for each feature to be one of the three pre-existing versions at the time of merge - ancestor, ours, or theirs (ie, there is no way for the resolution to be a new feature that merges fields from both ours and theirs)

Much more to do, but this can be built upon.

<img width="622" alt="Screen Shot 2020-04-23 at 4 18 20 PM" src="https://user-images.githubusercontent.com/7425442/80058722-2d439a00-857e-11ea-8e24-e4d7c14e09f8.png">