### PR TITLE
Fix exit codes for commit-not-found case, clean up code.

### DIFF
--- a/sno/conflicts.py
+++ b/sno/conflicts.py
@@ -223,7 +223,7 @@ def resolve_merge_conflicts(repo, merge_index, ancestor, ours, theirs, dry_run=F
 
     repo - a pygit2.Repository
     merge_index - a pygit2.Index containing the attempted merge and merge conflicts.
-    ancestor, ours, theirs - each is a either a pygit2.Commit, or a CommitWithReference.
+    ancestor, ours, theirs - each is a refish, commit, or CommitWithReference.
     """
 
     # Shortcut used often below
@@ -232,9 +232,9 @@ def resolve_merge_conflicts(repo, merge_index, ancestor, ours, theirs, dry_run=F
 
     # We have three versions of lots of objects - ancestor, ours, theirs.
     commit_with_refs3 = AncestorOursTheirs(
-        CommitWithReference(ancestor),
-        CommitWithReference(ours),
-        CommitWithReference(theirs),
+        CommitWithReference.resolve(repo, ancestor),
+        CommitWithReference.resolve(repo, ours),
+        CommitWithReference.resolve(repo, theirs),
     )
     commits3 = aot(cwr.commit for cwr in commit_with_refs3)
     repo_structures3 = aot(

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -46,8 +46,8 @@ def merge(ctx, ff, ff_only, dry_run, commit):
         )
 
     # accept ref-ish things (refspec, branch, commit)
-    theirs = CommitWithReference.resolve_refish(repo, commit)
-    ours = CommitWithReference.resolve_refish(repo, "HEAD")
+    theirs = CommitWithReference.resolve(repo, commit)
+    ours = CommitWithReference.resolve(repo, "HEAD")
 
     click.echo(f"Merging {theirs} to {ours} ...")
     ancestor_id = repo.merge_base(theirs.id, ours.id)

--- a/sno/show.py
+++ b/sno/show.py
@@ -4,11 +4,10 @@ from datetime import datetime, timezone, timedelta
 from io import StringIO
 
 import click
-import pygit2
 
 from .cli_util import MutexOption
-from .exceptions import NotFound, NO_COMMIT
 from .output_util import dump_json_output, resolve_output_path
+from .structs import CommitWithReference
 from .timestamps import datetime_to_iso8601_utc, timedelta_to_iso8601_tz
 from . import diff
 
@@ -50,13 +49,9 @@ def show(ctx, *, refish, output_format, json_style, **kwargs):
     """
     Show the given commit, or HEAD
     """
-    # Ensure we were given a reference to a commit, and not a tree or something
     repo = ctx.obj.repo
-    try:
-        obj = repo.revparse_single(refish)
-        commit = obj.peel(pygit2.Commit)
-    except (KeyError, pygit2.InvalidSpecError):
-        raise NotFound(f"{refish} is not a commit", exit_code=NO_COMMIT)
+    # Ensures we were given a reference to a commit, and not a tree or something
+    commit = CommitWithReference.resolve(repo, refish).commit
 
     if commit.parents:
         parent = f"{refish}^"

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -72,6 +72,8 @@ class RepositoryStructure:
     def __repr__(self):
         if self._commit is not None:
             return f"RepoStructure<{self.repo.path}@{self._commit.id}>"
+        elif self._tree is not None:
+            return f"RepoStructure<{self.repo.path}@tree={self._tree.id}>"
         else:
             return f"RepoStructure<{self.repo.path} <empty>>"
 


### PR DESCRIPTION
![](https://media2.giphy.com/media/H7wajFPnZGdRWaQeu0/giphy.gif)

Clean up of code that uses resolve_refish and revparse_single - make sure the code ends up with the right type (eg commit or tree), and that exit code NO_COMMIT is returned if not found.