### PR TITLE
Multi table import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ vendor/Brewfile.lock.json
 pytest.xml
 .coverage
 /.pytest*
+/test-results/
 /dist
 /build
 *.code-workspace

--- a/sno/init.py
+++ b/sno/init.py
@@ -599,7 +599,7 @@ def import_table(
             dst_table = dst_table.replace("\\", "/")  # git paths use / as a delimiter
 
         if dst_table in loaders:
-            raise InvalidOperation(
+            raise click.UsageError(
                 f'table "{dst_table}" was specified more than once', param_hint="tables"
             )
         loaders[dst_table] = source_loader.clone_for_table(src_table)

--- a/sno/init.py
+++ b/sno/init.py
@@ -676,8 +676,11 @@ def import_table(
     "-m",
     help="Commit message (when used with --import). By default this is auto-generated.",
 )
-@click.argument(
-    "directory", type=click.Path(writable=True, file_okay=False), required=False
+@click.option(
+    "--path",
+    "directory",
+    type=click.Path(writable=True, file_okay=False),
+    required=False,
 )
 @click.option(
     "--version",

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -1,5 +1,4 @@
 import contextlib
-import errno
 import functools
 
 import json
@@ -119,13 +118,13 @@ def fast_import_tables(
                     if limit is not None and i == (limit - 1):
                         click.secho(f"  Stopping at {limit:,d} features", fg="yellow")
                         break
-
-                p.stdin.write(b"\ndone\n")
                 t3 = time.monotonic()
                 click.echo(f"Added {num_rows:,d} Features to index in {t3-t2:.1f}s")
                 click.echo(
                     f"Overall rate: {(num_rows/(t3-t2 or 1E-3)):.0f} features/s)"
                 )
+
+        p.stdin.write(b"\ndone\n")
     except BrokenPipeError as e:
         # if git-fast-import dies early, we get an EPIPE here
         # we'll deal with it below

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -1,4 +1,5 @@
 import contextlib
+import errno
 import functools
 
 import json
@@ -16,6 +17,126 @@ from . import core, gpkg
 from .exceptions import NotFound, NO_COMMIT
 
 L = logging.getLogger("sno.structure")
+
+
+def fast_import_tables(
+    repo, sources, max_pack_size="2G", limit=None, message=None, *, version
+):
+    for path, source in sources.items():
+        if not source.table:
+            raise ValueError("No table specified")
+
+        if not repo.is_empty:
+            if path in repo.head.peel(pygit2.Tree):
+                raise ValueError(f"{path}/ already exists")
+
+    click.echo("Starting git-fast-import...")
+    p = subprocess.Popen(
+        [
+            "git",
+            "fast-import",
+            "--date-format=now",
+            "--done",
+            "--stats",
+            f"--max-pack-size={max_pack_size}",
+        ],
+        cwd=repo.path,
+        stdin=subprocess.PIPE,
+    )
+    try:
+        user = repo.default_signature
+
+        if message is None:
+            if len(sources) == 1:
+                for path, source in sources.items():
+                    message = f"Import from {Path(source.source).name} to {path}/"
+            else:
+                message = f"Import {len(sources)} datasets from '{Path(source.source).name}':\n"
+                for path, source in sources.items():
+                    if path == source.table:
+                        message += f"\n* {path}/"
+                    else:
+                        message += f"\n* {path} (from {source.table})"
+
+        header = (
+            "commit refs/heads/master\n"
+            f"committer {user.name} <{user.email}> now\n"
+            f"data {len(message.encode('utf8'))}\n{message}\n"
+        )
+        p.stdin.write(header.encode("utf8"))
+
+        if not repo.is_empty:
+            # start with the existing tree/contents
+            p.stdin.write(b"from refs/heads/master^0\n")
+        for path, source in sources.items():
+            dataset = DatasetStructure.for_version(version)(tree=None, path=path)
+
+            with source:
+                if limit:
+                    num_rows = min(limit, source.row_count)
+                    click.echo(
+                        f"Importing {num_rows:,d} of {source.row_count:,d} features from {source} to {path}/ ..."
+                    )
+                else:
+                    num_rows = source.row_count
+                    click.echo(
+                        f"Importing {num_rows:,d} features from {source} to {path}/ ..."
+                    )
+
+                t0 = time.monotonic()
+                src_iterator = source.iter_features()
+
+                t1 = time.monotonic()
+                click.echo(f"Source setup in {t1-t0:.1f}s")
+
+                for i, (blob_path, blob_data) in enumerate(
+                    dataset.import_iter_meta_blobs(repo, source)
+                ):
+                    p.stdin.write(
+                        f"M 644 inline {blob_path}\ndata {len(blob_data)}\n".encode(
+                            "utf8"
+                        )
+                    )
+                    p.stdin.write(blob_data)
+                    p.stdin.write(b"\n")
+
+                # features
+                t2 = time.monotonic()
+                for i, (blob_path, blob_data) in enumerate(
+                    dataset.import_iter_feature_blobs(src_iterator, source)
+                ):
+                    p.stdin.write(
+                        f"M 644 inline {blob_path}\ndata {len(blob_data)}\n".encode(
+                            "utf8"
+                        )
+                    )
+                    p.stdin.write(blob_data)
+                    p.stdin.write(b"\n")
+
+                    if i and i % 100000 == 0:
+                        click.echo(f"  {i:,d} features... @{time.monotonic()-t2:.1f}s")
+
+                    if limit is not None and i == (limit - 1):
+                        click.secho(f"  Stopping at {limit:,d} features", fg="yellow")
+                        break
+
+                p.stdin.write(b"\ndone\n")
+                t3 = time.monotonic()
+                click.echo(f"Added {num_rows:,d} Features to index in {t3-t2:.1f}s")
+                click.echo(
+                    f"Overall rate: {(num_rows/(t3-t2 or 1E-3)):.0f} features/s)"
+                )
+    except BrokenPipeError as e:
+        # if git-fast-import dies early, we get an EPIPE here
+        # we'll deal with it below
+        pass
+    else:
+        p.stdin.close()
+    p.wait()
+    if p.returncode != 0:
+        raise subprocess.CalledProcessError(f"Error! {p.returncode}", "git-fast-import")
+    t4 = time.monotonic()
+    click.echo(f"Closed in {(t4-t3):.0f}s")
 
 
 class RepositoryStructure:
@@ -300,10 +421,6 @@ class DatasetStructure:
         raise ValueError(f"No DatasetStructure for v{version}")
 
     @classmethod
-    def importer(cls, path, version=None):
-        return cls.for_version(version)(tree=None, path=path)
-
-    @classmethod
     def instantiate(cls, tree, path):
         """ Load a DatasetStructure from a Tree """
         L = logging.getLogger(cls.__qualname__)
@@ -436,107 +553,6 @@ class DatasetStructure:
                 f"{self.path}/{self.META_PATH}/{name}",
                 json.dumps(value).encode("utf8"),
             )
-
-    def fast_import_table(
-        self, repo, source, max_pack_size="2G", limit=None, message=None
-    ):
-
-        table = source.table
-        if not table:
-            raise ValueError("No table specified")
-
-        path = self.path
-
-        if not repo.is_empty:
-            if path in repo.head.peel(pygit2.Tree):
-                raise ValueError(f"{path}/ already exists")
-
-        with source:
-            if limit:
-                num_rows = min(limit, source.row_count)
-                click.echo(
-                    f"Importing {num_rows:,d} of {source.row_count:,d} features from {source} to {path}/ ..."
-                )
-            else:
-                num_rows = source.row_count
-                click.echo(
-                    f"Importing {num_rows:,d} features from {source} to {path}/ ..."
-                )
-
-            t0 = time.monotonic()
-            src_iterator = source.iter_features()
-
-            t1 = time.monotonic()
-            click.echo(f"Source setup in {t1-t0:.1f}s")
-
-            click.echo("Starting git-fast-import...")
-            p = subprocess.Popen(
-                [
-                    "git",
-                    "fast-import",
-                    "--date-format=now",
-                    "--done",
-                    "--stats",
-                    f"--max-pack-size={max_pack_size}",
-                ],
-                cwd=repo.path,
-                stdin=subprocess.PIPE,
-            )
-
-            user = repo.default_signature
-
-            if message is None:
-                message = f'Import from {Path(source.source).name} to {path}/\n'
-
-            header = (
-                "commit refs/heads/master\n"
-                f"committer {user.name} <{user.email}> now\n"
-                f"data {len(message.encode('utf8'))}\n{message}\n"
-            )
-            p.stdin.write(header.encode("utf8"))
-
-            if not repo.is_empty:
-                # start with the existing tree/contents
-                p.stdin.write(b"from refs/heads/master^0\n")
-
-            for blob_path, blob_data in self.import_iter_meta_blobs(repo, source):
-                p.stdin.write(
-                    f"M 644 inline {blob_path}\ndata {len(blob_data)}\n".encode("utf8")
-                )
-                p.stdin.write(blob_data)
-                p.stdin.write(b"\n")
-
-            # features
-            t2 = time.monotonic()
-            for i, (blob_path, blob_data) in enumerate(
-                self.import_iter_feature_blobs(src_iterator, source)
-            ):
-                p.stdin.write(
-                    f"M 644 inline {blob_path}\ndata {len(blob_data)}\n".encode("utf8")
-                )
-                p.stdin.write(blob_data)
-                p.stdin.write(b"\n")
-
-                if i and i % 100000 == 0:
-                    click.echo(f"  {i:,d} features... @{time.monotonic()-t2:.1f}s")
-
-                if limit is not None and i == (limit - 1):
-                    click.secho(f"  Stopping at {limit:,d} features", fg="yellow")
-                    break
-
-            p.stdin.write(b"\ndone\n")
-            t3 = time.monotonic()
-            click.echo(f"Added {num_rows:,d} Features to index in {t3-t2:.1f}s")
-            click.echo(f"Overall rate: {(num_rows/(t3-t2 or 1E-3)):.0f} features/s)")
-
-            p.stdin.close()
-            p.wait()
-            if p.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    f"Error! {p.returncode}", "git-fast-import"
-                )
-            t4 = time.monotonic()
-            click.echo(f"Closed in {(t4-t3):.0f}s")
 
     RTREE_INDEX_EXTENSIONS = ("sno-idxd", "sno-idxi")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,8 +305,7 @@ def data_imported(cli_runner, data_archive, chdir, request, tmp_path_factory):
                         "import",
                         f"GPKG:{data / source_gpkg}",
                         f"--version={version}",
-                        f"--table={table}",
-                        "mytable",
+                        f"{table}:mytable",
                     ]
                 )
                 assert r.exit_code == 0, r

--- a/tests/scripts/e2e-1.ps1
+++ b/tests/scripts/e2e-1.ps1
@@ -50,7 +50,7 @@ $SQLITE=(Join-Path $SNO_PREFIX 'sqlite3.exe')
 New-Item -ItemType Directory -Path "${TMP_PATH}\test"
 Push-Location "${TMP_PATH}\test"
 try {
-    Exec { sno init --path . }
+    Exec { sno init . }
     Exec { sno -v config --local 'user.name' 'Sno E2E Test 1' }
     Exec { sno -v config --local 'user.email' 'sno-e2e-test-1@email.invalid' }
     Exec { sno -v config --local 'core.pager' false }

--- a/tests/scripts/e2e-1.ps1
+++ b/tests/scripts/e2e-1.ps1
@@ -50,11 +50,11 @@ $SQLITE=(Join-Path $SNO_PREFIX 'sqlite3.exe')
 New-Item -ItemType Directory -Path "${TMP_PATH}\test"
 Push-Location "${TMP_PATH}\test"
 try {
-    Exec { sno init . }
+    Exec { sno init --path . }
     Exec { sno -v config --local 'user.name' 'Sno E2E Test 1' }
     Exec { sno -v config --local 'user.email' 'sno-e2e-test-1@email.invalid' }
     Exec { sno -v config --local 'core.pager' false }
-    Exec { sno import "GPKG:${TEST_GPKG}" "--table=mylayer" }
+    Exec { sno import "GPKG:${TEST_GPKG}" "mylayer" }
 
     Exec { sno log }
     Exec { sno checkout }

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -32,7 +32,7 @@ mkdir "${TMP_PATH}/test"
 cd "${TMP_PATH}/test"
 set -x
 
-sno init --path .
+sno init .
 sno config user.name "Sno E2E Test 1"
 sno config user.email "sno-e2e-test-1@email.invalid"
 sno import "GPKG:${TEST_GPKG}" mylayer

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -32,10 +32,10 @@ mkdir "${TMP_PATH}/test"
 cd "${TMP_PATH}/test"
 set -x
 
-sno init .
+sno init --path .
 sno config user.name "Sno E2E Test 1"
 sno config user.email "sno-e2e-test-1@email.invalid"
-sno import "GPKG:${TEST_GPKG}" --table=mylayer
+sno import "GPKG:${TEST_GPKG}" mylayer
 
 sno log
 sno checkout

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -134,7 +134,7 @@ def test_branches(
 
 def test_branches_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "wiz.sno"
-    r = cli_runner.invoke(["init", repo_path])
+    r = cli_runner.invoke(["init", f"--path={repo_path}"])
     assert r.exit_code == 0, r
 
     with chdir(repo_path):

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -134,7 +134,7 @@ def test_branches(
 
 def test_branches_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "wiz.sno"
-    r = cli_runner.invoke(["init", f"--path={repo_path}"])
+    r = cli_runner.invoke(["init", repo_path])
     assert r.exit_code == 0, r
 
     with chdir(repo_path):

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -280,7 +280,7 @@ def test_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "one.sno"
 
     # empty repo
-    r = cli_runner.invoke(["init", repo_path])
+    r = cli_runner.invoke(["init", f"--path={repo_path}"])
     assert r.exit_code == 0, r
     with chdir(repo_path):
         r = cli_runner.invoke(["commit", "--allow-empty"])

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -280,7 +280,7 @@ def test_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "one.sno"
 
     # empty repo
-    r = cli_runner.invoke(["init", f"--path={repo_path}"])
+    r = cli_runner.invoke(["init", str(repo_path)])
     assert r.exit_code == 0, r
     with chdir(repo_path):
         r = cli_runner.invoke(["commit", "--allow-empty"])

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -54,7 +54,7 @@ def test_e2e(
             assert r.exit_code == 0
 
             # import data
-            r = cli_runner.invoke(["import", f"GPKG:{data / gpkg}", "--table", table])
+            r = cli_runner.invoke(["import", f"GPKG:{data / gpkg}", table])
             assert r.exit_code == 0
 
             # check there's a commit

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -48,7 +48,7 @@ def test_init_import_single_table_source(data_archive_readonly, tmp_path, cli_ru
                 "init",
                 "--import",
                 data / "nz-pa-points-topo-150k.gpkg",
-                tmp_path / "emptydir",
+                f"--path={tmp_path / 'emptydir'}",
             ]
         )
         # You don't have to specify a table if there's only one.
@@ -69,7 +69,7 @@ def test_init_import_custom_message(data_archive_readonly, tmp_path, cli_runner,
                 "Custom message",
                 "--import",
                 data / "nz-pa-points-topo-150k.gpkg",
-                tmp_path / "emptydir",
+                f"--path={tmp_path / 'emptydir'}",
             ]
         )
         assert r.exit_code == 0, r
@@ -86,7 +86,7 @@ def test_init_import_table_with_prompt(data_archive_readonly, tmp_path, cli_runn
                 "init",
                 "--import",
                 data / "census2016_sdhca_ot_short.gpkg",
-                tmp_path / "emptydir",
+                f"--path={tmp_path / 'emptydir'}",
             ],
             input="census2016_sdhca_ot_ced_short\n",
         )
@@ -110,7 +110,7 @@ def test_init_import_table_with_prompt_with_no_input(
                 "init",
                 "--import",
                 data / "census2016_sdhca_ot_short.gpkg",
-                tmp_path / "emptydir",
+                f"--path={tmp_path / 'emptydir'}",
             ],
         )
         # Table was specified interactively via prompt
@@ -126,7 +126,9 @@ def test_init_import_table_with_prompt_with_no_input(
 def test_init_import_table_ogr_types(data_archive_readonly, tmp_path, cli_runner):
     with data_archive_readonly("types") as data:
         repo_path = tmp_path / "repo"
-        r = cli_runner.invoke(["init", "--import", data / "types.gpkg", repo_path],)
+        r = cli_runner.invoke(
+            ["init", "--import", data / "types.gpkg", f"--path={repo_path}"],
+        )
         assert r.exit_code == 0, r
 
         # There's a bunch of wacky types in here, let's check them
@@ -291,7 +293,13 @@ def test_init_import_name_clash(data_archive, cli_runner, geopackage):
     """ Import the GeoPackage into a Sno repository of the same name, and checkout a working copy of the same name. """
     with data_archive("gpkg-editing") as data:
         r = cli_runner.invoke(
-            ["init", "--import", f"GPKG:editing.gpkg", "--table=editing", "editing"]
+            [
+                "init",
+                "--import",
+                f"GPKG:editing.gpkg",
+                "--table=editing",
+                "--path=editing",
+            ]
         )
         repo_path = data / "editing"
 
@@ -355,7 +363,13 @@ def test_init_import_errors(data_archive, tmp_path, chdir, cli_runner):
             # not empty
             (repo_path / "a.file").touch()
             r = cli_runner.invoke(
-                ["init", "--import", f"gpkg:{data/gpkg}", f"--table={table}", repo_path]
+                [
+                    "init",
+                    "--import",
+                    f"gpkg:{data/gpkg}",
+                    f"--table={table}",
+                    f'--path={repo_path}',
+                ]
             )
             assert r.exit_code == INVALID_OPERATION, r
             assert "isn't empty" in r.stderr
@@ -367,13 +381,13 @@ def test_init_empty(tmp_path, cli_runner, chdir):
     repo_path.mkdir()
 
     # empty dir
-    r = cli_runner.invoke(["init", repo_path])
+    r = cli_runner.invoke(["init", f"--path={repo_path}"])
     assert r.exit_code == 0, r
     assert (repo_path / "HEAD").exists()
 
     # makes dir tree
     repo_path = tmp_path / "foo" / "bar" / "wiz.sno"
-    r = cli_runner.invoke(["init", repo_path])
+    r = cli_runner.invoke(["init", f"--path={repo_path}"])
     assert r.exit_code == 0, r
     assert (repo_path / "HEAD").exists()
 
@@ -389,7 +403,7 @@ def test_init_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "tree"
     repo_path.mkdir()
     (repo_path / "a.file").touch()
-    r = cli_runner.invoke(["init", repo_path])
+    r = cli_runner.invoke(["init", f"--path={repo_path}"])
     assert r.exit_code == INVALID_OPERATION, r
     assert not (repo_path / "HEAD").exists()
 
@@ -406,7 +420,7 @@ def test_init_import_alt_names(data_archive, tmp_path, cli_runner, chdir, geopac
     repo_path = tmp_path / "data.sno"
     repo_path.mkdir()
 
-    r = cli_runner.invoke(["init", repo_path])
+    r = cli_runner.invoke(["init", f"--path={repo_path}"])
     assert r.exit_code == 0, r
 
     ARCHIVE_PATHS = (
@@ -481,7 +495,7 @@ def test_init_import_home_resolve(
     repo_path = tmp_path / "data.sno"
     repo_path.mkdir()
 
-    r = cli_runner.invoke(["init", repo_path])
+    r = cli_runner.invoke(["init", f"--path={repo_path}"])
     assert r.exit_code == 0, r
 
     with data_archive("gpkg-points") as source_path:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -120,7 +120,7 @@ def test_init_import_table_with_prompt_with_no_input(
             "  census2016_sdhca_ot_ced_short - census2016_sdhca_ot_ced_short"
             in r.stdout
         )
-        assert "Invalid value for --table: No table specified" in r.stderr
+        assert "No table specified" in r.stderr
 
 
 def test_init_import_table_ogr_types(data_archive_readonly, tmp_path, cli_runner):
@@ -250,9 +250,7 @@ def test_init_import(
         repo_path.mkdir()
 
         with chdir(repo_path):
-            r = cli_runner.invoke(
-                ["init", "--import", f"gpkg:{data / gpkg}", f"--table={table}"]
-            )
+            r = cli_runner.invoke(["init", "--import", f"gpkg:{data / gpkg}", table])
             assert r.exit_code == 0, r
             assert (repo_path / "HEAD").exists()
 
@@ -293,13 +291,7 @@ def test_init_import_name_clash(data_archive, cli_runner, geopackage):
     """ Import the GeoPackage into a Sno repository of the same name, and checkout a working copy of the same name. """
     with data_archive("gpkg-editing") as data:
         r = cli_runner.invoke(
-            [
-                "init",
-                "--import",
-                f"GPKG:editing.gpkg",
-                "--table=editing",
-                "--path=editing",
-            ]
+            ["init", "--import", f"GPKG:editing.gpkg", "editing", "--path=editing",]
         )
         repo_path = data / "editing"
 
@@ -355,21 +347,15 @@ def test_init_import_errors(data_archive, tmp_path, chdir, cli_runner):
             assert "Couldn't find 'thingz.gpkg'" in r.stderr
 
             r = cli_runner.invoke(
-                ["init", "--import", f"gpkg:{data/gpkg}", f"--table=no-existey"]
+                ["init", "--import", f"gpkg:{data/gpkg}", "no-existey"]
             )
             assert r.exit_code == NO_TABLE, r
-            assert "Invalid value for --table: Table 'no-existey' not found" in r.stderr
+            assert "Table 'no-existey' not found" in r.stderr
 
             # not empty
             (repo_path / "a.file").touch()
             r = cli_runner.invoke(
-                [
-                    "init",
-                    "--import",
-                    f"gpkg:{data/gpkg}",
-                    f"--table={table}",
-                    f'--path={repo_path}',
-                ]
+                ["init", "--import", f"gpkg:{data/gpkg}", table, f'--path={repo_path}',]
             )
             assert r.exit_code == INVALID_OPERATION, r
             assert "isn't empty" in r.stderr
@@ -451,7 +437,7 @@ def test_init_import_alt_names(data_archive, tmp_path, cli_runner, chdir, geopac
                     [
                         "import",
                         f"GPKG:{source_path / source_gpkg}",
-                        f"--table={source_table}:{import_path}",
+                        f"{source_table}:{import_path}",
                     ]
                 )
                 assert r.exit_code == 0, r
@@ -506,7 +492,7 @@ def test_init_import_home_resolve(
                 [
                     "import",
                     "GPKG:~/nz-pa-points-topo-150k.gpkg",
-                    "--table=nz_pa_points_topo_150k",
+                    "nz_pa_points_topo_150k",
                 ]
             )
             assert r.exit_code == 0, r
@@ -530,7 +516,7 @@ def test_import_existing_wc(
                 [
                     "import",
                     f"GPKG:{source_path / 'nz-waca-adjustments.gpkg'}",
-                    f"--table={H.POLYGONS.LAYER}",
+                    H.POLYGONS.LAYER,
                 ]
             )
             assert r.exit_code == 0, r
@@ -568,7 +554,7 @@ def test_import_existing_wc(
                 [
                     "import",
                     f"GPKG:{source_path / 'nz-waca-adjustments.gpkg'}",
-                    f"--table={H.POLYGONS.LAYER}:waca2",
+                    f"{H.POLYGONS.LAYER}:waca2",
                 ]
             )
             assert r.exit_code == 0, r

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -233,7 +233,7 @@ def test_status(
 
 def test_status_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "wiz.sno"
-    r = cli_runner.invoke(["init", repo_path])
+    r = cli_runner.invoke(["init", f"--path={repo_path}"])
     assert r.exit_code == 0, r
 
     with chdir(repo_path):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -233,7 +233,7 @@ def test_status(
 
 def test_status_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "wiz.sno"
-    r = cli_runner.invoke(["init", f"--path={repo_path}"])
+    r = cli_runner.invoke(["init", str(repo_path)])
     assert r.exit_code == 0, r
 
     with chdir(repo_path):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -394,7 +394,13 @@ def test_import_from_non_gpkg(
         gpkg_repo_path = tmp_path / "gpkg"
         gpkg_repo_path.mkdir()
         r = cli_runner.invoke(
-            ["init", "--import", data / source_gpkg, f"--table={table}", gpkg_repo_path]
+            [
+                "init",
+                "--import",
+                data / source_gpkg,
+                f"--table={table}",
+                f"--path={gpkg_repo_path}",
+            ]
         )
         assert r.exit_code == 0, r
 
@@ -491,7 +497,9 @@ def test_shp_import_meta(
 
         # now import the SHP
         repo_path = tmp_path / "repo"
-        r = cli_runner.invoke(["init", "--import", source_filename, repo_path])
+        r = cli_runner.invoke(
+            ["init", "--import", source_filename, f"--path={repo_path}"]
+        )
         assert r.exit_code == 0, r
 
         # now check metadata

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -393,10 +393,11 @@ def test_import_from_non_gpkg(
         # First, import the original GPKG to one repo
         gpkg_repo_path = tmp_path / "gpkg"
         gpkg_repo_path.mkdir()
-        r = cli_runner.invoke(
-            ["init", "--import", data / source_gpkg, table, f"--path={gpkg_repo_path}",]
-        )
-        assert r.exit_code == 0, r
+        with chdir(gpkg_repo_path):
+            r = cli_runner.invoke(["init"])
+            assert r.exit_code == 0, r
+            r = cli_runner.invoke(["import", data / source_gpkg, table])
+            assert r.exit_code == 0, r
 
         gpkg_repo = pygit2.Repository(str(gpkg_repo_path))
         gpkg_tree = gpkg_repo.head.peel(pygit2.Tree) / table
@@ -491,9 +492,7 @@ def test_shp_import_meta(
 
         # now import the SHP
         repo_path = tmp_path / "repo"
-        r = cli_runner.invoke(
-            ["init", "--import", source_filename, f"--path={repo_path}"]
-        )
+        r = cli_runner.invoke(["init", "--import", source_filename, str(repo_path)])
         assert r.exit_code == 0, r
 
         # now check metadata

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -162,7 +162,7 @@ def test_import(
                     "import",
                     str(data / source_gpkg),
                     f"--version={import_version}",
-                    f'--table={table}',
+                    table,
                 ]
             )
             assert r.exit_code == 0, r
@@ -394,13 +394,7 @@ def test_import_from_non_gpkg(
         gpkg_repo_path = tmp_path / "gpkg"
         gpkg_repo_path.mkdir()
         r = cli_runner.invoke(
-            [
-                "init",
-                "--import",
-                data / source_gpkg,
-                f"--table={table}",
-                f"--path={gpkg_repo_path}",
-            ]
+            ["init", "--import", data / source_gpkg, table, f"--path={gpkg_repo_path}",]
         )
         assert r.exit_code == 0, r
 
@@ -432,7 +426,7 @@ def test_import_from_non_gpkg(
                     "import",
                     str(source_filename),
                     f"--version={import_version}",
-                    f"--table=data:{table}",
+                    f"data:{table}",
                 ]
             )
             assert r.exit_code == 0, r
@@ -666,7 +660,7 @@ def test_import_multiple(
                         "import",
                         f"GPKG:{data / source_gpkg}",
                         f"--version={import_version}",
-                        f"--table={table}",
+                        table,
                     ]
                 )
                 assert r.exit_code == 0, r
@@ -685,7 +679,7 @@ def test_import_multiple(
                                 "import",
                                 f"GPKG:{data / source_gpkg}",
                                 f"--version={import_version}",
-                                f"--table={table}",
+                                table,
                             ]
                         )
 


### PR DESCRIPTION
This changes the `init` and `import` commands so they can import multiple tables at once.

Further, it changes the usage so that:

* there's an `--all-tables` option
* tables are now positional arguments for the import command ~~both commands~~
* any table can be renamed during import using `source_table:dest_table`
* the existing optional (poorly named) `DIRECTORY` argument to `import` has been removed. It renamed tables, so is obsoleted by the above.
* tables cannot be specified in the `init --import` command - it always imports all tables.
* ~~the existing optional `DIRECTORY` argument to the `init` has been moved to a `--path PATH` option. This was required to make table names unambiguous in that command. The command raises a helpful error if you attempt to `init` with a table name without passing `--import`, because that's now clearly a mis-usage.~~

# todo:

tests:

- [x] add a test for multiple table import

Fixes #92 . 