### PR TITLE
Don't lock "sno diff" and "sno show" when in merging state

### DIFF
--- a/sno/diff.py
+++ b/sno/diff.py
@@ -15,6 +15,7 @@ from .exceptions import (
     NO_WORKING_COPY,
     UNCATEGORIZED_ERROR,
 )
+from .repo_files import RepoState
 
 
 L = logging.getLogger("sno.diff")
@@ -417,7 +418,8 @@ def diff_with_writer(
         if isinstance(output_path, str) and output_path != "-":
             output_path = Path(output_path).expanduser()
 
-        repo = ctx.obj.repo
+        repo = ctx.obj.get_repo(allowed_states=RepoState.ALL_STATES)
+
         args = list(args)
 
         # TODO: handle [--] and [<dataset>[:pk]...] without <commit>

--- a/sno/show.py
+++ b/sno/show.py
@@ -5,6 +5,7 @@ from io import StringIO
 
 import click
 
+from .repo_files import RepoState
 from .output_util import dump_json_output, resolve_output_path
 from .structs import CommitWithReference
 from .timestamps import datetime_to_iso8601_utc, timedelta_to_iso8601_tz
@@ -37,7 +38,7 @@ def show(ctx, *, refish, output_format, json_style, **kwargs):
     if output_format == 'patch':
         output_format = 'json'
 
-    repo = ctx.obj.repo
+    repo = ctx.obj.get_repo(allowed_states=RepoState.ALL_STATES)
     # Ensures we were given a reference to a commit, and not a tree or something
     commit = CommitWithReference.resolve(repo, refish).commit
 


### PR DESCRIPTION
sno diff and sno show are still pretty useful, and they are harmless - they can't mess up your merge.