### PR TITLE
Remove MergedOursTheirs struct

### DIFF
--- a/sno/resolve.py
+++ b/sno/resolve.py
@@ -1,7 +1,7 @@
 import click
 
 from .cli_util import MutexOption
-from .merge_util import MergedOursTheirs, MergeIndex, MergeContext, RichConflict
+from .merge_util import MergeIndex, MergeContext, RichConflict
 from .exceptions import InvalidOperation, NotFound, NO_CONFLICT
 from .repo_files import RepoState
 
@@ -61,11 +61,15 @@ def resolve(ctx, resolve_to_version, conflict_label):
                 )
 
             if resolve_to_version == "delete":
-                res = MergedOursTheirs.EMPTY
+                res = []
             else:
-                res = MergedOursTheirs.partial(
-                    merged=getattr(conflict3, resolve_to_version)
-                )
+                res = [getattr(conflict3, resolve_to_version)]
+                if res == [None]:
+                    click.echo(
+                        f'Version "{resolve_to_version}" does not exist - resolving conflict by deleting.'
+                    )
+                    res = []
+
             merge_index.add_resolve(key, res)
             merge_index.write_to_repo(repo)
             click.echo(

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from sno.merge_util import MergeIndex, MergedOursTheirs
+from sno.merge_util import MergeIndex
 from sno.structs import CommitWithReference
 
 H = pytest.helpers.helpers()
@@ -36,10 +36,10 @@ def test_merge_index_roundtrip(create_conflicts, cli_runner):
         items = list(r1.conflicts.items())
         key, conflict = items[0]
         # Resolve conflict 0 by accepting our version.
-        r1.add_resolve(key, MergedOursTheirs.partial(merged=conflict.ours))
+        r1.add_resolve(key, [conflict.ours])
         # Resolve conflict 1 by deleting it entirely.
         key, conflict = items[1]
-        r1.add_resolve(key, MergedOursTheirs.EMPTY)
+        r1.add_resolve(key, [])
         assert r1 != orig
         assert len(r1.entries) == 242
         assert len(r1.conflicts) == 4

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -3,7 +3,7 @@ import pytest
 
 from sno.diff_output import json_row
 from sno.exceptions import INVALID_OPERATION
-from sno.merge_util import MergedOursTheirs, MergeIndex
+from sno.merge_util import MergeIndex
 from sno.structure import RepositoryStructure
 
 H = pytest.helpers.helpers()
@@ -57,12 +57,12 @@ def test_resolve_conflicts(create_conflicts, cli_runner):
         assert len(merge_index.resolves) == 4
 
         ck0, ck1, ck2, ck3 = ck_order
-        assert merge_index.resolves[ck0].merged == merge_index.conflicts[ck0].ancestor
-        # But the ancestor is actually None in conflict ck0:
+        # Conflict ck0 is resolved to ancestor, but the ancestor is None.
+        assert merge_index.resolves[ck0] == []
         assert merge_index.conflicts[ck0].ancestor is None
-        assert merge_index.resolves[ck1].merged == merge_index.conflicts[ck1].ours
-        assert merge_index.resolves[ck2].merged == merge_index.conflicts[ck2].theirs
-        assert merge_index.resolves[ck3] == MergedOursTheirs.EMPTY
+        assert merge_index.resolves[ck1] == [merge_index.conflicts[ck1].ours]
+        assert merge_index.resolves[ck2] == [merge_index.conflicts[ck2].theirs]
+        assert merge_index.resolves[ck3] == []
 
         r = cli_runner.invoke(["merge", "--continue"])
 


### PR DESCRIPTION
Resolutions to conflicts were stored in a MergedOursTheirs struct - where up to 3 versions could be stored, most likely no version, a single merged version, or 2 versions: ours and theirs.

However, all versions are in the end treated exactly the same: all of them get added to the index when the merge is complete. Keeping track of which is which is unnecessary, and it makes resolutions more difficult - if the user provided two versions, we would require them to tell us which version they are, even though this information is not used.

Changed MergeIndex to simply store resolutions that contain N (zero or more) versions, removed MergedOursTheirs struct.