### PR TITLE
--output-format=json instead of --json

### DIFF
--- a/sno/apply.py
+++ b/sno/apply.py
@@ -145,6 +145,6 @@ def apply_patch(*, repo, commit, patch_file, allow_empty, **kwargs):
 @click.argument("patch_file", type=click.File('r', encoding="utf-8"))
 def apply(ctx, **kwargs):
     """
-    Applies and commits the given JSON patch (as created by `sno show --json`)
+    Applies and commits the given JSON patch (as created by `sno show -o json`)
     """
     apply_patch(repo=ctx.obj.repo, **kwargs)

--- a/sno/branch.py
+++ b/sno/branch.py
@@ -3,7 +3,6 @@ import sys
 import click
 import pygit2
 
-from .cli_util import do_json_option
 from .exceptions import InvalidOperation
 from .exec import execvp
 from .output_util import dump_json_output
@@ -11,19 +10,21 @@ from .output_util import dump_json_output
 
 @click.command(context_settings=dict(ignore_unknown_options=True))
 @click.pass_context
-@do_json_option
+@click.option(
+    "--output-format", "-o", type=click.Choice(["text", "json"]), default="text",
+)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
-def branch(ctx, do_json, args):
+def branch(ctx, output_format, args):
     """ List, create, or delete branches """
     repo = ctx.obj.repo
 
     sargs = set(args)
-    if do_json:
-        valid_args = {"--list"}  # "sno branch --json" or "sno branch --list --json"
+    if output_format == 'json':
+        valid_args = {"--list"}  # "sno branch -o json" or "sno branch --list -o json"
         invalid_args = sargs - valid_args
         if invalid_args:
             raise click.UsageError(
-                "Illegal usage: 'sno branch --json' only supports listing branches."
+                "Illegal usage: 'sno branch --output-format=json' only supports listing branches."
             )
         dump_json_output(list_branches_json(repo), sys.stdout)
         return

--- a/sno/cli_util.py
+++ b/sno/cli_util.py
@@ -44,17 +44,6 @@ class MutexOption(click.Option):
         return super().handle_parse_result(ctx, opts, args)
 
 
