### PR TITLE
Update how merge_context is stored, and JSON output

### DIFF
--- a/sno/repo_files.py
+++ b/sno/repo_files.py
@@ -9,14 +9,16 @@ import subprocess
 from . import is_windows
 from .exceptions import SubprocessError
 
-
+# Standard git files:
 HEAD = "HEAD"
 COMMIT_EDITMSG = "COMMIT_EDITMSG"
 ORIG_HEAD = "ORIG_HEAD"
 MERGE_HEAD = "MERGE_HEAD"
 MERGE_MSG = "MERGE_MSG"
+
+# Sno-specific files:
 MERGE_INDEX = "MERGE_INDEX"
-MERGE_LABELS = "MERGE_LABELS"
+MERGE_BRANCH = "MERGE_BRANCH"
 
 
 def repo_file_path(repo, filename):
@@ -69,14 +71,16 @@ def user_edit_repo_file(repo, filename):
         ) from e
 
 
-def read_repo_file(repo, filename):
+def read_repo_file(repo, filename, missing_ok=False):
     path = repo_file_path(repo, filename)
+    if missing_ok and not path.exists():
+        return None
     return path.read_text(encoding="utf-8")
 
 
 def remove_repo_file(repo, filename, missing_ok=True):
     path = repo_file_path(repo, filename)
-    if not path.exists() and missing_ok:
+    if missing_ok and not path.exists():
         return  # TODO: use path.unlink(missing_ok=True) (python3.8)
     path.unlink()
 
@@ -92,8 +96,8 @@ def is_ongoing_merge(repo):
 
 
 def remove_all_merge_repo_files(repo):
-    """Deletes the following files (if they exist) - MERGE_HEAD, MERGE_MSG, MERGE_INDEX, MERGE_LABELS."""
+    """Deletes the following files (if they exist) - MERGE_HEAD, MERGE_BRANCH, MERGE_MSG, MERGE_INDEX"""
     remove_repo_file(repo, MERGE_HEAD)
+    remove_repo_file(repo, MERGE_BRANCH)
     remove_repo_file(repo, MERGE_MSG)
     remove_repo_file(repo, MERGE_INDEX)
-    remove_repo_file(repo, MERGE_LABELS)

--- a/sno/structs.py
+++ b/sno/structs.py
@@ -6,8 +6,8 @@ from .exceptions import NotFound, NO_COMMIT
 class CommitWithReference:
     """
     Simple struct containing a commit, and optionally the reference used to find the commit.
-    When struct is passed around in place of sole commit, then any code that uses the commit is able to give a better
-    human-readable name to describe it.
+    When struct is passed around in place of sole commit, then any code that uses the commit
+    is able to give a better human-readable name to describe it.
     Example:
     >>> cwr = CommitWithReference.resolve(repo, "master")
     >>> cwr.commit.id
@@ -39,6 +39,10 @@ class CommitWithReference:
         return self.commit.id
 
     @property
+    def short_id(self):
+        return self.commit.short_id
+
+    @property
     def tree(self):
         return self.commit.tree
 
@@ -46,7 +50,7 @@ class CommitWithReference:
     def shorthand(self):
         if self.reference is not None:
             return self.reference.shorthand
-        return self.id.hex
+        return self.commit.short_id
 
     @property
     def reference_type(self):
@@ -59,14 +63,8 @@ class CommitWithReference:
         return None
 
     @property
-    def shorthand_with_type(self):
-        if self.reference is not None:
-            ref_type = self.reference_type
-            if ref_type:
-                return f'{ref_type} "{self.reference.shorthand}"'
-            else:
-                return f'"{self.reference.shorthand}"'
-        return self.id.hex
+    def branch_shorthand(self):
+        return self.reference.shorthand if self.reference_type == "branch" else None
 
     @staticmethod
     def resolve(repo, refish):

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -92,7 +92,7 @@ def test_merge_fastforward_noff(
 
         H.git_graph(request, "post-merge")
 
-        merge_commit_id = json.loads(r.stdout)["sno.merge/v1"]["mergeCommit"]
+        merge_commit_id = json.loads(r.stdout)["sno.merge/v1"]["commit"]
 
         assert repo.head.name == "refs/heads/master"
         assert repo.head.target.hex == merge_commit_id
@@ -148,7 +148,7 @@ def test_merge_true(
         assert r.exit_code == 0, r
         H.git_graph(request, "post-merge")
 
-        merge_commit_id = json.loads(r.stdout)["sno.merge/v1"]["mergeCommit"]
+        merge_commit_id = json.loads(r.stdout)["sno.merge/v1"]["commit"]
 
         assert repo.head.name == "refs/heads/master"
         assert repo.head.target.hex == merge_commit_id


### PR DESCRIPTION
Got rid of MERGE_LABELS which used to contain some labels for ancestor, ours and theirs during a merge. Specifically it contained
```
(ANCESTOR_COMMIT_ID)
"OURS_BRANCH" (OURS_COMMIT_ID)
"THEIRS_BRANCH" (THEIRS_COMMIT_ID)
```
but that information is mostly redundant. There's no ancestor branch since its ambiguous / irrelevant what it is. Ancestor commit id can be inferred by knowing ours and theirs. Our commit ID can be learned from HEAD, as can our branch (if we have one). Their commit ID is stored in MERGE_HEAD. The only informating missing was their commit ID, which I have now stored in MERGE_BRANCH. So, less redundant information is being stored, and that information which is being stored is less free-form text, and more structured.

Also updated JSON output of merge command to be more similar to `sno status` json output - in a follow up PR, `sno status` will include merging JSON output if the repo is in merging state, so the two commands output should be structurally very similar - ie, both `sno status` and `sno merge` need to return what state you are in - what branch you are on, what commit you are at, and what is being merged, if anything.