### PR TITLE
Implement "move_repo_to_merging_state". Resolving conflicts not implemented

### DIFF
--- a/sno/repo_files.py
+++ b/sno/repo_files.py
@@ -1,0 +1,91 @@
+import os
+
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+
+
+from . import is_windows
+from .exceptions import SubprocessError
+
+
+HEAD = "HEAD"
+COMMIT_EDITMSG = "COMMIT_EDITMSG"
+ORIG_HEAD = "ORIG_HEAD"
+MERGE_HEAD = "MERGE_HEAD"
+MERGE_MSG = "MERGE_MSG"
+MERGE_INDEX = "MERGE_INDEX"
+MERGE_LABELS = "MERGE_LABELS"
+
+
+def repo_file_path(repo, filename):
+    return Path(repo.path) / filename
+
+
+def repo_file_exists(repo, filename):
+    return repo_file_path(repo, filename).exists()
+
+
+def write_repo_file(repo, filename, contents):
+    if not isinstance(contents, str):
+        raise TypeError("File contents must be a string", type(contents))
+    if not contents.endswith("\n"):
+        contents += "\n"
+
+    path = repo_file_path(repo, filename)
+    path.write_text(contents, encoding="utf-8")
+
+
+def fallback_editor():
+    if is_windows:
+        return "notepad.exe"
+    else:
+        return shutil.which("nano") and "nano" or "vi"
+
+
+def user_edit_repo_file(repo, filename):
+    editor = os.environ.get("GIT_EDITOR")
+    if not editor:
+        editor = os.environ.get("VISUAL")
+    if not editor:
+        editor = os.environ.get("EDITOR")
+    if not editor:
+        editor = fallback_editor()
+
+    path = str(repo_file_path(repo, filename))
+    if is_windows:
+        # No shlex.quote() on windows
+        # " isn't legal in filenames
+        editor_cmd = f'{editor} "{path}"'
+    else:
+        editor_cmd = f"{editor} {shlex.quote(path)}"
+    try:
+        subprocess.check_call(editor_cmd, shell=True)
+    except subprocess.CalledProcessError as e:
+        raise SubprocessError(
+            f"There was a problem with the editor '{editor}': {e}",
+            called_process_error=e,
+        ) from e
+
+
+def read_repo_file(repo, filename):
+    path = repo_file_path(repo, filename)
+    return path.read_text(encoding="utf-8")
+
+
+def remove_repo_file(repo, filename, missing_ok=True):
+    path = repo_file_path(repo, filename)
+    if not path.exists() and missing_ok:
+        return  # TODO: use path.unlink(missing_ok=True) (python3.8)
+    path.unlink()
+
+
+def is_ongoing_merge(repo):
+    if repo_file_exists(repo, MERGE_HEAD):
+        if not repo_file_exists(repo, MERGE_INDEX):
+            raise RuntimeError(
+                "Repository is in merging state but MERGE_INDEX is missing. Try `sno merge --abort`"
+            )
+        return True
+    return False

--- a/sno/structs.py
+++ b/sno/structs.py
@@ -70,13 +70,6 @@ class CommitWithReference:
                 return f'"{self.reference.shorthand}"'
         return self.id.hex
 
-    def as_json(self):
-        result = {"commit": self.commit.id.hex}
-        ref_type = self.reference_type
-        if ref_type is not None:
-            result[ref_type] = self.reference.shorthand
-        return result
-
     @staticmethod
     def resolve(repo, refish):
         """
@@ -84,7 +77,7 @@ class CommitWithReference:
         which raises NO_COMMIT if no commit is found with that ID / at that branch / etc.
 
         Refish could be:
-        - a CommitWithReference or Commit object
+        - a pygit2 OID object
         - branch name
         - tag name
         - remote branch
@@ -93,11 +86,8 @@ class CommitWithReference:
         - 'refs/tags/1.2.3' some other refspec
         but not: branch ID or blob ID
         """
-        if isinstance(refish, CommitWithReference):
-            return refish
-        elif isinstance(refish, pygit2.Commit):
-            return CommitWithReference(refish)
-
+        if isinstance(refish, pygit2.Oid):
+            refish = refish.hex
         try:
             obj, reference = repo.resolve_refish(refish)
             commit = obj.peel(pygit2.Commit)

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -9,7 +9,7 @@ import pytest
 
 import pygit2
 
-from sno.commit import FALLBACK_EDITOR
+from sno.repo_files import fallback_editor
 from sno.structure import RepositoryStructure
 from sno.working_copy import WorkingCopy
 
@@ -232,7 +232,7 @@ def test_commit_message(
         assert r.exit_code == 0, r
         editmsg_path = f"{repo_dir}{os.sep}COMMIT_EDITMSG"
         assert re.match(
-            rf'{FALLBACK_EDITOR} "?{re.escape(editmsg_path)}"?$', editor_cmd
+            rf'{fallback_editor()} "?{re.escape(editmsg_path)}"?$', editor_cmd
         )
         assert editor_in == (
             "\n"


### PR DESCRIPTION
![](https://media1.giphy.com/media/10FNzgU8vsEdOg/giphy.gif)

Running "sno merge <other_branch> will merge other branch, unless there are conflicts.
In which case, it will put the repository into a merging state.
```
~/mysnorepo (BARE:mybranch) $ sno merge other
~/mysnorepo (BARE:mybranch|MERGING) $
```
Unfortunately, since conflicts cannot be resolved, the only option is to abandon the merging state.
```
~/mysnorepo (BARE:mybranch|MERGING) $ sno merge --abort
~/mysnorepo (BARE:mybranch) $
```
However, the merging state is real, and contains (most of?) the information we will need to make step-by-step resolution of conflicts possible. Resolving conflicts is to be done in a follow up PR.

Also still to be done is a way to display the merging state including conflicts / summary of conflicts. Running `sno status` and `sno show` right now doesn't mention that you are in merging state. This is to be done in a follow up PR.
Other commands may also have to be deactivated, since they make no sense in the context of a merge.

Some tidying:
- Added a new file sno/repo_files.py to make it easier to read and write files inside the bare repository. Modified commit.py to use this functionality.
- Changed the JSON output of merge.py to focus on commits, not commits + branches. Commits are what is actually merged, and the branch head may have moved on by the the merge is complete.

