### PR TITLE
Fix conflict list structure, make it valid geojson

### DIFF
--- a/sno/resolve.py
+++ b/sno/resolve.py
@@ -60,9 +60,8 @@ def ensure_geojson_resolve_supported(rich_conflict):
     - otherwise we won't know which table should contain the resolution -
     and the conflict only involves features, since we can't load metadata from geojson.
     """
-    categorised_label = rich_conflict.categorised_label
-    single_table = categorised_label[0] == rich_conflict.any_true_version.table
-    only_features = categorised_label[1] == "featureConflicts"
+    single_table = "," not in rich_conflict.decoded_path[0]
+    only_features = rich_conflict.decoded_path[1] == "feature"
     if not single_table or not only_features:
         raise NotYetImplemented(
             "Sorry, only feature conflicts can currently be resolved using --with-file"
@@ -100,6 +99,11 @@ def resolve(ctx, with_version, file_path, conflict_label):
 
     merge_index = MergeIndex.read_from_repo(repo)
     merge_context = MergeContext.read_from_repo(repo)
+
+    if conflict_label.endswith(":"):
+        # Due to the way conflict labels are often displayed with ":ancestor" etc on the end,
+        # a user could easily have an extra ":" on the end by accident.
+        conflict_label = conflict_label[:-1]
 
     for key, conflict3 in merge_index.conflicts.items():
         rich_conflict = RichConflict(conflict3, merge_context)

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -83,7 +83,7 @@ class RepositoryStructure:
         """
         Given a path in the sno repository - eg "table_A/.sno-table/49/3e/Bg==" -
         returns a tuple in either of the following forms:
-        1. (table, "feature", primary_key_field, primary_key)
+        1. (table, "feature", primary_key)
         2. (table, "meta", metadata_file_path)
         """
         table, table_path = path.split("/.sno-table/", 1)
@@ -700,7 +700,7 @@ class Dataset1(DatasetStructure):
         """
         Given a path in this layer of the sno repository - eg ".sno-table/49/3e/Bg==" -
         returns a tuple in either of the following forms:
-        1. ("feature", primary_key_field, primary_key)
+        1. ("feature", primary_key)
         2. ("meta", metadata_file_path)
         """
         if path.startswith(".sno-table/"):
@@ -708,7 +708,7 @@ class Dataset1(DatasetStructure):
         if path.startswith("meta/"):
             return ("meta", path[len("meta/") :])
         pk = self.decode_pk(os.path.basename(path))
-        return ("feature", self.primary_key, pk)
+        return ("feature", pk)
 
     def import_meta_items(self, source):
         """

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -61,24 +61,11 @@ def test_summarise_conflicts(create_conflicts, cli_runner):
         assert r.exit_code == 0, r
         assert r.stdout.split("\n") == [
             'nz_waca_adjustments:',
-            '  Feature conflicts:',
-            '    add/add:',
-            '      nz_waca_adjustments:id=98001',
-            '    edit/edit:',
-            '      nz_waca_adjustments:id=1452332',
-            '      nz_waca_adjustments:id=1456853',
-            '      nz_waca_adjustments:id=1456912',
-            '',
-            '',
-        ]
-
-        r = cli_runner.invoke(["conflicts", "-s", "--flat"])
-        assert r.exit_code == 0, r
-        assert r.stdout.split("\n") == [
-            'nz_waca_adjustments:id=98001',
-            'nz_waca_adjustments:id=1452332',
-            'nz_waca_adjustments:id=1456853',
-            'nz_waca_adjustments:id=1456912',
+            '    nz_waca_adjustments:feature:',
+            '        nz_waca_adjustments:feature:98001',
+            '        nz_waca_adjustments:feature:1452332',
+            '        nz_waca_adjustments:feature:1456853',
+            '        nz_waca_adjustments:feature:1456912',
             '',
             '',
         ]
@@ -87,57 +74,24 @@ def test_summarise_conflicts(create_conflicts, cli_runner):
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
             "sno.conflicts/v1": {
-                "nz_waca_adjustments": {
-                    "featureConflicts": {
-                        "add/add": ["nz_waca_adjustments:id=98001"],
-                        "edit/edit": [
-                            "nz_waca_adjustments:id=1452332",
-                            "nz_waca_adjustments:id=1456853",
-                            "nz_waca_adjustments:id=1456912",
-                        ],
-                    }
-                }
+                "nz_waca_adjustments": {"feature": [98001, 1452332, 1456853, 1456912]}
             }
