### PR TITLE
App merge conflict flow step 1 - JSON output

### DIFF
--- a/sno/conflicts.py
+++ b/sno/conflicts.py
@@ -2,15 +2,12 @@ from collections import namedtuple
 import json
 import logging
 import re
-import sys
 
 import click
 import pygit2
 
-from .diff_output import repr_row
-from .exceptions import InvalidOperation, NotYetImplemented, MERGE_CONFLICT
-from .structs import AncestorOursTheirs, CommitWithReference
-from .structure import RepositoryStructure
+from .exceptions import NotYetImplemented
+from .structs import AncestorOursTheirs
 
 
 L = logging.getLogger("sno.conflicts")
@@ -162,211 +159,79 @@ class ConflictIndex:
             )
 
 
-def first_true(iterable):
-    """Returns the value from the iterable that is truthy."""
-    return next(filter(None, iterable))
-
-
-class InputMode:
-    DEFAULT = 0
-    INTERACTIVE = 1
-    NO_INPUT = 2
-
-
-def get_input_mode():
-    if sys.stdin.isatty() and sys.stdout.isatty():
-        return InputMode.INTERACTIVE
-    elif sys.stdin.isatty() and not sys.stdout.isatty():
-        return InputMode.NO_INPUT
-    elif is_empty_stream(sys.stdin):
-        return InputMode.NO_INPUT
-    else:
-        return InputMode.DEFAULT
-
-
-def is_empty_stream(stream):
-    if stream.seekable():
-        pos = stream.tell()
-        if stream.read(1) == "":
-            return True
-        stream.seek(pos)
-    return False
-
-
-def interactive_pause(prompt):
-    """Like click.pause() but waits for the Enter key specifically."""
-    click.prompt(prompt, prompt_suffix="", default="", show_default=False)
-
-
-def _safe_get_dataset_for_index_entry(repo_structure, index_entry):
-    """Gets the dataset that a pygit2.IndexEntry refers to, or None"""
-    if index_entry is None:
-        return None
-    try:
-        return repo_structure.get_for_index_entry(index_entry)
-    except KeyError:
-        return None
-
-
-def _safe_get_feature(dataset, pk):
-    """Gets the dataset's feature with a particular primary key, or None"""
-    try:
-        _, feature = dataset.get_feature(pk)
-        return feature
-    except KeyError:
-        return None
-
-
-def resolve_merge_conflicts(repo, merge_index, ancestor, ours, theirs, dry_run=False):
-    """
-    Supports resolution of basic merge conflicts, fails in more complex unsupported cases.
-
-    repo - a pygit2.Repository
-    merge_index - a pygit2.Index containing the attempted merge and merge conflicts.
-    ancestor, ours, theirs - each is a refish, commit, or CommitWithReference.
-    """
-
+def summarise_conflicts_json(repo, conflict_index):
     # Shortcut used often below
     def aot(generator_or_tuple):
         return AncestorOursTheirs(*generator_or_tuple)
 
