### PR TITLE
Better mutually exclusive options

### DIFF
--- a/sno/conflicts.py
+++ b/sno/conflicts.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 
-from .cli_util import MutexOption
+from .cli_util import MutexOption, one_of
 from .exceptions import SUCCESS, SUCCESS_WITH_FLAG
 from .merge_util import MergeIndex, MergeContext, rich_conflicts
 from .output_util import dump_json_output
@@ -175,39 +175,22 @@ def conflicts_json_as_text(json_obj):
 
 @click.command()
 @click.pass_context
-@click.option(
-    "--text",
-    "output_format",
-    flag_value="text",
-    default=True,
-    help="Get the diff in text format",
-    cls=MutexOption,
-    exclusive_with=["json", "geojson", "quiet"],
-)
-@click.option(
-    "--json",
-    "output_format",
-    flag_value="json",
-    help="Get the diff in JSON format",
-    hidden=True,
-    cls=MutexOption,
-    exclusive_with=["text", "geojson", "quiet"],
-)
-@click.option(
-    "--geojson",
-    "output_format",
-    flag_value="geojson",
-    help="Get the diff in GeoJSON format",
-    cls=MutexOption,
-    exclusive_with=["text", "json", "quiet"],
-)
-@click.option(
-    "--quiet",
-    "output_format",
-    flag_value="quiet",
-    help="Disable all output of the program. Implies --exit-code.",
-    cls=MutexOption,
-    exclusive_with=["json", "text", "geojson", "html"],
+@one_of(
+    click.option(
+        "--text", flag_value="text", default=True, help="Get the diff in text format",
+    ),
+    click.option(
+        "--json", flag_value="json", help="Get the diff in JSON format", hidden=True,
+    ),
+    click.option(
+        "--geojson", flag_value="geojson", help="Get the diff in GeoJSON format",
+    ),
+    click.option(
+        "--quiet",
+        flag_value="quiet",
+        help="Disable all output of the program. Implies --exit-code.",
+    ),
+    name="output_format",
 )
 @click.option(
     "--exit-code",

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import click
 
-from .cli_util import MutexOption
+from .cli_util import MutexOption, one_of
 from .diff_output import *  # noqa - used from globals()
 from .exceptions import (
     InvalidOperation,
@@ -507,48 +507,25 @@ def diff_with_writer(
 
 @click.command()
 @click.pass_context
-@click.option(
-    "--text",
-    "output_format",
-    flag_value="text",
-    default=True,
-    help="Get the diff in text format",
-    cls=MutexOption,
-    exclusive_with=["html", "json", "geojson", "quiet"],
-)
-@click.option(
-    "--json",
-    "output_format",
-    flag_value="json",
-    help="Get the diff in JSON format",
-    hidden=True,
-    cls=MutexOption,
-    exclusive_with=["html", "text", "geojson", "quiet"],
-)
-@click.option(
-    "--geojson",
-    "output_format",
-    flag_value="geojson",
-    help="Get the diff in GeoJSON format",
-    cls=MutexOption,
-    exclusive_with=["html", "text", "json", "quiet"],
-)
-@click.option(
-    "--html",
-    "output_format",
-    flag_value="html",
-    help="View the diff in a browser",
-    hidden=True,
-    cls=MutexOption,
-    exclusive_with=["json", "text", "geojson", "quiet"],
-)
-@click.option(
-    "--quiet",
-    "output_format",
-    flag_value="quiet",
-    help="Disable all output of the program. Implies --exit-code.",
-    cls=MutexOption,
-    exclusive_with=["json", "text", "geojson", "html"],
+@one_of(
+    click.option(
+        "--text", flag_value="text", default=True, help="Get the diff in text format",
+    ),
+    click.option(
+        "--json", flag_value="json", help="Get the diff in JSON format", hidden=True,
+    ),
+    click.option(
+        "--geojson", flag_value="geojson", help="Get the diff in GeoJSON format",
+    ),
+    click.option(
+        "--html", flag_value="html", help="View the diff in a browser", hidden=True,
+    ),
+    click.option(
+        "--quiet",
+        flag_value="quiet",
+        help="Disable all output of the program. Implies --exit-code.",
+    ),
+    name="output_format",
 )
 @click.option(
     "--exit-code",

--- a/sno/show.py
+++ b/sno/show.py
@@ -5,7 +5,7 @@ from io import StringIO
 
 import click
 
-from .cli_util import MutexOption
+from .cli_util import MutexOption, one_of
 from .output_util import dump_json_output, resolve_output_path
 from .structs import CommitWithReference
 from .timestamps import datetime_to_iso8601_utc, timedelta_to_iso8601_tz
@@ -17,24 +17,18 @@ EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 @click.command()
 @click.pass_context
-@click.option(
-    "--text",
-    "output_format",
-    flag_value="text",
-    default=True,
-    help="Show commit in text format",
-    cls=MutexOption,
-    exclusive_with=["json"],
-)
-@click.option(
-    "--json",
-    "--patch",
-    "-p",
-    "output_format",
-    flag_value="json",
-    help="Show commit in JSON patch format",
-    cls=MutexOption,
-    exclusive_with=["text"],
+@one_of(
+    click.option(
+        "--text", flag_value="text", default=True, help="Show commit in text format",
+    ),
+    click.option(
+        "--json",
+        "--patch",
+        "-p",
+        flag_value="json",
+        help="Show commit in JSON patch format",
+    ),
+    name="output_format",
 )
 @click.option(
     "--json-style",


### PR DESCRIPTION
Fixes #99.

The existing MutexOption class only works where the options are given
different names. For most of the cases we're using it, that isn't the
case - the options all have the name `output_format`. By the time the
`MutexOption.handle_parse_result` is called, the options have been
collapsed into one (`{"output_format": "json"}`) which is the last
option to have been specified on the command line.

This change adds a way of handling the options together via a grouping
decorator. The options are parsed individually, but then checked for
mutual exclusion and only one value passed to the command function.