### PR TITLE
Make `sno status` give info about ongoing merge

### DIFF
--- a/sno/merge_util.py
+++ b/sno/merge_util.py
@@ -5,7 +5,6 @@ import re
 import pygit2
 
 from .diff_output import text_row, json_row, geojson_row
-from .exceptions import InvalidOperation
 from .repo_files import (
     MERGE_HEAD,
     MERGE_INDEX,
@@ -491,7 +490,7 @@ class MergeContext:
         branches3 = AncestorOursTheirs(
             None,
             head.branch_shorthand,
-            read_repo_file(repo, MERGE_BRANCH, missing_ok=True),
+            read_repo_file(repo, MERGE_BRANCH, missing_ok=True, strip=True),
         )
 
         return cls._zip_together(repo, commit_ids3, short_ids3, branches3)

--- a/sno/repo_files.py
+++ b/sno/repo_files.py
@@ -71,11 +71,14 @@ def user_edit_repo_file(repo, filename):
         ) from e
 
 
-def read_repo_file(repo, filename, missing_ok=False):
+def read_repo_file(repo, filename, missing_ok=False, strip=False):
     path = repo_file_path(repo, filename)
     if missing_ok and not path.exists():
         return None
-    return path.read_text(encoding="utf-8")
+    result = path.read_text(encoding="utf-8")
+    if strip:
+        result = result.strip()
+    return result
 
 
 def remove_repo_file(repo, filename, missing_ok=True):

--- a/sno/status.py
+++ b/sno/status.py
@@ -4,8 +4,12 @@ import click
 import pygit2
 
 from .cli_util import do_json_option
+from .conflicts import list_conflicts
 from .output_util import dump_json_output
 from .structure import RepositoryStructure
+from .repo_files import RepoState
+from .merge import merge_status_to_text
+from .merge_util import MergeContext, MergeIndex
 
 
 @click.command()
@@ -13,18 +17,25 @@ from .structure import RepositoryStructure
 @do_json_option
 def status(ctx, do_json):
     """ Show the working copy status """
-    repo = ctx.obj.repo
-    jdict = get_status_json(repo)
+    repo = ctx.obj.get_repo(allowed_states=RepoState.ALL_STATES)
+    jdict = get_branch_status_json(repo)
+
+    if RepoState.get_state(repo) == RepoState.MERGING:
+        merge_index = MergeIndex.read_from_repo(repo)
+        merge_context = MergeContext.read_from_repo(repo)
+        jdict["merging"] = merge_context.as_json()
+        output_format = "json" if do_json else "text"
+        jdict["conflicts"] = list_conflicts(
+            merge_index, merge_context, output_format, summarise=2
+        )
+        jdict["state"] = "merging"
+    else:
+        jdict["workingCopy"] = get_working_copy_status_json(repo)
+
     if do_json:
-        dump_json_output(jdict, sys.stdout)
+        dump_json_output({"sno.status/v1": jdict}, sys.stdout)
     else:
         click.echo(status_to_text(jdict))
-
-
-def get_status_json(repo):
-    output = get_branch_status_json(repo)
-    output["workingCopy"] = get_working_copy_status_json(repo)
-    return {"sno.status/v1": output}
 
 
 def get_branch_status_json(repo):
@@ -93,14 +104,19 @@ def get_diff_status_json(wc_changes):
 
 
 def status_to_text(jdict):
-    branch_status = branch_status_to_text(jdict["sno.status/v1"])
-    wc_status = working_copy_status_to_text(jdict["sno.status/v1"]["workingCopy"])
+    branch_status = branch_status_to_text(jdict)
+    is_empty = not jdict["commit"]
+    is_merging = jdict.get("state", None) == RepoState.MERGING
 
-    is_empty = not jdict["sno.status/v1"]["commit"]
-    if is_empty:
-        return branch_status
+    if is_merging:
+        merge_status = merge_status_to_text(jdict, fresh=False)
+        return "\n\n".join([branch_status, merge_status])
 
-    return "\n\n".join([branch_status, wc_status])
+    if not is_empty:
+        wc_status = working_copy_status_to_text(jdict["workingCopy"])
+        return "\n\n".join([branch_status, wc_status])
+
+    return branch_status
 
 
 def branch_status_to_text(jdict):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -4,6 +4,8 @@ import subprocess
 import pytest
 
 from sno.exceptions import NO_REPOSITORY
+from sno.repo_files import RepoState
+from sno.structs import CommitWithReference
 
 
 H = pytest.helpers.helpers()
@@ -259,3 +261,62 @@ def test_status_none(tmp_path, cli_runner, chdir):
             r.stderr.splitlines()[-1]
             == "Error: Current directory is not an existing repository"
         )
+
+
+def test_status_merging(create_conflicts, cli_runner):
+    with create_conflicts(H.POINTS) as repo:
+        r = cli_runner.invoke(["merge", "theirs_branch"])
+        assert r.exit_code == 0, r
+
+        assert RepoState.get_state(repo) == RepoState.MERGING
+        assert text_status(cli_runner) == [
+            "On branch ours_branch",
+            "",
+            'Repository is in "merging" state.',
+            'Merging branch "theirs_branch" into ours_branch',
+            "Conflicts:",
+            "",
+            "nz_pa_points_topo_150k:",
+            "  Feature conflicts:",
+            "    add/add: 1",
+            "    edit/edit: 3",
+            "",
+            "",
+            "View conflicts with `sno conflicts` and resolve them with `sno resolve`.",
+            "Once no conflicts remain, complete this merge with `sno merge --continue`.",
+            "Or use `sno merge --abort` to return to the previous state.",
+        ]
+
+        ancestor = CommitWithReference.resolve(repo, "ancestor_branch")
+        ours = CommitWithReference.resolve(repo, "ours_branch")
+        theirs = CommitWithReference.resolve(repo, "theirs_branch")
+        assert json_status(cli_runner) == {
+            'sno.status/v1': {
+                "abbrevCommit": ours.short_id,
+                "commit": ours.id.hex,
+                "branch": "ours_branch",
+                "upstream": None,
+                "state": "merging",
+                "merging": {
+                    "ancestor": {
+                        "abbrevCommit": ancestor.short_id,
+                        "commit": ancestor.id.hex,
+                    },
+                    "ours": {
+                        "abbrevCommit": ours.short_id,
+                        "commit": ours.id.hex,
+                        "branch": "ours_branch",
+                    },
+                    "theirs": {
+                        "abbrevCommit": theirs.short_id,
+                        "commit": theirs.id.hex,
+                        "branch": "theirs_branch",
+                    },
+                },
+                "conflicts": {
+                    "nz_pa_points_topo_150k": {
+                        "featureConflicts": {"add/add": 1, "edit/edit": 3}
+                    }
+                },
+            }
+        }


### PR DESCRIPTION
![](https://media3.giphy.com/media/GIKxvhc3X48Ss/giphy.gif)

```
$ sno status
On branch ours_branch

Repository is in "merging" state.
Merging branch "theirs_branch" into ours_branch
Conflicts:

nz_pa_points_topo_150k:
  Feature conflicts:
    add/add: 1
    edit/edit: 3


View conflicts with `sno conflicts` and resolve them with `sno resolve`.
Once no conflicts remain, complete this merge with `sno merge --continue`.
Or use `sno merge --abort` to return to the previous state.
```

Also supports `--json` output.