### PR TITLE
In non-CI, skip benchmark tests by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,8 @@ ci-test:
 		-p no:sugar \
 		--cov-report term \
 		--cov-report html:test-results/coverage/ \
-		--junit-xml=test-results/junit.xml
+		--junit-xml=test-results/junit.xml \
+		--benchmark-enable
 
 # Cleanup
 

--- a/makefile.vc
+++ b/makefile.vc
@@ -66,7 +66,8 @@ ci-test:
 		-p no:sugar \
 		--cov-report term \
 		--cov-report html:test-results\coverage/ \
-		--junit-xml=test-results\junit.xml
+		--junit-xml=test-results\junit.xml \
+		--benchmark-enable
 
 # Packaging
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,8 @@ addopts = -ra
           --cov=sno
           --benchmark-max-time=5.0
           --pstats-dir=.pytest_profiles
+          # override this with --benchmark-enable if you want to run benchmarks
+          --benchmark-disable
 
 testpaths = tests
 norecursedirs = .* build dist CVS _darcs *.egg venv *.git data tests/data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 
 import pytest
+import click
 from click.testing import CliRunner
 
 import apsw
@@ -37,6 +38,15 @@ def pytest_addoption(parser):
         default=False,
         help="Allow calling pytest.set_trace() within Click commands",
     )
+
+
+def pytest_report_header(config):
+    if config._benchmarksession.disabled:
+        click.secho(
+            "\nSkipping benchmarks in tests. Use --benchmark-enable to run them.",
+            bold=True,
+            fg='yellow',
+        )
 
 
 # https://github.com/pytest-dev/pytest/issues/363


### PR DESCRIPTION
Use `--run-benchmarks` to run them.

This avoids multiple screens worth of output at the end of test runs (even in non-verbose mode), which can be annoying for debugging other tests.

All tests still run in CI.

This also adds a bold+yellow message at the start of test runs when it skips tests:
<img width="1160" alt="Screen Shot 2020-05-14 at 9 19 27 AM" src="https://user-images.githubusercontent.com/32112/81866946-12d06f80-95c4-11ea-9dbc-47f0fb21b15a.png">
