### PR TITLE
Faster tests via a data_archive_readonly fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import tarfile
 import time
 from pathlib import Path
@@ -101,8 +100,32 @@ def chdir():
     return chdir_
 
 
+def cleanup_dir(d):
+    try:
+        shutil.rmtree(d)
+    except PermissionError as e:
+        L.debug("W: Issue cleaning up temporary folder: %s", e)
+
+
+def extract_archive(name, extract_dir):
+    archive_name = f"{name}.tgz"
+    archive_path = Path(__file__).parent / "data" / archive_name
+    with tarfile.open(archive_path) as archive:
+        archive.extractall(extract_dir)
+
+    L.info("Extracted %s to %s", archive_name, extract_dir)
+
+    # data archive should have a single dir at the top-level, matching the archive name.
+    assert (
+        len(os.listdir(extract_dir)) == 1
+    ), f"Expected {name}/ as the only top-level item in {archive_name}"
+    d = extract_dir / name
+    assert d.is_dir(), f"Expected {name}/ as the only top-level item in {archive_name}"
+    return d
+
+
 @pytest.fixture
-def data_archive(request, tmp_path_factory, chdir):
+def data_archive(request, tmp_path_factory):
     """
     Extract a .tgz data archive to a temporary folder.
 
@@ -110,52 +133,54 @@ def data_archive(request, tmp_path_factory, chdir):
 
     Context-manager produces the directory path and sets the current working directory.
     """
-    incr = 0
 
     @contextlib.contextmanager
-    def _data_archive(name):
-        nonlocal incr
-
-        extract_dir = tmp_path_factory.mktemp(request.node.name, str(incr))
-        incr += 1
+    def ctx(name):
+        extract_dir = tmp_path_factory.mktemp(request.node.name, numbered=True)
         cleanup = True
         try:
-            archive_name = f"{name}.tgz"
-            archive_path = Path(__file__).parent / "data" / archive_name
-            with tarfile.open(archive_path) as archive:
-                archive.extractall(extract_dir)
-
-            L.info("Extracted %s to %s", archive_name, extract_dir)
-
-            # data archive should have a single dir at the top-level, matching the archive name.
-            assert (
-                len(os.listdir(extract_dir)) == 1
-            ), f"Expected {name}/ as the only top-level item in {archive_name}"
-            d = extract_dir / name
-            assert (
-                d.is_dir()
-            ), f"Expected {name}/ as the only top-level item in {archive_name}"
-
-            with chdir(d):
+            d = extract_archive(name, extract_dir)
+            with chdir_(d):
                 try:
                     yield d
-                except Exception:
+                finally:
                     if request.config.getoption("--preserve-data"):
                         L.info(
                             "Not cleaning up %s because --preserve-data was specified",
                             extract_dir,
                         )
                         cleanup = False
-                    raise
         finally:
             if cleanup:
                 time.sleep(1)
-                try:
-                    shutil.rmtree(extract_dir)
-                except PermissionError as e:
-                    L.debug("W: Issue cleaning up temporary folder: %s", e)
+                cleanup_dir(extract_dir)
 
-    return _data_archive
+    return ctx
+
+
+@pytest.fixture()
+def data_archive_readonly(request, pytestconfig):
+    """
+    Extract a .tgz data archive to a temporary folder, and CACHE it in the pytest cache.
+    Don't use this if you're going to write to the dir!
+    If you don't need to write to the extracted archive, use this in preference to data_archive.
+
+    Context-manager produces the directory path and sets the current working directory.
+    """
+
+    @contextlib.contextmanager
+    def ctx(name):
+        root = Path(request.config.cache.makedir('data_archive_readonly'))
+        path = root / name
+        if path.exists():
+            L.info("Found cache at %s", path)
+        else:
+            d = extract_archive(name, root)
+            assert d == path
+        with chdir_(path):
+            yield path
+
+    yield ctx
 
 
 @pytest.fixture

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1265,7 +1265,7 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
         pytest.param(H.POINTS.HEAD_TREE_SHA, H.POINTS.HEAD1_TREE_SHA, id="tree_hash"),
     ],
 )
-def test_diff_rev_noop(head_sha, head1_sha, data_archive, cli_runner):
+def test_diff_rev_noop(head_sha, head1_sha, data_archive_readonly, cli_runner):
     """diff between trees / commits - no-op"""
 
     NOOP_SPECS = (
@@ -1277,7 +1277,7 @@ def test_diff_rev_noop(head_sha, head1_sha, data_archive, cli_runner):
         f"..{head_sha}",
     )
 
