### PR TITLE
Add `sno conflicts` command to list conflicts.

### DIFF
--- a/sno/cli.py
+++ b/sno/cli.py
@@ -12,6 +12,7 @@ from . import (
     branch,
     checkout,
     clone,
+    conflicts,
     commit,
     diff,
     init,
@@ -110,6 +111,7 @@ cli.add_command(checkout.restore)
 cli.add_command(checkout.switch)
 cli.add_command(checkout.workingcopy_set_path)
 cli.add_command(clone.clone)
+cli.add_command(conflicts.conflicts)
 cli.add_command(commit.commit)
 cli.add_command(diff.diff)
 cli.add_command(fsck.fsck)

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -27,6 +27,8 @@ class RepositoryStructure:
     @staticmethod
     def lookup(repo, key):
         L.debug(f"key={key}")
+        if isinstance(key, pygit2.Oid):
+            key = key.hex
         try:
             obj = repo.revparse_single(key)
         except KeyError:


### PR DESCRIPTION
![](https://media2.giphy.com/media/xT5LMs2kDpcmKbHwGY/giphy.gif)

Mostly uses existing code in conflicts.py written for this purpose, that hadn't yet been turned into a command.
Updated tests to run this command instead of calling list_conflicts directly.
Other changes:
Made output_format and summarised-ness orthogonal to each other.
Made list_conflicts return a single string when the output format is text, instead of a json dict that contains text somewhere inside it.
Moved entering/leave merging state code from conflicts.py into merge.py