### PR TITLE
Use github actions job number in dev versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
             VER="${BASH_REMATCH[1]}"
             IS_RELEASE=1
           else
-            VER=$(sed -E "s/(.*)/\1+ci.${GITHUB_SHA::8}/" sno/VERSION)
+            VER=$(sed -E "s/(.*)/\1+ci.${{ github.run_number }}.git${GITHUB_SHA::8}/" sno/VERSION)
             IS_RELEASE=0
           fi
           echo "App Version: $VER"


### PR DESCRIPTION
Dev packages now look like: `sno_0.3.2.dev0+ci.256.git6698bf01-1_amd64.deb`

The previous numbering didn't necessarily produce increasing versions, due to git hashes