### PR TITLE
Fix two and three dot behaviour in `sno diff`

### DIFF
--- a/sno/show.py
+++ b/sno/show.py
@@ -52,7 +52,7 @@ def show(ctx, *, refish, output_format, json_style, **kwargs):
         ctx,
         patch_writer,
         exit_code=False,
-        args=[f"{parent}..{refish}"],
+        args=[f"{parent}...{refish}"],
         json_style=json_style,
     )
 

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -139,12 +139,12 @@ class RepositoryStructure:
     @property
     def id(self):
         obj = self._commit or self._tree
-        return obj.id if obj else None
+        return obj.id if obj is not None else None
 
     @property
     def short_id(self):
         obj = self._commit or self._tree
-        return obj.short_id if obj else None
+        return obj.short_id if obj is not None else None
 
     @property
     def head_commit(self):


### PR DESCRIPTION
As per https://github.com/koordinates/sno/issues/51 -

two dots should shows the changes on one branch that are not on the other branch.
three dots should show all the changes on both branches, since they diverged.