### PR TITLE
mac: fix missing git-remote-https

### DIFF
--- a/sno.spec
+++ b/sno.spec
@@ -131,8 +131,8 @@ if platform.system() == "Darwin":
                     # this symlinks to git: rewrite it
                     os.symlink('git', os.path.join(dist_libexec_root, relpath))
                     continue
-                if not os.path.exists(fpath):
-                    print(f"ignoring broken link {relpath}")
+                if not os.path.exists(fpath) and not os.path.exists(os.path.join(dist_bin_root, link_path)):
+                    print(f"ignoring broken link {relpath} -> {link_path}")
                     # ignore broken symlinks (git-csvserver/git-shell)
                     continue
             elif subprocess.check_output(['file', '-b', fpath], text=True).startswith('Mach-O'):

--- a/vendor/git/Makefile
+++ b/vendor/git/Makefile
@@ -93,6 +93,7 @@ source: src
 
 $(configure-git): export PKG_CONFIG_PATH=/dev/null
 $(configure-git): export CURL_CONFIG=$(CURL_PREFIX)/bin/curl-config
+$(configure-git): export NO_GETTEXT=YesPlease
 $(configure-git): | src $(libs)
 	cd src/ && ./configure \
 		--prefix=$(PREFIX) \

--- a/vendor/git/Makefile
+++ b/vendor/git/Makefile
@@ -27,11 +27,13 @@ export PATH := $(CCACHE_PATH):$(PREFIX)/bin:$(PATH)
 export PKG_CONFIG_PATH := $(realpath $(PREFIX)/lib/pkgconfig)
 
 ifeq ($(PLATFORM),Linux)
-CURL_PREFIX = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config curl --variable=prefix)
-libcurl := $(PREFIX)/lib/libcurl.$(LIBSUFFIX)
-libs += $(libcurl)
-CONFIG_FLAGS += --with-curl=$(CURL_PREFIX)
-export LDFLAGS += -Wl,-rpath=$$ORIGIN/../../lib
+	CURL_PREFIX = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config curl --variable=prefix)
+	libcurl := $(PREFIX)/lib/libcurl.$(LIBSUFFIX)
+	libs += $(libcurl)
+	export LDFLAGS += -Wl,-rpath=$$ORIGIN/../../lib
+else
+	# on macOS, force to the OS builtin libcurl
+	CURL_PREFIX=/usr
 endif
 
 export INSTALL_SYMLINKS=1
@@ -90,12 +92,13 @@ src: $(GIT_ARCHIVE)
 source: src
 
 $(configure-git): export PKG_CONFIG_PATH=/dev/null
+$(configure-git): export CURL_CONFIG=$(CURL_PREFIX)/bin/curl-config
 $(configure-git): | src $(libs)
 	cd src/ && ./configure \
 		--prefix=$(PREFIX) \
 		--without-tcltk \
 		--without-python \
-		$(CONFIG_FLAGS)
+		--with-curl=$(CURL_PREFIX)
 
 .PHONY: configure
 configure: clean-configure $(configure-git)

--- a/vendor/git/Makefile
+++ b/vendor/git/Makefile
@@ -36,7 +36,10 @@ else
 	CURL_PREFIX=/usr
 endif
 
-export INSTALL_SYMLINKS=1
+CONFIG_FLAGS += CURL_CONFIG=$(CURL_PREFIX)/bin/curl-config
+CONFIG_FLAGS += NO_GETTEXT=YesPlease
+CONFIG_FLAGS += V=1
+CONFIG_FLAGS += INSTALL_SYMLINKS=1
 
 build-git := src/git
 configure-git = src/config.status
@@ -58,7 +61,7 @@ cleaner: clean
 	$(MAKE) clean-configure
 
 .PHONY: cleanest
-cleanest: cleaner
+cleanest:
 	-$(RM) -r src/
 
 .PHONY: clean-configure
@@ -92,10 +95,8 @@ src: $(GIT_ARCHIVE)
 source: src
 
 $(configure-git): export PKG_CONFIG_PATH=/dev/null
-$(configure-git): export CURL_CONFIG=$(CURL_PREFIX)/bin/curl-config
-$(configure-git): export NO_GETTEXT=YesPlease
 $(configure-git): | src $(libs)
-	cd src/ && ./configure \
+	cd src/ && $(CONFIG_FLAGS) ./configure \
 		--prefix=$(PREFIX) \
 		--without-tcltk \
 		--without-python \
@@ -104,8 +105,9 @@ $(configure-git): | src $(libs)
 .PHONY: configure
 configure: clean-configure $(configure-git)
 
+$(build-git): export PKG_CONFIG_PATH=/dev/null
 $(build-git): $(configure-git)
-	$(MAKE) -C src -j 2 all strip
+	$(MAKE) -C src -j 2 $(CONFIG_FLAGS) all strip
 	$(MAKE) print-lib-deps-$(PLATFORM)
 
 #
@@ -114,7 +116,7 @@ $(build-git): $(configure-git)
 
 .PHONY: install
 install: $(build-git)
-	$(MAKE) -C src install
+	$(MAKE) -C src $(CONFIG_FLAGS) install
 
 .PHONY: print-lib-deps
 print-lib-deps: print-lib-deps-$(PLATFORM)


### PR DESCRIPTION
* fix missing `git-remote-https` symlink related to file processing order in PyInstaller
* force linking against macOS system libcurl
* since we last built the CI environment seems to have changed so git pulls in `libintl`, disable that via `NO_GETTEXT`