-    # We have three versions of lots of objects - ancestor, ours, theirs.
-    commit_with_refs3 = AncestorOursTheirs(
-        CommitWithReference.resolve(repo, ancestor),
-        CommitWithReference.resolve(repo, ours),
-        CommitWithReference.resolve(repo, theirs),
+    conflicts = {}
+
+    for key, conflict3 in conflict_index.conflicts.items():
+        paths3 = aot(c.path if c else None for c in conflict3)
+        if not any(paths3):
+            # Shouldn't happen
+            raise RuntimeError("Conflict has no paths")
+
+        # Paths look like this: # path/to/table/.sno-table/feature_path for features
+        # Or path/to/table/.sno-table/meta/... for metadata
+        # (This will need updating if newer dataset versions don't follow this pattern.)
+        tables3 = aot(p.split("/.sno-table/", 1)[0] if p else None for p in paths3)
+        actual_tables = [t for t in tables3 if t]
+        all_same_table = all(a == actual_tables[0] for a in actual_tables)
+        if not all_same_table:
+            # This is a really bad conflict - it seems to involve multiple tables.
+            # Perhaps features were moved from one table to another, or perhaps
+            # a table was renamed.
+            conflicts.setdefault("<other>", 0)
+            conflicts["<other>"] += 1
+            continue
+
+        table = actual_tables[0]
+        conflicts.setdefault(table, {})
+        conflicts_table = conflicts[table]
+
+        meta_change = any("/.sno-table/meta/" in (p or "") for p in paths3)
+        if meta_change:
+            conflicts_table.setdefault("metaConflicts", 0)
+            conflicts_table["metaConflicts"] += 1
+            continue
+
+        conflicts_table.setdefault("featureConflicts", {})
+        feature_conflicts = conflicts_table["featureConflicts"]
+
+        all_same_path = all((p == paths3[0] for p in paths3))
+        if all_same_path:
+            feature_conflicts.setdefault("edit/edit", 0)
+            feature_conflicts["edit/edit"] += 1
+            continue
+
+        feature_conflicts.setdefault("other", 0)
+        feature_conflicts["other"] += 1
+
+    return conflicts
+
+
+def move_repo_to_merging_state(repo, conflict_index, ancestor, ours, theirs):
+    raise NotYetImplemented(
+        "Sorry, putting the repository into a merging state is not yet supported"
     )
-    commits3 = aot(cwr.commit for cwr in commit_with_refs3)
-    repo_structures3 = aot(
-        RepositoryStructure(repo, commit=c.commit) for c in commit_with_refs3
-    )
-
-    conflict_pks = {}
-    for index_entries3 in merge_index.conflicts:
-        datasets3 = aot(
-            _safe_get_dataset_for_index_entry(rs, ie)
-            for rs, ie in zip(repo_structures3, index_entries3)
-        )
-        dataset = first_true(datasets3)
-        dataset_path = dataset.path
-        if None in datasets3:
-            for cwr, ds in zip(commit_with_refs3, datasets3):
-                presence = "present" if ds is not None else "absent"
-                click.echo(f"{cwr}: {dataset_path} is {presence}")
-            raise NotYetImplemented(
-                "Sorry, resolving conflicts where features are added or removed isn't supported yet"
-            )
-
-        pks3 = aot(
-            ds.index_entry_to_pk(ie) for ds, ie in zip(datasets3, index_entries3)
-        )
-        if "META" in pks3:
-            click.echo(f"Merge conflict found in metadata for {dataset_path}")
-            raise NotYetImplemented(
-                "Sorry, resolving conflicts in metadata isn't supported yet"
-            )
-        pk = first_true(pks3)
-        if pks3.count(pk) != 3:
-            click.echo(
-                f"Merge conflict found where primary keys have changed in {dataset_path}"
-            )
-            for cwr, pk in zip(commit_with_refs3, pks3):
-                click.echo(f"{cwr}: {dataset_path}:{pk}")
-            raise NotYetImplemented(
-                "Sorry, resolving conflicts where primary keys have changed isn't supported yet"
-            )
-        conflict_pks.setdefault(dataset_path, [])
-        conflict_pks[dataset_path].append(pk)
-
-    num_conflicts = sum(len(pk_list) for pk_list in conflict_pks.values())
-    click.echo(f"\nFound {num_conflicts} conflicting features:")
-    for dataset_path, pks in conflict_pks.items():
-        click.echo(f"{len(pks)} in {dataset_path}")
-    click.echo()
-
-    # Check for dirty working copy before continuing - we don't want to fail after interactive part.
-    ours_rs = repo_structures3.ours
-    ours_rs.working_copy.reset(commits3.ours, ours_rs)
-
-    # At this point, the failure should be dealt with so we can start resolving conflicts interactively.
-    # We don't want to fail during conflict resolution, since then we would lose all the user's work.
-    # TODO: Support other way(s) of resolving conflicts.
-    input_mode = get_input_mode()
-    if dry_run:
-        click.echo("Printing conflicts but not resolving due to --dry-run")
-    elif input_mode == InputMode.INTERACTIVE:
-        interactive_pause(
-            "Press enter to begin resolving merge conflicts, or Ctrl+C to abort at any time..."
-        )
-    elif input_mode == InputMode.NO_INPUT:
-        click.echo(
-            "Printing conflicts but not resolving - run from an interactive terminal to resolve"
-        )
-
-    # For each conflict, print and maybe resolve it.
-    for dataset_path, pks in sorted(conflict_pks.items()):
-        datasets3 = aot(rs[dataset_path] for rs in repo_structures3)
-        ours_ds = datasets3.ours
-        for pk in sorted(pks):
-            feature_name = f"{dataset_path}:{ours_ds.primary_key}={pk}"
-            features3 = aot(_safe_get_feature(d, pk) for d in datasets3)
-            print_conflict(feature_name, features3, commit_with_refs3)
-
-            if not dry_run and input_mode != InputMode.NO_INPUT:
-                index_path = f"{dataset_path}/{ours_ds.get_feature_path(pk)}"
-                resolve_conflict_interactive(feature_name, merge_index, index_path)
-
-    if dry_run:
-        raise InvalidOperation(
-            "Run without --dry-run to resolve merge conflicts", exit_code=MERGE_CONFLICT
-        )
-    elif input_mode == InputMode.NO_INPUT:
-        raise InvalidOperation(
-            "Use an interactive terminal to resolve merge conflicts",
-            exit_code=MERGE_CONFLICT,
-        )
-
-    # Conflicts are resolved
-    assert not merge_index.conflicts
-    return merge_index
 
 
-def print_conflict(feature_name, features3, commit_with_refs3):
-    """
-    Prints 3 versions of a feature.
-    feature_name - the name of the feature.
-    features3 - AncestorOursTheirs tuple containing three versions of a feature.
-    commit_with_refs3 - AncestorOursTheirs tuple containing a CommitWithReference
-        for each of the three versions.
-    """
-    click.secho(f"\n=========== {feature_name} ==========", bold=True)
-    for name, feature, cwr in zip(
-        AncestorOursTheirs.NAMES, features3, commit_with_refs3
-    ):
-        prefix = "---" if name == "ancestor" else "+++"
-        click.secho(f"{prefix} {name:>9}: {cwr}")
-        if feature is not None:
-            prefix = "- " if name == "ancestor" else "+ "
-            fg = "red" if name == "ancestor" else "green"
-            click.secho(repr_row(feature, prefix=prefix), fg=fg)
+def output_json_conflicts_as_text(jdict):
+    for table, table_conflicts in sorted(jdict.items()):
+        if table == "<other>":
+            continue
+        click.secho(f"{table}:", bold=True)
+        meta_conflicts = table_conflicts.get("metaConflicts", 0)
+        if meta_conflicts:
+            click.echo(f"  META conflicts: {meta_conflicts}")
+        feature_conflicts = table_conflicts.get("featureConflicts", {})
+        if feature_conflicts:
+            click.echo("  Feature conflicts:")
+            for k, v in sorted(feature_conflicts.items()):
+                click.echo(f"    {k}: {v}")
+        click.echo()
 
-
-_aot_choice = click.Choice(choices=AncestorOursTheirs.CHARS)
-
-
-def resolve_conflict_interactive(feature_name, merge_index, index_path):
-    """
-    Resolves the conflict at merge_index.conflicts[index_path] by asking
-    the user version they prefer - ancestor, ours or theirs.
-    feature_name - the name of the feature at index_path.
-    merge_index - a pygit2.Index with conflicts.
-    index_path - a path where merge_index has a conflict.
-    """
-    char = click.prompt(
-        f"For {feature_name} accept which version - ancestor, ours or theirs",
-        type=_aot_choice,
-    )
-    choice = AncestorOursTheirs.CHARS.index(char)
-    index_entries3 = merge_index.conflicts[index_path]
-    del merge_index.conflicts[index_path]
-    merge_index.add(index_entries3[choice])
+    non_table_conflicts = jdict.get("<other>", 0)
+    if non_table_conflicts:
+        click.secho(f"Other conflicts: {non_table_conflicts}", bold=True)

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -1,9 +1,17 @@
 import logging
+import sys
 
 import click
 
-from .conflicts import resolve_merge_conflicts
-from .exceptions import InvalidOperation
+from .cli_util import do_json_option
+from .conflicts import (
+    ConflictIndex,
+    move_repo_to_merging_state,
+    summarise_conflicts_json,
+    output_json_conflicts_as_text,
+)
+from .exceptions import InvalidOperation, NotYetImplemented
+from .output_util import dump_json_output
 from .structs import CommitWithReference
 from .structure import RepositoryStructure
 
@@ -35,11 +43,32 @@ L = logging.getLogger("sno.merge")
     help="Don't perform a merge - just show what would be done",
 )
 @click.argument("commit", required=True, metavar="COMMIT")