-def do_json_option(func):
-    """Apply --json/--text output format options to a Click command """
-    return click.option(
-        "--json/--text",
-        "do_json",
-        is_flag=True,
-        default=False,
-        help="Whether to format the out output as JSON instead the default text output.",
-    )(func)
-
-
 def call_and_exit_flag(*args, callback, **kwargs):
     """
     Add an is_flag option that, when set, eagerly calls the given callback with only the context as a parameter.

--- a/sno/commit.py
+++ b/sno/commit.py
@@ -30,7 +30,7 @@ from .timestamps import (
 )
 from .working_copy import WorkingCopy
 from .structure import RepositoryStructure
-from .cli_util import MutexOption, do_json_option
+from .cli_util import MutexOption
 
 
 @click.command()
@@ -62,8 +62,10 @@ from .cli_util import MutexOption, do_json_option
         "such a commit. This option bypasses the safety"
     ),
 )
-@do_json_option
-def commit(ctx, message, message_file, allow_empty, do_json):
+@click.option(
+    "--output-format", "-o", type=click.Choice(["text", "json"]), default="text",
+)
+def commit(ctx, message, message_file, allow_empty, output_format):
     """ Record changes to the repository """
     repo = ctx.obj.repo
 
@@ -90,6 +92,7 @@ def commit(ctx, message, message_file, allow_empty, do_json):
     if not wc_diff and not allow_empty:
         raise NotFound("No changes to commit", exit_code=NO_CHANGES)
 
+    do_json = output_format == "json"
     if message_file:
         commit_msg = message_file.read().strip()
     elif message:

--- a/sno/conflicts.py
+++ b/sno/conflicts.py
@@ -3,7 +3,6 @@ import sys
 
 import click
 
-from .cli_util import MutexOption
 from .exceptions import SUCCESS, SUCCESS_WITH_FLAG
 from .merge_util import MergeIndex, MergeContext, rich_conflicts
 from .output_util import dump_json_output
@@ -176,38 +175,11 @@ def conflicts_json_as_text(json_obj):
 @click.command()
 @click.pass_context
 @click.option(
-    "--text",
-    "output_format",
-    flag_value="text",
-    default=True,
-    help="Get the diff in text format",
-    cls=MutexOption,
-    exclusive_with=["json", "geojson", "quiet"],
-)
-@click.option(
-    "--json",
-    "output_format",
-    flag_value="json",
-    help="Get the diff in JSON format",
-    hidden=True,
-    cls=MutexOption,
-    exclusive_with=["text", "geojson", "quiet"],
-)
-@click.option(
-    "--geojson",
-    "output_format",
-    flag_value="geojson",
-    help="Get the diff in GeoJSON format",
-    cls=MutexOption,
-    exclusive_with=["text", "json", "quiet"],
-)
-@click.option(
-    "--quiet",
-    "output_format",
-    flag_value="quiet",
-    help="Disable all output of the program. Implies --exit-code.",
-    cls=MutexOption,
-    exclusive_with=["json", "text", "geojson", "html"],
+    "--output-format",
+    "-o",
+    type=click.Choice(["text", "json", "geojson", "quiet"]),
+    default="text",
+    help="Output format. 'quiet' disables all output and implies --exit-code.",
 )
 @click.option(
     "--exit-code",
@@ -218,9 +190,7 @@ def conflicts_json_as_text(json_obj):
     "--json-style",
     type=click.Choice(["extracompact", "compact", "pretty"]),
     default="pretty",
-    help="How to format the output. Only used with --json or --geojson",
-    cls=MutexOption,
-    exclusive_with=["text", "quiet"],
+    help="How to format the output. Only used with `-o json` and `-o geojson`",
 )
 @click.option(
     "--exit-code",

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import click
 
-from .cli_util import MutexOption
 from .diff_output import *  # noqa - used from globals()
 from .exceptions import (
     InvalidOperation,
@@ -528,47 +527,14 @@ def diff_with_writer(
 @click.command()
 @click.pass_context
 @click.option(
-    "--text",
-    "output_format",
-    flag_value="text",
-    default=True,
-    help="Get the diff in text format",
-    cls=MutexOption,
-    exclusive_with=["html", "json", "geojson", "quiet"],
-)
-@click.option(
-    "--json",
-    "output_format",
-    flag_value="json",
-    help="Get the diff in JSON format",
-    hidden=True,
-    cls=MutexOption,
-    exclusive_with=["html", "text", "geojson", "quiet"],
-)
-@click.option(
-    "--geojson",
-    "output_format",
-    flag_value="geojson",
-    help="Get the diff in GeoJSON format",
-    cls=MutexOption,
-    exclusive_with=["html", "text", "json", "quiet"],
-)
-@click.option(
-    "--html",
-    "output_format",
-    flag_value="html",
-    help="View the diff in a browser",
-    hidden=True,
-    cls=MutexOption,
-    exclusive_with=["json", "text", "geojson", "quiet"],
-)
-@click.option(
-    "--quiet",
-    "output_format",
-    flag_value="quiet",
-    help="Disable all output of the program. Implies --exit-code.",
-    cls=MutexOption,
-    exclusive_with=["json", "text", "geojson", "html"],
+    "--output-format",
+    "-o",
+    type=click.Choice(["text", "json", "geojson", "quiet", "html"]),
+    default="text",
+    help=(
+        "Output format. 'quiet' disables all output and implies --exit-code.\n"
+        "'html' attempts to open a browser unless writing to stdout ( --output=- )"
+    ),
 )
 @click.option(
     "--exit-code",
@@ -585,9 +551,7 @@ def diff_with_writer(
     "--json-style",
     type=click.Choice(["extracompact", "compact", "pretty"]),
     default="pretty",
-    help="How to format the output. Only used with --json or --geojson",
-    cls=MutexOption,
-    exclusive_with=["html", "text", "quiet"],
+    help="How to format the output. Only used with -o json or -o geojson",
 )
 @click.argument("args", nargs=-1)
 def diff(ctx, output_format, output_path, exit_code, json_style, args):

--- a/sno/diff_output.py
+++ b/sno/diff_output.py
@@ -244,7 +244,8 @@ def diff_output_json(*, output_path, dataset_count, json_style="pretty", **kwarg
     if isinstance(output_path, Path):
         if output_path.is_dir():
             raise click.BadParameter(
-                "Directory is not valid for --output with --json", param_hint="--output"
+                "Directory is not valid for --output with --output-format=json",
+                param_hint="--output",
             )
 
     accumulated = {}

--- a/sno/init.py
+++ b/sno/init.py
@@ -12,7 +12,7 @@ from osgeo import gdal, ogr
 from sno import is_windows
 from . import gpkg, checkout, structure
 from .core import check_git_user
-from .cli_util import call_and_exit_flag, do_json_option
+from .cli_util import call_and_exit_flag
 from .exceptions import (
     InvalidOperation,
     NotFound,
@@ -552,8 +552,12 @@ def list_import_formats(ctx):
     callback=list_import_formats,
     help="List available import formats, and then exit",
 )
-@do_json_option
-def import_table(ctx, source, directory, table, message, do_list, do_json, version):
+@click.option(
+    "--output-format", "-o", type=click.Choice(["text", "json"]), default="text",
+)
+def import_table(
+    ctx, source, directory, table, message, do_list, output_format, version
+):
     """
     Import data into a repository.
 
