### PR TITLE
Support editing of merge commit messages

### DIFF
--- a/sno/diff.py
+++ b/sno/diff.py
@@ -335,8 +335,19 @@ class Diff:
 
         return True
 
-    def counts(self, dataset):
+    def dataset_counts(self, dataset=None):
+        """Returns a dict containing the count of each type of diff, for a particular dataset."""
         return {k: len(v) for k, v in self._data[dataset.path].items()}
+
+    def counts(self, dataset=None):
+        """
+        Returns multiple dataset_counts dicts, one for each dataset touched by this diff.
+        The dataset_counts dicts are returned in a top-level dict keyed by dataset path.
+        """
+
+        return {
+            dataset.path: self.dataset_counts(dataset) for dataset in self.datasets()
+        }
 
     def __repr__(self):
         return repr(self._data)
@@ -373,6 +384,15 @@ def get_dataset_diff(base_rs, target_rs, working_copy, dataset_path, pk_filter):
         diff += diff_wc
 
     return diff
+
+
+def get_repo_diff(base_rs, target_rs):
+    """Generates a Diff for every dataset in both RepositoryStructures."""
+    all_datasets = {ds.path for ds in base_rs} | {ds.path for ds in target_rs}
+    result = Diff(None)
+    for dataset in all_datasets:
+        result += get_dataset_diff(base_rs, target_rs, None, dataset, None)
+    return result
 
 
 def diff_with_writer(

--- a/sno/exceptions.py
+++ b/sno/exceptions.py
@@ -91,4 +91,4 @@ class SubprocessError(BaseException):
             message, exit_code=exit_code, param=param, param_hint=param_hint
         )
         if called_process_error and not exit_code:
-            self.exit_code = SUBPROCESS_ERROR_FLAG + called_process_error.return_code
+            self.exit_code = SUBPROCESS_ERROR_FLAG + called_process_error.returncode

--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -647,7 +647,8 @@ class WorkingCopy_GPKG_1(WorkingCopyGPKG):
 
     def diff_db_to_tree(self, dataset, pk_filter=None):
         """
-        Generates a diff between a working copy DB and the underlying repository tree
+        Generates a diff between a working copy DB and the underlying repository tree,
+        for a single dataset only.
 
         Pass a list of PK values to filter results to them
         """
@@ -731,6 +732,16 @@ class WorkingCopy_GPKG_1(WorkingCopyGPKG):
                 deletes=dict(itertools.chain(*candidates_del.values())),
                 updates=candidates_upd,
             )
+
+    def diff_to_tree(self, repo_structure):
+        """
+        Generates a diff between a working copy DB and the underlying repository tree,
+        for every dataset in the given repository structure.
+        """
+        result = diff.Diff(None)
+        for dataset in repo_structure:
+            result += self.diff_db_to_tree(dataset)
+        return result
 
     def commit_callback(self, dataset, action, **kwargs):
         with self.session() as db:
@@ -1004,7 +1015,3 @@ class WorkingCopy_GPKG_1(WorkingCopyGPKG):
                     f"UPDATE {self.META_TABLE} SET value=? WHERE table_name='*' AND key='tree';",
                     (target_tree.hex,),
                 )
-
-    def status(self, dataset):
-        diff = self.diff_db_to_tree(dataset)
-        return diff.counts(dataset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -731,3 +731,12 @@ def create_conflicts(data_working_copy, geopackage, cli_runner, update, insert):
             yield repo
 
     return ctx
+
+
+@pytest.fixture
+def disable_editor():
+    old_environ = dict(os.environ)
+    os.environ["GIT_EDITOR"] = "echo"
+    yield
+    os.environ.clear()
+    os.environ.update(old_environ)

--- a/tests/scripts/e2e-1.ps1
+++ b/tests/scripts/e2e-1.ps1
@@ -75,7 +75,7 @@ try {
     Exec { sno commit -m 'my-commit' }
     Exec { sno switch 'master' }
     Exec { sno status }
-    Exec { sno merge 'edit-1' --no-ff }
+    Exec { sno merge 'edit-1' --no-ff -m 'my-merge'}
     Exec { sno log }
 }
 catch {

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -50,7 +50,7 @@ sno diff
 sno commit -m my-commit
 sno switch master
 sno status
-sno merge edit-1 --no-ff
+sno merge edit-1 --no-ff -m merge-1
 sno log
 
 { echo -e "\n✅ E2E: Success"; } 2>/dev/null

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -105,7 +105,7 @@ def test_e2e(
             assert r.stdout.splitlines()[0] == "On branch master"
 
             # merge it
-            r = cli_runner.invoke(["merge", "edit-1", "--no-ff"])
+            r = cli_runner.invoke(["merge", "edit-1", "--no-ff", "-m", "merge-1"])
             assert r.exit_code == 0
             assert "Fast-forward" not in r.stdout
             sha_merge1 = r.stdout.splitlines()[-1].split(" ")[-1]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -72,7 +72,7 @@ def test_merge_fastforward(
     ],
 )
 def test_merge_fastforward_noff(
-    archive, data_working_copy, geopackage, cli_runner, insert, request
+    archive, data_working_copy, geopackage, cli_runner, insert, request, disable_editor
 ):
     with data_working_copy(archive) as (repo_path, wc):
         repo = pygit2.Repository(str(repo_path))
@@ -122,7 +122,15 @@ def test_merge_fastforward_noff(
     ],
 )
 def test_merge_true(
-    archive, layer, pk_field, data_working_copy, geopackage, cli_runner, insert, request
+    archive,
+    layer,
+    pk_field,
+    data_working_copy,
+    geopackage,
+    cli_runner,
+    insert,
+    request,
+    disable_editor,
 ):
     with data_working_copy(archive) as (repo_path, wc):
         repo = pygit2.Repository(str(repo_path))

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -34,7 +34,7 @@ def get_json_feature(rs, layer, pk):
         return None
 
 
-def test_resolve_with_version(create_conflicts, cli_runner):
+def test_resolve_with_version(create_conflicts, cli_runner, disable_editor):
     with create_conflicts(H.POLYGONS) as repo:
         r = cli_runner.invoke(["merge", "theirs_branch", "--json"])
         assert r.exit_code == 0, r
@@ -105,7 +105,7 @@ def test_resolve_with_version(create_conflicts, cli_runner):
         assert get_json_feature(merged, l, pk3) is None
 
 
-def test_resolve_with_file(create_conflicts, cli_runner):
+def test_resolve_with_file(create_conflicts, cli_runner, disable_editor):
     with create_conflicts(H.POLYGONS) as repo:
         r = cli_runner.invoke(["diff", "ancestor_branch..ours_branch", "--geojson"])
         assert r.exit_code == 0, r

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -32,7 +32,14 @@ def get_commit_ids(jdict):
 
 
 def test_status(
-    data_archive, data_working_copy, geopackage, cli_runner, insert, tmp_path, request
+    data_archive,
+    data_working_copy,
+    geopackage,
+    cli_runner,
+    insert,
+    tmp_path,
+    request,
+    disable_editor,
 ):
     with data_working_copy("points") as (path1, wc):
         assert text_status(cli_runner) == [


### PR DESCRIPTION
Commit messages can be edited, but not during a merge.
Now they can be edited during a merge as well!
A little more complex because, during a merge, the commit message is stored throughout the entire merge in a file called MERGE_MSG.