-        }
-
-        r = cli_runner.invoke(["conflicts", "-s", "--flat", "-o", "json"])
-        assert json.loads(r.stdout) == {
-            "sno.conflicts/v1": [
-                "nz_waca_adjustments:id=98001",
-                "nz_waca_adjustments:id=1452332",
-                "nz_waca_adjustments:id=1456853",
-                "nz_waca_adjustments:id=1456912",
-            ]
         }
 
         r = cli_runner.invoke(["conflicts", "-ss"])
         assert r.exit_code == 0, r
         assert r.stdout.split("\n") == [
             'nz_waca_adjustments:',
-            '  Feature conflicts:',
-            '    add/add: 1',
-            '    edit/edit: 3',
+            '    nz_waca_adjustments:feature: 4 conflicts',
             '',
             '',
         ]
 
-        r = cli_runner.invoke(["conflicts", "-ss", "--flat"])
-        assert r.exit_code == 0, r
-        assert r.stdout.strip() == "4"
-
         r = cli_runner.invoke(["conflicts", "-ss", "-o", "json"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
-            "sno.conflicts/v1": {
-                "nz_waca_adjustments": {
-                    "featureConflicts": {"add/add": 1, "edit/edit": 3}
-                }
-            },
+            "sno.conflicts/v1": {"nz_waca_adjustments": {"feature": 4}},
         }
-
-        r = cli_runner.invoke(["conflicts", "-ss", "--flat", "-o", "json"])
-        assert r.exit_code == 0, r
-        assert json.loads(r.stdout) == {"sno.conflicts/v1": 4}
 
 
 def test_list_conflicts(create_conflicts, cli_runner):
@@ -152,24 +106,23 @@ def test_list_conflicts(create_conflicts, cli_runner):
         assert r.exit_code == 0, r
         assert r.stdout.split("\n") == [
             'nz_pa_points_topo_150k:',
-            '  Feature conflicts:',
-            '    edit/edit:',
-            '      nz_pa_points_topo_150k:fid=4:',
-            '        ancestor:',
+            '    nz_pa_points_topo_150k:feature:',
+            '        nz_pa_points_topo_150k:feature:4:',
+            '            nz_pa_points_topo_150k:feature:4:ancestor:',
             '                                     fid = 4',
             '                                    geom = POINT(...)',
             '                              macronated = N',
             '                                    name = ␀',
             '                              name_ascii = ␀',
             '                                 t50_fid = 2426274',
-            '        ours:',
+            '            nz_pa_points_topo_150k:feature:4:ours:',
             '                                     fid = 4',
             '                                    geom = POINT(...)',
             '                              macronated = N',
             '                                    name = ours_version',
             '                              name_ascii = ␀',
             '                                 t50_fid = 2426274',
-            '        theirs:',
+            '            nz_pa_points_topo_150k:feature:4:theirs:',
             '                                     fid = 4',
             '                                    geom = POINT(...)',
             '                              macronated = N',
@@ -185,43 +138,41 @@ def test_list_conflicts(create_conflicts, cli_runner):
         assert json.loads(r.stdout) == {
             "sno.conflicts/v1": {
                 "nz_pa_points_topo_150k": {
-                    "featureConflicts": {
-                        "edit/edit": {
-                            "nz_pa_points_topo_150k:fid=4": {
-                                "ancestor": {
-                                    "geometry": "0101000000E699C7FE092966404E7743C1B50B43C0",
-                                    "properties": {
-                                        "fid": 4,
-                                        "macronated": "N",
-                                        "name": None,
-                                        "name_ascii": None,
-                                        "t50_fid": 2426274,
-                                    },
-                                    "id": 4,
+                    "feature": {
+                        "4": {
+                            "ancestor": {
+                                "geometry": "0101000000E699C7FE092966404E7743C1B50B43C0",
+                                "properties": {
+                                    "fid": 4,
+                                    "macronated": "N",
+                                    "name": None,
+                                    "name_ascii": None,
+                                    "t50_fid": 2426274,
                                 },
-                                "ours": {
-                                    "geometry": "0101000000E699C7FE092966404E7743C1B50B43C0",
-                                    "properties": {
-                                        "fid": 4,
-                                        "t50_fid": 2426274,
-                                        "name_ascii": None,
-                                        "macronated": "N",
-                                        "name": "ours_version",
-                                    },
-                                    "id": 4,
+                                "id": 4,
+                            },
+                            "ours": {
+                                "geometry": "0101000000E699C7FE092966404E7743C1B50B43C0",
+                                "properties": {
+                                    "fid": 4,
+                                    "t50_fid": 2426274,
+                                    "name_ascii": None,
+                                    "macronated": "N",
+                                    "name": "ours_version",
                                 },
-                                "theirs": {
-                                    "geometry": "0101000000E699C7FE092966404E7743C1B50B43C0",
-                                    "properties": {
-                                        "fid": 4,
-                                        "t50_fid": 2426274,
-                                        "name_ascii": None,
-                                        "macronated": "N",
-                                        "name": "theirs_version",
-                                    },
-                                    "id": 4,
+                                "id": 4,
+                            },
+                            "theirs": {
+                                "geometry": "0101000000E699C7FE092966404E7743C1B50B43C0",
+                                "properties": {
+                                    "fid": 4,
+                                    "t50_fid": 2426274,
+                                    "name_ascii": None,
+                                    "macronated": "N",
+                                    "name": "theirs_version",
                                 },
-                            }
+                                "id": 4,
+                            },
                         }
                     }
                 }
@@ -231,68 +182,52 @@ def test_list_conflicts(create_conflicts, cli_runner):
         r = cli_runner.invoke(["conflicts", "-o", "geojson"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
-            "sno.conflicts/v1": {
-                "nz_pa_points_topo_150k": {
-                    "featureConflicts": {
-                        "edit/edit": {
-                            "nz_pa_points_topo_150k:fid=4": {
-                                "ancestor": {
-                                    "type": "Feature",
-                                    "geometry": {
-                                        "type": "Point",
-                                        "coordinates": [
-                                            177.28247012123683,
-                                            -38.09148422044983,
-                                        ],
-                                    },
-                                    "properties": {
-                                        "fid": 4,
-                                        "macronated": "N",
-                                        "name": None,
-                                        "name_ascii": None,
-                                        "t50_fid": 2426274,
-                                    },
-                                    "id": 4,
-                                },
-                                "ours": {
-                                    "type": "Feature",
-                                    "geometry": {
-                                        "type": "Point",
-                                        "coordinates": [
-                                            177.28247012123683,
-                                            -38.09148422044983,
-                                        ],
-                                    },
-                                    "properties": {
-                                        "fid": 4,
-                                        "t50_fid": 2426274,
-                                        "name_ascii": None,
-                                        "macronated": "N",
-                                        "name": "ours_version",
-                                    },
-                                    "id": 4,
-                                },
-                                "theirs": {
-                                    "type": "Feature",
-                                    "geometry": {
-                                        "type": "Point",
-                                        "coordinates": [
-                                            177.28247012123683,
-                                            -38.09148422044983,
-                                        ],
-                                    },
-                                    "properties": {
-                                        "fid": 4,
-                                        "t50_fid": 2426274,
-                                        "name_ascii": None,
-                                        "macronated": "N",
-                                        "name": "theirs_version",
-                                    },
-                                    "id": 4,
-                                },
-                            }
-                        }
-                    }
-                }
-            }
+            'features': [
+                {
+                    'geometry': {
+                        'coordinates': [177.28247012123683, -38.09148422044983],
+                        'type': 'Point',
+                    },
+                    'id': 'nz_pa_points_topo_150k:feature:4:ancestor',
+                    'properties': {
+                        'fid': 4,
+                        'macronated': 'N',
+                        'name': None,
+                        'name_ascii': None,
+                        't50_fid': 2426274,
+                    },
+                    'type': 'Feature',
+                },
+                {
+                    'geometry': {
+                        'coordinates': [177.28247012123683, -38.09148422044983],
+                        'type': 'Point',
+                    },
+                    'id': 'nz_pa_points_topo_150k:feature:4:ours',
+                    'properties': {
+                        'fid': 4,
+                        'macronated': 'N',
+                        'name': 'ours_version',
+                        'name_ascii': None,
+                        't50_fid': 2426274,
+                    },
+                    'type': 'Feature',
+                },
+                {
+                    'geometry': {
+                        'coordinates': [177.28247012123683, -38.09148422044983],
+                        'type': 'Point',
+                    },
+                    'id': 'nz_pa_points_topo_150k:feature:4:theirs',
+                    'properties': {
+                        'fid': 4,
+                        'macronated': 'N',
+                        'name': 'theirs_version',
+                        'name_ascii': None,
+                        't50_fid': 2426274,
+                    },
+                    'type': 'Feature',
+                },
+            ],
+            'type': 'FeatureCollection',
         }

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -235,9 +235,7 @@ def test_merge_conflicts(
                     "Conflicts found:",
                     "",
                     f"{data.LAYER}:",
-                    "  Feature conflicts:",
-                    "    add/add: 1",
-                    "    edit/edit: 3",
+                    f"    {data.LAYER}:feature: 4 conflicts",
                     "",
                 ]
                 + merging_state_message
@@ -267,11 +265,7 @@ def test_merge_conflicts(
                     },
                     "dryRun": dry_run,
                     "message": "Merge branch \"theirs_branch\" into ours_branch",
-                    "conflicts": {
-                        data.LAYER: {
-                            "featureConflicts": {"add/add": 1, "edit/edit": 3}
-                        },
-                    },
+                    "conflicts": {data.LAYER: {"feature": 4}},
                     "state": "merging",
                 },
             }

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -60,7 +60,7 @@ def test_resolve_with_version(create_conflicts, cli_runner, disable_editor):
         while conflict_ids:
             num_conflicts = len(conflict_ids)
             conflict_id = conflict_ids[0]
-            pk = conflict_id.split("=", 1)[1]
+            pk = conflict_id.split(":", 2)[2]
             pk_order += [pk]
 
             r = cli_runner.invoke(
@@ -127,8 +127,8 @@ def test_resolve_with_file(create_conflicts, cli_runner, disable_editor):
         assert r.exit_code == 0, r
 
         conflicts = json.loads(r.stdout)["sno.conflicts/v1"]
-        add_add_conflict = conflicts[H.POLYGONS.LAYER]["featureConflicts"]["add/add"][0]
-        assert add_add_conflict == "nz_waca_adjustments:id=98001"
+        add_add_conflict_pk = conflicts[H.POLYGONS.LAYER]["feature"][0]
+        assert add_add_conflict_pk == 98001
 
         # These IDs are irrelevant, but we change them to at least be unique.
         ours_geojson["id"] = "ours-feature"
@@ -142,7 +142,11 @@ def test_resolve_with_file(create_conflicts, cli_runner, disable_editor):
         }
         write_repo_file(repo, "resolution.geojson", json.dumps(resolution))
         r = cli_runner.invoke(
-            ["resolve", add_add_conflict, "--with-file=resolution.geojson"]
+            [
+                "resolve",
+                f"{H.POLYGONS.LAYER}:feature:98001",
+                "--with-file=resolution.geojson",
+            ]
         )
         assert r.exit_code == 0, r
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -284,9 +284,7 @@ def test_status_merging(create_conflicts, cli_runner):
             "Conflicts:",
             "",
             "nz_pa_points_topo_150k:",
-            "  Feature conflicts:",
-            "    add/add: 1",
-            "    edit/edit: 3",
+            "    nz_pa_points_topo_150k:feature: 4 conflicts",
             "",
             "",
             "View conflicts with `sno conflicts` and resolve them with `sno resolve`.",
@@ -320,10 +318,6 @@ def test_status_merging(create_conflicts, cli_runner):
                         "branch": "theirs_branch",
                     },
                 },
-                "conflicts": {
-                    "nz_pa_points_topo_150k": {
-                        "featureConflicts": {"add/add": 1, "edit/edit": 3}
-                    }
-                },
+                "conflicts": {"nz_pa_points_topo_150k": {"feature": 4}},
             }
         }


### PR DESCRIPTION
sno conflicts --geojson wasn't real geojson before, since it wasn't flat. Fixed now.

Also simplified conflict labelling logic so it makes sense.
Previously a conflict had a label (like a name), and a category (its place in the hierarchy of conflicts). These two concepts were very related - the place a conflict belonged was with other conflicts of the same dataset, and a conflicts label should also begin with its dataset.

This PR also unifies these two concepts into one. Since geojson is flat, we can only show a label and no category, so making these two concepts the same avoids confusion.

As a result of this, types of conflicts eg "add/add" and "edit/edit" have disappeared for the time being. They could be reintroduced later if needed.