-    with data_archive("points"):
+    with data_archive_readonly("points"):
         for spec in NOOP_SPECS:
             print(f"noop: {spec}")
             r = cli_runner.invoke(["diff", "--exit-code", spec])
@@ -1291,7 +1291,7 @@ def test_diff_rev_noop(head_sha, head1_sha, data_archive, cli_runner):
         pytest.param(H.POINTS.HEAD_TREE_SHA, H.POINTS.HEAD1_TREE_SHA, id="tree_hash"),
     ],
 )
-def test_diff_rev_rev(head_sha, head1_sha, data_archive, cli_runner):
+def test_diff_rev_rev(head_sha, head1_sha, data_archive_readonly, cli_runner):
     """diff between trees / commits - no-op"""
 
     F_SPECS = (
@@ -1314,7 +1314,7 @@ def test_diff_rev_rev(head_sha, head1_sha, data_archive, cli_runner):
         ("U-::1095", "U+::1095"),
     }
 
-    with data_archive("points"):
+    with data_archive_readonly("points"):
         for spec in F_SPECS:
             print(f"fwd: {spec}")
             r = cli_runner.invoke(["diff", "--exit-code", "--json", spec])
@@ -1680,11 +1680,11 @@ def test_diff_3way(data_working_copy, geopackage, cli_runner, insert, request):
 
 
 @pytest.mark.parametrize("output_format", SHOW_OUTPUT_FORMATS)
-def test_show_points_HEAD(output_format, data_archive, cli_runner):
+def test_show_points_HEAD(output_format, data_archive_readonly, cli_runner):
     """
     Show a patch; ref defaults to HEAD
     """
-    with data_archive("points"):
+    with data_archive_readonly("points"):
         r = cli_runner.invoke(["show", f"--{output_format}", "HEAD"])
         assert r.exit_code == 0, r
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -4,9 +4,9 @@ import pytest
 H = pytest.helpers.helpers()
 
 
-def test_log(data_archive, cli_runner):
+def test_log(data_archive_readonly, cli_runner):
     """ review commit history """
-    with data_archive("points"):
+    with data_archive_readonly("points"):
         r = cli_runner.invoke(["log"])
         assert r.exit_code == 0, r
         assert r.stdout.splitlines() == [

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -12,8 +12,10 @@ H = pytest.helpers.helpers()
     "working_copy",
     [pytest.param(True, id="with-wc"), pytest.param(False, id="without-wc"),],
 )
-def test_clone(working_copy, data_archive, tmp_path, cli_runner, chdir, geopackage):
-    with data_archive("points") as remote_path:
+def test_clone(
+    working_copy, data_archive_readonly, tmp_path, cli_runner, chdir, geopackage
+):
+    with data_archive_readonly("points") as remote_path:
         with chdir(tmp_path):
 
             r = cli_runner.invoke(
@@ -69,7 +71,13 @@ def test_clone(working_copy, data_archive, tmp_path, cli_runner, chdir, geopacka
 
 
 def test_fetch(
-    data_archive, data_working_copy, geopackage, cli_runner, insert, tmp_path, request
+    data_archive_readonly,
+    data_working_copy,
+    geopackage,
+    cli_runner,
+    insert,
+    tmp_path,
+    request,
 ):
     with data_working_copy("points") as (path1, wc):
         subprocess.run(["git", "init", "--bare", str(tmp_path)], check=True)
@@ -116,7 +124,7 @@ def test_fetch(
 
 
 def test_pull(
-    data_archive,
+    data_archive_readonly,
     data_working_copy,
     geopackage,
     cli_runner,


### PR DESCRIPTION
The `data_archive` fixture extracts an archive for each test,
even if a previous test used the same archive and didn't modify the
extracted output.

This change adds a new `data_archive_readonly` fixture, that re-uses
the same extracted directory for multiple tests. It uses the pytest cache.

I get consistent results of 215s for a full test run, compared to 230s before, for a win of 15 seconds (6.5%). I was hoping for a bigger win here, but it's better than nothing.

I was hoping to do a similar thing for `data_working_copy`, but all the tests that use that fixture end up writing to either the repo directory or the working copy, so they can't use this unfortunately.