+@do_json_option
 @click.pass_context
-def merge(ctx, ff, ff_only, dry_run, commit):
+def merge(ctx, ff, ff_only, dry_run, do_json, commit):
     """ Incorporates changes from the named commits (usually other branch heads) into the current branch. """
     repo = ctx.obj.repo
+    merge_jdict = do_merge(repo, ff, ff_only, dry_run, commit)
+    no_op = merge_jdict.get("noOp", False) or merge_jdict.get("dryRun", False)
 
+    if not no_op:
+        # Update working copy.
+        repo_structure = RepositoryStructure(repo)
+        wc = repo_structure.working_copy
+        if wc:
+            L.debug(f"Updating {wc.path} ...")
+            merge_commit = repo[merge_jdict["mergeCommit"]]
+            wc.reset(merge_commit, repo_structure)
+
+    if do_json:
+        jdict = {"sno.merge/v1": merge_jdict}
+        dump_json_output(jdict, sys.stdout)
+    else:
+        output_merge_json_as_text(merge_jdict)
+
+
+def do_merge(repo, ff, ff_only, dry_run, commit):
+    """Does a merge, but doesn't update the working copy."""
     if ff_only and not ff:
         raise click.BadParameter(
             "Conflicting parameters: --no-ff & --ff-only", param_hint="--ff-only"
@@ -48,18 +77,29 @@ def merge(ctx, ff, ff_only, dry_run, commit):
     # accept ref-ish things (refspec, branch, commit)
     theirs = CommitWithReference.resolve(repo, commit)
     ours = CommitWithReference.resolve(repo, "HEAD")
-
-    click.echo(f"Merging {theirs} to {ours} ...")
     ancestor_id = repo.merge_base(theirs.id, ours.id)
-    click.echo(f"Found common ancestor: {ancestor_id}")
 
     if not ancestor_id:
         raise InvalidOperation(f"Commits {theirs.id} and {ours.id} aren't related.")
 
+    merge_message = f"Merge {theirs.shorthand_with_type} into {ours.shorthand}"
+    merge_jdict = {
+        "ancestor": {"commit": ancestor_id.hex},
+        "ours": ours.as_json(),
+        "theirs": theirs.as_json(),
+        "message": merge_message,
+        "conflicts": None,
+    }
+
     # We're up-to-date if we're trying to merge our own common ancestor.
     if ancestor_id == theirs.id:
-        click.echo("Already merged!")
-        return
+        merge_jdict["mergeCommit"] = ours.id.hex
+        merge_jdict["noOp"] = True
+        return merge_jdict
+
+    # "dryRun": True means we didn't actually do this
+    # "dryRun": False means we *did* actually do this
+    merge_jdict["dryRun"] = dry_run
 
     # We're fastforwardable if we're our own common ancestor.
     can_ff = ancestor_id == ours.id
@@ -71,51 +111,81 @@ def merge(ctx, ff, ff_only, dry_run, commit):
 
     if can_ff and ff:
         # do fast-forward merge
-        click.echo(f"Can fast-forward to {theirs.id}")
-        if dry_run:
-            return
+        L.debug(f"Fast forward: {theirs.id.hex}")
+        merge_jdict["mergeCommit"] = theirs.id.hex
+        merge_jdict["fastForward"] = True
+        if not dry_run:
+            repo.head.set_target(theirs.id, f"{merge_message}: Fast-forward")
+        return merge_jdict
 
-        repo.head.set_target(theirs.id, "merge: Fast-forward")
-        commit_id = theirs.id
-    else:
-        c_ancestor = repo[ancestor_id]
-        merge_index = repo.merge_trees(
-            ancestor=c_ancestor.tree, ours=ours.tree, theirs=theirs.tree
-        )
+    c_ancestor = repo[ancestor_id]
+    merge_index = repo.merge_trees(
+        ancestor=c_ancestor.tree, ours=ours.tree, theirs=theirs.tree
+    )
 
-        if not merge_index.conflicts:
-            click.echo("No conflicts!")
-        else:
-            merge_index = resolve_merge_conflicts(
-                repo,
-                merge_index,
-                ancestor=c_ancestor,
-                ours=ours,
-                theirs=theirs,
-                dry_run=dry_run,
+    if merge_index.conflicts:
+        conflict_index = ConflictIndex(merge_index)
+        merge_jdict["conflicts"] = summarise_conflicts_json(repo, conflict_index)
+        if not dry_run:
+            move_repo_to_merging_state(
+                repo, conflict_index, ancestor=c_ancestor, ours=ours, theirs=theirs
             )
+        return merge_jdict
 
+    if dry_run:
+        merge_jdict["mergeCommit"] = "(dryRun)"
+        return merge_jdict
+
+    merge_tree_id = merge_index.write_tree(repo)
+    L.debug(f"Merge tree: {merge_tree_id}")
+
+    user = repo.default_signature
+    merge_commit_id = repo.create_commit(
+        repo.head.name, user, user, merge_message, merge_tree_id, [ours.id, theirs.id],
+    )
+
+    L.debug(f"Merge commit: {merge_commit_id}")
+    merge_jdict["mergeCommit"] = merge_commit_id.hex
+
+    return merge_jdict
+
+
+def output_merge_json_as_text(jdict):
+    click.echo(jdict["message"].replace("Merge", "Merging", 1))
+
+    if jdict.get("noOp", False):
+        click.echo("Already up to date")
+        return
+
+    dry_run = jdict.get("dryRun", False)
+    merge_commit = jdict.get("mergeCommit", None)
+
+    if jdict.get("fastForward", False):
         if dry_run:
-            return
+            click.echo(
+                f"Can fast-forward to {merge_commit}\n"
+                "(Not actually fast-forwarding due to --dry-run)",
+            )
+        else:
+            click.echo(f"Fast-forwarded to {merge_commit}")
+        return
 
-        merge_tree_id = merge_index.write_tree(repo)
-        L.debug(f"Merge tree: {merge_tree_id}")
+    conflicts = jdict.get("conflicts", None)
+    if not conflicts:
+        if dry_run:
+            click.echo(
+                "No conflicts: merge will succeed!\n"
+                "(Not actually merging due to --dry-run)"
+            )
+        else:
+            click.echo(f"No conflicts!\nMerge commited as {merge_commit}")
+        return
 
-        user = repo.default_signature
-        merge_message = f"Merge {theirs.shorthand_with_type} into {ours.shorthand}"
-        commit_id = repo.create_commit(
-            repo.head.name,
-            user,
-            user,
-            merge_message,
-            merge_tree_id,
-            [ours.id, theirs.id],
-        )
-        click.echo(f"Merge committed as: {commit_id}")
+    click.echo("Conflicts found:\n")
+    output_json_conflicts_as_text(conflicts)
 
-    # update our working copy
-    repo_structure = RepositoryStructure(repo)
-    wc = repo_structure.working_copy
-    L.info(f"Updating {wc.path} ...")
-    commit = repo[commit_id]
-    wc.reset(commit, repo_structure)
+    if dry_run:
+        click.echo("(Not actually merging due to --dry-run)")
+    else:
+        # TODO: explain how to resolve conflicts, when this is possible
+        raise NotYetImplemented("Sorry, resolving conflicts is not yet supported")

--- a/sno/structs.py
+++ b/sno/structs.py
@@ -51,15 +51,31 @@ class CommitWithReference:
         return self.id.hex
 
     @property
+    def reference_type(self):
+        if self.reference is None:
+            return None
+        elif self.reference.name.startswith("refs/heads/"):
+            return "branch"
+        elif self.reference.name.startswith("refs/tags/"):
+            return "tag"
+        return None
+
+    @property
     def shorthand_with_type(self):
         if self.reference is not None:
-            if self.reference.name.startswith("refs/heads/"):
-                return f'branch "{self.reference.shorthand}"'
-            elif self.reference.name.startswith("refs/tags/"):
-                return f'tag "{self.reference.shorthand}"'
+            ref_type = self.reference_type
+            if ref_type:
+                return f'{ref_type} "{self.reference.shorthand}"'
             else:
                 return f'"{self.reference.shorthand}"'
         return self.id.hex
+
+    def as_json(self):
+        result = {"commit": self.commit.id.hex}
+        ref_type = self.reference_type
+        if ref_type is not None:
+            result[ref_type] = self.reference.shorthand
+        return result
 
     @staticmethod
     def resolve(repo, refish):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -108,7 +108,7 @@ def test_e2e(
             r = cli_runner.invoke(["merge", "edit-1", "--no-ff"])
             assert r.exit_code == 0
             assert "Fast-forward" not in r.stdout
-            sha_merge1 = r.stdout.splitlines()[-1].split(": ")[1]
+            sha_merge1 = r.stdout.splitlines()[-1].split(" ")[-1]
             print("Merge SHA:", sha_merge1)
 
             H.git_graph(request, "post edit-1 merge", count=10)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 import pygit2
@@ -86,12 +87,12 @@ def test_merge_fastforward_noff(
         assert repo.head.target.hex != commit_id
 
         # force creation of a merge commit
-        r = cli_runner.invoke(["merge", "--no-ff", "changes"])
+        r = cli_runner.invoke(["merge", "changes", "--no-ff", "--json"])
         assert r.exit_code == 0, r
 
         H.git_graph(request, "post-merge")
 
-        merge_commit_id = r.stdout.splitlines()[-1].split(": ")[1]
+        merge_commit_id = json.loads(r.stdout)["sno.merge/v1"]["mergeCommit"]
 
         assert repo.head.name == "refs/heads/master"
         assert repo.head.target.hex == merge_commit_id
@@ -143,11 +144,11 @@ def test_merge_true(
             "Can't resolve as a fast-forward merge and --ff-only specified" in r.stderr
         )
 
-        r = cli_runner.invoke(["merge", "--ff", "changes"])
+        r = cli_runner.invoke(["merge", "changes", "--ff", "--json"])
         assert r.exit_code == 0, r
         H.git_graph(request, "post-merge")
 
-        merge_commit_id = r.stdout.splitlines()[-1].split(": ")[1]
+        merge_commit_id = json.loads(r.stdout)["sno.merge/v1"]["mergeCommit"]
 
         assert repo.head.name == "refs/heads/master"
         assert repo.head.target.hex == merge_commit_id


### PR DESCRIPTION
![](https://media3.giphy.com/media/Xg9qVfblOUg5oMBS1v/giphy.gif)

Doing a sno-merge should either succeed if there are no conflicts, or return a list / summary of conflicts while putting the repository into a "merging" state.
Then the user can run follow-up commands to see and resolve conflicts one by one, finally getting the repo back into a normal state once they are all resolved and the merge is committed.

This PR moves us in that direction, but there is much more to do.

Changes in this PR (some functionality added, some removed):
- JSON/text output for `sno merge` is now supported, and gives the result of the merge operation, including a summary of conflicts. 
(Getting the complete list of conflicts in text or JSON will need a follow up change - this could even be a separate command, since querying the full list of remaining conflicts is a separate operation to beginning the merge).
- Seeing or resolving individual conflicts is no longer supported - that will come back in a follow up change, with a separate command eg `sno resolve <conflict_id> <conflict_resolution>`
- Completing a merge in a single go by resolving every conflict interactively is no longer supported - this might come back eventually, perhaps built on top of `sno resolve`.