### PR TITLE
Add --json-style option for `diff`/`show`

### DIFF
--- a/sno/diff.py
+++ b/sno/diff.py
@@ -375,7 +375,9 @@ def get_dataset_diff(base_rs, target_rs, working_copy, dataset_path, pk_filter):
     return diff
 
 
-def diff_with_writer(ctx, diff_writer, *, output_path='-', exit_code, args):
+def diff_with_writer(
+    ctx, diff_writer, *, output_path='-', exit_code, args, json_style="pretty"
+):
     """
     Calculates the appropriate diff from the arguments,
     and writes it using the given writer contextmanager.
@@ -461,6 +463,7 @@ def diff_with_writer(ctx, diff_writer, *, output_path='-', exit_code, args):
             "target": target_rs,
             "output_path": output_path,
             "dataset_count": len(all_datasets),
+            "json_style": json_style,
         }
 
         L.debug(
@@ -558,8 +561,16 @@ def diff_with_writer(ctx, diff_writer, *, output_path='-', exit_code, args):
     help="Output to a specific file/directory instead of stdout.",
     type=click.Path(writable=True, allow_dash=True),
 )
+@click.option(
+    "--json-style",
+    type=click.Choice(["extracompact", "compact", "pretty"]),
+    default="pretty",
+    help="How to format the output. Only used with --json or --geojson",
+    cls=MutexOption,
+    exclusive_with=["html", "text", "quiet"],
+)
 @click.argument("args", nargs=-1)
-def diff(ctx, output_format, output_path, exit_code, args):
+def diff(ctx, output_format, output_path, exit_code, json_style, args):
     """
     Show changes between commits, commit and working tree, etc
 
@@ -573,5 +584,10 @@ def diff(ctx, output_format, output_path, exit_code, args):
         exit_code = True
 
     return diff_with_writer(
-        ctx, diff_writer, output_path=output_path, exit_code=exit_code, args=args,
+        ctx,
+        diff_writer,
+        output_path=output_path,
+        exit_code=exit_code,
+        args=args,
+        json_style=json_style,
     )

--- a/sno/diff_output.py
+++ b/sno/diff_output.py
@@ -153,7 +153,7 @@ def repr_row(row, prefix="", exclude=None):
 
 
 @contextlib.contextmanager
-def diff_output_geojson(*, output_path, dataset_count, **kwargs):
+def diff_output_geojson(*, output_path, dataset_count, json_style, **kwargs):
     """
     Contextmanager.
 
@@ -221,13 +221,13 @@ def diff_output_geojson(*, output_path, dataset_count, **kwargs):
             fc["features"].append(_json_row(v_old, "U-", pk_field))
             fc["features"].append(_json_row(v_new, "U+", pk_field))
 
-        dump_json_output(fc, fp)
+        dump_json_output(fc, fp, json_style=json_style)
 
     yield _out
 
 
 @contextlib.contextmanager
-def diff_output_json(*, output_path, dataset_count, **kwargs):
+def diff_output_json(*, output_path, dataset_count, json_style="pretty", **kwargs):
     """
     Contextmanager.
     Yields a callable which can be called with dataset diffs
@@ -277,7 +277,9 @@ def diff_output_json(*, output_path, dataset_count, **kwargs):
 
     yield _out
 
-    dump_json_output({"sno.diff/v1": accumulated}, output_path)
+    dump_json_output(
+        {"sno.diff/v1": accumulated}, output_path, json_style=json_style
+    )
 
 
 def _json_row(row, change, pk_field):

--- a/sno/output_util.py
+++ b/sno/output_util.py
@@ -2,28 +2,31 @@ import io
 import json
 import sys
 
+JSON_PARAMS = {
+    "compact": {},
+    "pretty": {"indent": 2, "sort_keys": True},
+    "extracompact": {"separators": (',', ':')},
+}
 
-def dump_json_output(output, output_path, pretty=True):
+
+def dump_json_output(output, output_path, json_style="pretty"):
     """
     Dumps the output to JSON in the output file.
     """
 
     fp = resolve_output_path(output_path)
 
-    json_params = {}
-    if pretty:
-        json_params.update({"indent": 2, "sort_keys": True})
-    if pretty and fp == sys.stdout and fp.isatty():
+    if json_style == 'pretty' and fp == sys.stdout and fp.isatty():
         # Add syntax highlighting
         from pygments import highlight
         from pygments.lexers import JsonLexer
         from pygments.formatters import TerminalFormatter
 
-        dumped = json.dumps(output, **json_params)
+        dumped = json.dumps(output, **JSON_PARAMS[json_style])
         highlighted = highlight(dumped.encode(), JsonLexer(), TerminalFormatter())
         fp.write(highlighted)
     else:
-        json.dump(output, fp, **json_params)
+        json.dump(output, fp, **JSON_PARAMS[json_style])
 
 
 def resolve_output_path(output_path):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1747,3 +1747,12 @@ def test_show_points_HEAD(output_format, data_archive_readonly, cli_runner):
                 'authorTimeOffset': '+01:00',
                 'message': 'Improve naming on Coromandel East coast',
             }
+
+
+def test_show_json_format(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points"):
+        r = cli_runner.invoke(["show", f"--json", "--json-style=compact", "HEAD"])
+
+        assert r.exit_code == 0, r
+        # output is compact, no indentation
+        assert '"sno.diff/v1": {"' in r.stdout


### PR DESCRIPTION
Works with `--json` and `--geojson` output.

Reduces size of patches by a lot:

```
$ sno show --json --json-style=extracompact | wc -c
2576

$ sno show --json --json-style=compact | wc -c
2811

$ sno show --json --json-style=pretty | wc -c
5405
```

The default is still `pretty`.