@@ -566,9 +570,9 @@ def import_table(ctx, source, directory, table, message, do_list, do_json, versi
     $ sno import --list GPKG:my.gpkg
     """
 
-    if do_json and not do_list:
+    if output_format == 'json' and not do_list:
         raise click.UsageError(
-            "Illegal usage: 'sno import --json' only supports --list"
+            "Illegal usage: '--output-format=json' only supports --list"
         )
 
     use_repo_ctx = not do_list
@@ -580,7 +584,7 @@ def import_table(ctx, source, directory, table, message, do_list, do_json, versi
     source_loader = OgrImporter.open(source, table)
 
     if do_list:
-        source_loader.print_table_list(do_json=do_json)
+        source_loader.print_table_list(do_json=output_format == 'json')
         return
 
     source_loader.check_table(prompt=True)

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -4,7 +4,7 @@ import sys
 import click
 
 from . import commit
-from .cli_util import do_json_option, call_and_exit_flag
+from .cli_util import call_and_exit_flag
 from .conflicts import (
     list_conflicts,
     conflicts_json_as_text,
@@ -337,6 +337,9 @@ def merge_status_to_text(jdict, fresh):
 @click.option(
     "--message", "-m", help="Use the given message as the commit message.",
 )
+@click.option(
+    "--output-format", "-o", type=click.Choice(["text", "json"]), default="text",
+)
 @call_and_exit_flag(
     '--abort',
     callback=abort_merging_state,
@@ -348,15 +351,16 @@ def merge_status_to_text(jdict, fresh):
     help="Completes and commits a merge once all conflicts are resolved and leaves the merging state",
 )
 @click.argument("commit", required=True, metavar="COMMIT")
-@do_json_option
 @click.pass_context
-def merge(ctx, ff, ff_only, dry_run, message, do_json, commit):
+def merge(ctx, ff, ff_only, dry_run, message, output_format, commit):
     """ Incorporates changes from the named commits (usually other branch heads) into the current branch. """
 
     repo = ctx.obj.get_repo(
         allowed_states=[RepoState.NORMAL],
         bad_state_message="A merge is already ongoing - see `sno merge --abort` or `sno merge --continue`",
     )
+
+    do_json = output_format == 'json'
 
     jdict = do_merge(repo, ff, ff_only, dry_run, commit, message, quiet=do_json)
     no_op = jdict.get("noOp", False) or jdict.get("dryRun", False)

--- a/sno/show.py
+++ b/sno/show.py
@@ -5,7 +5,6 @@ from io import StringIO
 
 import click
 
-from .cli_util import MutexOption
 from .output_util import dump_json_output, resolve_output_path
 from .structs import CommitWithReference
 from .timestamps import datetime_to_iso8601_utc, timedelta_to_iso8601_tz
@@ -18,37 +17,26 @@ EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 @click.command()
 @click.pass_context
 @click.option(
-    "--text",
-    "output_format",
-    flag_value="text",
-    default=True,
-    help="Show commit in text format",
-    cls=MutexOption,
-    exclusive_with=["json"],
-)
-@click.option(
-    "--json",
-    "--patch",
-    "-p",
-    "output_format",
-    flag_value="json",
-    help="Show commit in JSON patch format",
-    cls=MutexOption,
-    exclusive_with=["text"],
+    "--output-format",
+    "-o",
+    type=click.Choice(["text", "json", "patch"]),
+    default="text",
+    help="Output format. 'patch' is a synonym for 'json'",
 )
 @click.option(
     "--json-style",
     type=click.Choice(["extracompact", "compact", "pretty"]),
     default="pretty",
-    help="How to format the output. Only used with --json",
-    cls=MutexOption,
-    exclusive_with=["text"],
+    help="How to format the output. Only used with --output-format=json",
 )
 @click.argument("refish", default='HEAD', required=False)
 def show(ctx, *, refish, output_format, json_style, **kwargs):
     """
     Show the given commit, or HEAD
     """
+    if output_format == 'patch':
+        output_format = 'json'
+
     repo = ctx.obj.repo
     # Ensures we were given a reference to a commit, and not a tree or something
     commit = CommitWithReference.resolve(repo, refish).commit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -658,7 +658,9 @@ def insert(request, cli_runner):
         func.index += 1
 
         if commit:
-            r = cli_runner.invoke(["commit", "-m", f"commit-{func.index}", "--json"])
+            r = cli_runner.invoke(
+                ["commit", "-m", f"commit-{func.index}", "-o", "json"]
+            )
             assert r.exit_code == 0, r
 
             commit_id = json.loads(r.stdout)["sno.commit/v1"]["commit"]
@@ -688,7 +690,7 @@ def update(request, cli_runner):
             assert db.changes() == 1
 
         if commit:
-            r = cli_runner.invoke(["commit", "-m", f"commit-update-{pk}", "--json"])
+            r = cli_runner.invoke(["commit", "-m", f"commit-update-{pk}", "-o", "json"])
             assert r.exit_code == 0, r
 
             commit_id = json.loads(r.stdout)["sno.commit/v1"]["commit"]

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -27,7 +27,11 @@ def test_apply_empty_patch(data_archive_readonly, cli_runner):
 
 def test_apply_with_wrong_dataset_name(data_archive, cli_runner):
     patch_data = json.dumps(
-        {'sno.diff/v1+hexwkb': {'wrong-name': {'featureChanges': [], 'metaChanges': [],}}}
+        {
+            'sno.diff/v1+hexwkb': {
+                'wrong-name': {'featureChanges': [], 'metaChanges': [],}
+            }
+        }
     )
     with data_archive("points"):
         r = cli_runner.invoke(["apply", '-'], input=patch_data)
@@ -85,8 +89,8 @@ def test_apply_with_no_working_copy(data_archive, cli_runner):
         bits = r.stdout.split()
         assert bits[0] == 'Commit'
 
-        # Check that the `sno show --json` output is the same as our original patch file had.
-        r = cli_runner.invoke(['show', '--json'])
+        # Check that the `sno show -o json` output is the same as our original patch file had.
+        r = cli_runner.invoke(['show', '-o', 'json'])
         assert r.exit_code == 0
         patch = json.loads(r.stdout)
         original_patch = json.load(patch_path.open('r', encoding='utf-8'))
@@ -134,8 +138,8 @@ def test_apply_with_working_copy(
             names = dict(cur.fetchall())
             assert names == workingcopy_verify_names
 
-        # Check that the `sno show --json` output is the same as our original patch file had.
-        r = cli_runner.invoke(['show', '--json'])
+        # Check that the `sno show -o json` output is the same as our original patch file had.
+        r = cli_runner.invoke(['show', '-o', 'json'])
         assert r.exit_code == 0
         patch = json.loads(r.stdout)
         original_patch = json.load(patch_path.open('r', encoding='utf-8'))
@@ -173,7 +177,7 @@ def test_apply_with_working_copy_with_no_commit(
         assert bits[0] == 'Updating'
 
         # Check that the working copy diff is the same as the original patch file
-        r = cli_runner.invoke(['diff', '--json'])
+        r = cli_runner.invoke(['diff', '-o', 'json'])
         assert r.exit_code == 0
         patch = json.loads(r.stdout)
         original_patch = json.load(patch_path.open('r', encoding='utf-8'))
@@ -183,7 +187,7 @@ def test_apply_with_working_copy_with_no_commit(
 
 def test_apply_multiple_dataset_patch_roundtrip(data_archive, cli_runner):
     with data_archive("au-census"):
-        r = cli_runner.invoke(["show", "--json", "master"])
+        r = cli_runner.invoke(["show", "-o", "json", "master"])
         assert r.exit_code == 0, r
         patch_text = r.stdout
         patch_json = json.loads(patch_text)
@@ -197,7 +201,7 @@ def test_apply_multiple_dataset_patch_roundtrip(data_archive, cli_runner):
         r = cli_runner.invoke(["apply", "-"], input=patch_text)
         assert r.exit_code == 0, r
 
-        r = cli_runner.invoke(["show", "--json"])
+        r = cli_runner.invoke(["show", "-o", "json"])
         assert r.exit_code == 0, r
         new_patch_json = json.loads(r.stdout)
 
@@ -225,7 +229,7 @@ def test_apply_benchmark(
         assert r.exit_code == 0, r
 
         # Make it into a patch
-        r = cli_runner.invoke(["show", "--json"])
+        r = cli_runner.invoke(["show", "-o", "json"])
         assert r.exit_code == 0, r
         patch_text = r.stdout
         patch_json = json.loads(patch_text)

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -16,7 +16,7 @@ def text_branches(cli_runner):
 
 
 def json_branches(cli_runner):
-    r = cli_runner.invoke(["branch", "--json"])
+    r = cli_runner.invoke(["branch", "-o", "json"])
     assert r.exit_code == 0, r
     return json.loads(r.stdout)
 
@@ -154,7 +154,7 @@ def test_branches_none(tmp_path, cli_runner, chdir):
             == "Error: Current directory is not an existing repository"
         )
 
-        r = cli_runner.invoke(["branch", "--json"])
+        r = cli_runner.invoke(["branch", "-o", "json"])
         assert r.exit_code == NO_REPOSITORY, r
         assert (
             r.stderr.splitlines()[-1]

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -96,7 +96,7 @@ def test_commit(archive, layer, data_working_copy, geopackage, cli_runner, reque
 
         print(f"deleted fid={pk_del}")
 
-        r = cli_runner.invoke(["commit", "-m", "test-commit-1", "--json"])
+        r = cli_runner.invoke(["commit", "-m", "test-commit-1", "-o", "json"])
         assert r.exit_code == 0, r
         commit_id = json.loads(r.stdout)["sno.commit/v1"]["commit"]
         print("commit:", commit_id)

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -83,7 +83,7 @@ def test_summarise_conflicts(create_conflicts, cli_runner):
             '',
         ]
 
-        r = cli_runner.invoke(["conflicts", "-s", "--json"])
+        r = cli_runner.invoke(["conflicts", "-s", "-o", "json"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
             "sno.conflicts/v1": {
@@ -100,7 +100,7 @@ def test_summarise_conflicts(create_conflicts, cli_runner):
             }
         }
 
-        r = cli_runner.invoke(["conflicts", "-s", "--flat", "--json"])
+        r = cli_runner.invoke(["conflicts", "-s", "--flat", "-o", "json"])
         assert json.loads(r.stdout) == {
             "sno.conflicts/v1": [
                 "nz_waca_adjustments:id=98001",
@@ -125,7 +125,7 @@ def test_summarise_conflicts(create_conflicts, cli_runner):
         assert r.exit_code == 0, r
         assert r.stdout.strip() == "4"
 
-        r = cli_runner.invoke(["conflicts", "-ss", "--json"])
+        r = cli_runner.invoke(["conflicts", "-ss", "-o", "json"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
             "sno.conflicts/v1": {
@@ -135,7 +135,7 @@ def test_summarise_conflicts(create_conflicts, cli_runner):
             },
         }
 
-        r = cli_runner.invoke(["conflicts", "-ss", "--flat", "--json"])
+        r = cli_runner.invoke(["conflicts", "-ss", "--flat", "-o", "json"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {"sno.conflicts/v1": 4}
 
@@ -180,7 +180,7 @@ def test_list_conflicts(create_conflicts, cli_runner):
             '',
         ]
 
-        r = cli_runner.invoke(["conflicts", "--json"])
+        r = cli_runner.invoke(["conflicts", "-o", "json"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
             "sno.conflicts/v1": {
@@ -228,7 +228,7 @@ def test_list_conflicts(create_conflicts, cli_runner):
             }
         }
 
-        r = cli_runner.invoke(["conflicts", "--geojson"])
+        r = cli_runner.invoke(["conflicts", "-o", "geojson"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
             "sno.conflicts/v1": {

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -34,7 +34,7 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
     with data_working_copy("points") as (repo, wc):
         # empty
         r = cli_runner.invoke(
-            ["diff", f"--{output_format}", "--output=-", "--exit-code"]
+            ["diff", f"--output-format={output_format}", "--output=-", "--exit-code"]
         )
         assert r.exit_code == 0, r
 
@@ -54,7 +54,9 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
             cur.execute(f"DELETE FROM {H.POINTS.LAYER} WHERE fid=3;")
             assert db.changes() == 1
 
-        r = cli_runner.invoke(["diff", f"--{output_format}", "--output=-"])
+        r = cli_runner.invoke(
+            ["diff", f"--output-format={output_format}", "--output=-"]
+        )
         print("STDOUT", repr(r.stdout))
         if output_format == "quiet":
             assert r.exit_code == 1, r
@@ -298,7 +300,7 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
     with data_working_copy("polygons") as (repo, wc):
         # empty
         r = cli_runner.invoke(
-            ["diff", f"--{output_format}", "--output=-", "--exit-code"]
+            ["diff", f"--output-format={output_format}", "--output=-", "--exit-code"]
         )
         assert r.exit_code == 0, r
 
@@ -318,7 +320,9 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
             cur.execute(f"DELETE FROM {H.POLYGONS.LAYER} WHERE id=1452332;")
             assert db.changes() == 1
 
-        r = cli_runner.invoke(["diff", f"--{output_format}", "--output=-"])
+        r = cli_runner.invoke(
+            ["diff", f"--output-format={output_format}", "--output=-"]
+        )
         if output_format == "quiet":
             assert r.exit_code == 1, r
             assert r.stdout == ""
@@ -648,7 +652,7 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
     with data_working_copy("table") as (repo, wc):
         # empty
         r = cli_runner.invoke(
-            ["diff", f"--{output_format}", "--output=-", "--exit-code"]
+            ["diff", f"--output-format={output_format}", "--output=-", "--exit-code"]
         )
         assert r.exit_code == 0, r
 
@@ -668,7 +672,9 @@ def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
             cur.execute(f'DELETE FROM {H.TABLE.LAYER} WHERE "OBJECTID"=3;')
             assert db.changes() == 1
 
-        r = cli_runner.invoke(["diff", f"--{output_format}", "--output=-"])
+        r = cli_runner.invoke(
+            ["diff", f"--output-format={output_format}", "--output=-"]
+        )
         if output_format == "quiet":
             assert r.exit_code == 1, r
             assert r.stdout == ""
@@ -1025,7 +1031,7 @@ def test_diff_rev_rev(head_sha, head1_sha, data_archive_readonly, cli_runner):
     with data_archive_readonly("points"):
         for spec in F_SPECS:
             print(f"fwd: {spec}")
-            r = cli_runner.invoke(["diff", "--exit-code", "--json", spec])
+            r = cli_runner.invoke(["diff", "--exit-code", "-o", "json", spec])
             assert r.exit_code == 1, r
             odata = json.loads(r.stdout)["sno.diff/v1+hexwkb"]
             assert len(odata[H.POINTS.LAYER]["featureChanges"]) == 5
@@ -1046,7 +1052,7 @@ def test_diff_rev_rev(head_sha, head1_sha, data_archive_readonly, cli_runner):
 
         for spec in R_SPECS:
             print(f"rev: {spec}")
-            r = cli_runner.invoke(["diff", "--exit-code", "--json", spec])
+            r = cli_runner.invoke(["diff", "--exit-code", "-o", "json", spec])
             assert r.exit_code == 1, r
             odata = json.loads(r.stdout)["sno.diff/v1+hexwkb"]
             assert len(odata[H.POINTS.LAYER]["featureChanges"]) == 5
@@ -1128,7 +1134,7 @@ def test_diff_rev_wc(data_working_copy, geopackage, cli_runner):
             return ds
 
         # changes from HEAD (R1 -> WC)
-        r = cli_runner.invoke(["diff", "--exit-code", "--json", R1])
+        r = cli_runner.invoke(["diff", "--exit-code", "-o", "json", R1])
         assert r.exit_code == 1, r
         odata = json.loads(r.stdout)["sno.diff/v1+hexwkb"]
         ddata = _extract(odata)
@@ -1145,7 +1151,7 @@ def test_diff_rev_wc(data_working_copy, geopackage, cli_runner):
         }
 
         # changes from HEAD^1 (R0 -> WC)
-        r = cli_runner.invoke(["diff", "--exit-code", "--json", R0])
+        r = cli_runner.invoke(["diff", "--exit-code", "-o", "json", R0])
         assert r.exit_code == 1, r
         odata = json.loads(r.stdout)["sno.diff/v1+hexwkb"]
         ddata = _extract(odata)
@@ -1372,17 +1378,17 @@ def test_diff_3way(data_working_copy, geopackage, cli_runner, insert, request):
         H.git_graph(request, "pre-merge-master")
 
         # changes <> master (commit <> commit) diff should fail
-        r = cli_runner.invoke(["diff", "--quiet", f"{m_commit_id}..{b_commit_id}"])
+        r = cli_runner.invoke(["diff", "-o", "quiet", f"{m_commit_id}..{b_commit_id}"])
         assert r.exit_code == NOT_YET_IMPLEMENTED, r
         assert "3-way diffs aren't supported" in r.stderr
 
         # same the other way around
-        r = cli_runner.invoke(["diff", "--quiet", f"{b_commit_id}..{m_commit_id}"])
+        r = cli_runner.invoke(["diff", "-o", "quiet", f"{b_commit_id}..{m_commit_id}"])
         assert r.exit_code == NOT_YET_IMPLEMENTED, r
         assert "3-way diffs aren't supported" in r.stderr
 
         # diff against working copy should fail too
-        r = cli_runner.invoke(["diff", "--quiet", b_commit_id])
+        r = cli_runner.invoke(["diff", "-o", "quiet", b_commit_id])
         assert r.exit_code == NOT_YET_IMPLEMENTED, r
         assert "3-way diffs aren't supported" in r.stderr
 
@@ -1393,7 +1399,7 @@ def test_show_points_HEAD(output_format, data_archive_readonly, cli_runner):
     Show a patch; ref defaults to HEAD
     """
     with data_archive_readonly("points"):
-        r = cli_runner.invoke(["show", f"--{output_format}", "HEAD"])
+        r = cli_runner.invoke(["show", f"--output-format={output_format}", "HEAD"])
         assert r.exit_code == 0, r
 
         if output_format == 'text':
@@ -1463,7 +1469,9 @@ def test_show_polygons_initial(output_format, data_archive_readonly, cli_runner)
     initial_commit = "1fb58eb54237c6e7bfcbd7ea65dc999a164b78ec"
 
     with data_archive_readonly("polygons"):
-        r = cli_runner.invoke(["show", f"--{output_format}", initial_commit])
+        r = cli_runner.invoke(
+            ["show", f"--output-format={output_format}", initial_commit]
+        )
         assert r.exit_code == 0, r
 
         if output_format == 'text':
@@ -1494,7 +1502,7 @@ def test_show_polygons_initial(output_format, data_archive_readonly, cli_runner)
 
 def test_show_json_format(data_archive_readonly, cli_runner):
     with data_archive_readonly("points"):
-        r = cli_runner.invoke(["show", f"--json", "--json-style=compact", "HEAD"])
+        r = cli_runner.invoke(["show", f"-o", "json", "--json-style=compact", "HEAD"])
 
         assert r.exit_code == 0, r
         # output is compact, no indentation

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -97,7 +97,7 @@ def test_merge_fastforward_noff(
         assert repo.head.target.hex != commit_id
 
         # force creation of a merge commit
-        r = cli_runner.invoke(["merge", "changes", "--no-ff", "--json"])
+        r = cli_runner.invoke(["merge", "changes", "--no-ff", "-o", "json"])
         assert r.exit_code == 0, r
 
         H.git_graph(request, "post-merge")
@@ -162,7 +162,7 @@ def test_merge_true(
             "Can't resolve as a fast-forward merge and --ff-only specified" in r.stderr
         )
 
-        r = cli_runner.invoke(["merge", "changes", "--ff", "--json"])
+        r = cli_runner.invoke(["merge", "changes", "--ff", "-o", "json"])
         assert r.exit_code == 0, r
         H.git_graph(request, "post-merge")
 
@@ -208,7 +208,7 @@ def test_merge_conflicts(
         ours = CommitWithReference.resolve(repo, "ours_branch")
         theirs = CommitWithReference.resolve(repo, "theirs_branch")
 
-        cmd = ["merge", "theirs_branch", f"--{output_format}"]
+        cmd = ["merge", "theirs_branch", f"--output-format={output_format}"]
         if dry_run:
             cmd += ["--dry-run"]
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -12,7 +12,7 @@ H = pytest.helpers.helpers()
 
 
 def get_conflict_ids(cli_runner):
-    r = cli_runner.invoke(["conflicts", "-s", "--flat", "--json"])
+    r = cli_runner.invoke(["conflicts", "-s", "--flat", "-o", "json"])
     assert r.exit_code == 0, r
     return json.loads(r.stdout)["sno.conflicts/v1"]
 
@@ -36,7 +36,7 @@ def get_json_feature(rs, layer, pk):
 
 def test_resolve_with_version(create_conflicts, cli_runner, disable_editor):
     with create_conflicts(H.POLYGONS) as repo:
-        r = cli_runner.invoke(["merge", "theirs_branch", "--json"])
+        r = cli_runner.invoke(["merge", "theirs_branch", "-o", "json"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout)["sno.merge/v1"]["conflicts"]
         assert RepoState.get_state(repo) == RepoState.MERGING
@@ -107,21 +107,23 @@ def test_resolve_with_version(create_conflicts, cli_runner, disable_editor):
 
 def test_resolve_with_file(create_conflicts, cli_runner, disable_editor):
     with create_conflicts(H.POLYGONS) as repo:
-        r = cli_runner.invoke(["diff", "ancestor_branch..ours_branch", "--geojson"])
+        r = cli_runner.invoke(["diff", "ancestor_branch..ours_branch", "-o", "geojson"])
         assert r.exit_code == 0, r
         ours_geojson = json.loads(r.stdout)["features"][0]
         assert ours_geojson["id"] == "I::98001"
 
-        r = cli_runner.invoke(["diff", "ancestor_branch..theirs_branch", "--geojson"])
+        r = cli_runner.invoke(
+            ["diff", "ancestor_branch..theirs_branch", "-o", "geojson"]
+        )
         assert r.exit_code == 0, r
         theirs_geojson = json.loads(r.stdout)["features"][0]
         assert theirs_geojson["id"] == "I::98001"
 
-        r = cli_runner.invoke(["merge", "theirs_branch", "--json"])
+        r = cli_runner.invoke(["merge", "theirs_branch", "-o", "json"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout)["sno.merge/v1"]["conflicts"]
 
-        r = cli_runner.invoke(["conflicts", "-s", "--json"])
+        r = cli_runner.invoke(["conflicts", "-s", "-o", "json"])
         assert r.exit_code == 0, r
 
         conflicts = json.loads(r.stdout)["sno.conflicts/v1"]

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -18,7 +18,7 @@ def text_status(cli_runner):
 
 
 def json_status(cli_runner):
-    r = cli_runner.invoke(["status", "--json"])
+    r = cli_runner.invoke(["status", "-o", "json"])
     assert r.exit_code == 0, r
     return json.loads(r.stdout)
 
@@ -262,7 +262,7 @@ def test_status_none(tmp_path, cli_runner, chdir):
             == "Error: Current directory is not an existing repository"
         )
 
-        r = cli_runner.invoke(["status", "--json"])
+        r = cli_runner.invoke(["status", "-o", "json"])
         assert r.exit_code == NO_REPOSITORY, r
         assert (
             r.stderr.splitlines()[-1]


### PR DESCRIPTION
This is much easier with click than the --json/etc options, and also
just neater than having a ton of options. (It is slightly more verbose
of course)

Fixes #99.