### PR TITLE
Added basic Schema support to Dataset2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,13 @@ import io
 import json
 import logging
 import os
+import random
 import re
 import shutil
 import subprocess
 import tarfile
 import time
+import uuid
 from pathlib import Path
 
 import pytest
@@ -57,6 +59,18 @@ def monkeypatch_session(request):
     mpatch = MonkeyPatch()
     yield mpatch
     mpatch.undo()
+
+
+@pytest.fixture
+def gen_uuid(request):
+    """ Deterministic "random" UUID generator seeded from the test ID """
+    seed = int(hashlib.sha1(request.node.nodeid.encode("utf8")).hexdigest(), 16)
+    _uuid_gen = random.Random(seed)
+
+    def _uuid():
+        return str(uuid.UUID(int=_uuid_gen.getrandbits(128)))
+
+    return _uuid
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_dataset2.py
+++ b/tests/test_dataset2.py
@@ -1,6 +1,7 @@
 import os
+import pytest
 
-from sno.dataset2 import Dataset2, Legend
+from sno.dataset2 import Dataset2, Legend, ColumnSchema, Schema
 
 
 class DictTree:
@@ -60,7 +61,7 @@ def test_raw_dict_to_value_tuples():
     assert roundtripped == raw_feature_dict
 
 
-def test_feature_roundtrip():
+def test_raw_feature_roundtrip():
     legend = Legend(["a", "b", "c"], ["d", "e", "f"])
     legend_path, legend_data = Dataset2.encode_legend(legend)
 
@@ -81,3 +82,164 @@ def test_feature_roundtrip():
     roundtripped = dataset2.read_raw_feature_dict(feature_path)
     assert roundtripped is not raw_feature_dict
     assert roundtripped == raw_feature_dict
+
+
+@pytest.fixture
+def pki(gen_uuid):
+    def _pki(pk_index):
+        # Returns an arbitrary ColumnSchema, but with the given pk_index property.
+        id = gen_uuid()
+        return ColumnSchema(id, id[:8], "integer", pk_index)
+
+    return _pki
+
+
+def test_valid_schemas(pki):
+    Schema([pki(None), pki(None), pki(None)])
+    Schema([pki(2), pki(1), pki(0)])
+    Schema([pki(None), pki(1), pki(None), pki(0)])
+
+
+def test_invalid_schemas(pki):
+    with pytest.raises(ValueError):
+        Schema([pki(0), pki(None), pki(2)])
+    with pytest.raises(ValueError):
+        Schema([pki(0), pki(1), pki(1)])
+    with pytest.raises(ValueError):
+        Schema([pki(-1), pki(None), pki(None)])
+
+
+GEOM_TYPE_INFO = {"geometryType": "MULTIPOLYGON ZM", "geometrySRS": "EPSG:2193"}
+
+
+def test_schema_roundtrip(gen_uuid):
+    orig = Schema(
+        [
+            ColumnSchema(gen_uuid(), "geom", "geometry", None, **GEOM_TYPE_INFO),
+            ColumnSchema(gen_uuid(), "id", "integer", 1, size=64),
+            ColumnSchema(gen_uuid(), "artist", "text", 0, length=200),
+            ColumnSchema(gen_uuid(), "recording", "blob", None),
+        ]
+    )
+
+    roundtripped = Schema.loads(orig.dumps())
+
+    assert roundtripped is not orig
+    assert roundtripped == orig
+
+    path, data = Dataset2.encode_current_schema(orig)
+    tree = DictTree({path: data})
+
+    dataset2 = Dataset2(tree)
+    roundtripped = dataset2.get_current_schema()
+
+    assert roundtripped is not orig
+    assert roundtripped == orig
+
+
+def test_feature_roundtrip(gen_uuid):
+    schema = Schema(
+        [
+            ColumnSchema(gen_uuid(), "geom", "geometry", None, **GEOM_TYPE_INFO),
+            ColumnSchema(gen_uuid(), "id", "integer", 1, size=64),
+            ColumnSchema(gen_uuid(), "artist", "text", 0, length=200),
+            ColumnSchema(gen_uuid(), "recording", "blob", None),
+        ]
+    )
+    schema_path, schema_data = Dataset2.encode_current_schema(schema)
+    legend_path, legend_data = Dataset2.encode_legend(schema.legend)
+
+    # Feature tuples must be in schema order:
+    feature_tuple = ("010100000087BF756489EF5C4C", 7, "GIS Choir", b"MP3")
+    # But for feature dicts, the initialisation order is not important.
+    feature_dict = {
+        "artist": "GIS Choir",
+        "recording": b"MP3",
+        "id": 7,
+        "geom": "010100000087BF756489EF5C4C",
+    }
+
+    feature_path, feature_data = Dataset2.encode_feature_tuple(feature_tuple, schema)
+    feature_path2, feature_data2 = Dataset2.encode_feature_dict(feature_dict, schema)
+    # Either encode method should give the same result.
+    assert (feature_path, feature_data) == (feature_path2, feature_data2)
+
+    tree = DictTree(
+        {schema_path: schema_data, legend_path: legend_data, feature_path: feature_data}
+    )
+
+    dataset2 = Dataset2(tree)
+    roundtripped = dataset2.read_feature_tuple(feature_path)
+    assert roundtripped is not feature_tuple
+    assert roundtripped == feature_tuple
+
+    roundtripped = dataset2.read_feature_dict(feature_path)
+    assert roundtripped is not feature_dict
+    assert roundtripped == feature_dict
+
+
+def test_schema_change_roundtrip(gen_uuid):
+    old_schema = Schema(
+        [
+            ColumnSchema(gen_uuid(), "ID", "integer", 0),
+            ColumnSchema(gen_uuid(), "given_name", "text", None),
+            ColumnSchema(gen_uuid(), "surname", "text", None),
+            ColumnSchema(gen_uuid(), "date_of_birth", "date", None),
+        ]
+    )
+    new_schema = Schema(
+        [
+            ColumnSchema(old_schema[0].id, "personnel_id", "integer", 0),
+            ColumnSchema(gen_uuid(), "tax_file_number", "text", None),
+            ColumnSchema(old_schema[2].id, "last_name", "text", None),
+            ColumnSchema(old_schema[1].id, "first_name", "text", None),
+            ColumnSchema(gen_uuid(), "middle_names", "text", None),
+        ]
+    )
+    # Updating the schema without updating features is only possible
+    # if the old and new schemas have the same primary key columns:
+    assert old_schema.is_pk_compatible(new_schema)
+
+    feature_tuple = (7, "Joe", "Bloggs", "1970-01-01")
+    feature_dict = {
+        "given_name": "Joe",
+        "surname": "Bloggs",
+        "date_of_birth": "1970-01-01",
+        "ID": 7,
+    }
+
+    feature_path, feature_data = Dataset2.encode_feature_tuple(
+        feature_tuple, old_schema
+    )
+    feature_path2, feature_data2 = Dataset2.encode_feature_dict(
+        feature_dict, old_schema
+    )
+    # Either encode method should give the same result.
+    assert (feature_path, feature_data) == (feature_path2, feature_data2)
+
+    # The dataset should store only the current schema, but all legends.
+    schema_path, schema_data = Dataset2.encode_current_schema(new_schema)
+    new_legend_path, new_legend_data = Dataset2.encode_legend(new_schema.legend)
+    old_legend_path, old_legend_data = Dataset2.encode_legend(old_schema.legend)
+    tree = DictTree(
+        {
+            schema_path: schema_data,
+            new_legend_path: new_legend_data,
+            old_legend_path: old_legend_data,
+            feature_path: feature_data,
+        }
+    )
+
+    dataset2 = Dataset2(tree)
+    # Old columns that are not present in the new schema are gone.
+    # New columns that are not present in the old schema have 'None's.
+    roundtripped = dataset2.read_feature_tuple(feature_path)
+    assert roundtripped == (7, None, "Bloggs", "Joe", None)
+    roundtripped = dataset2.read_feature_dict(feature_path)
+    assert roundtripped == {
+        "personnel_id": 7,
+        "tax_file_number": None,
+        "last_name": "Bloggs",
+        "first_name": "Joe",
+        "middle_names": None,
+    }


### PR DESCRIPTION
![](https://media1.giphy.com/media/ojpU1QtYzaVDa/giphy.gif) (schemer)

Allows for writing a feature to the dataset using one schema, and then changing the schema, and reading the schema back.

Supports two ways of representing features - {column-name:value} dicts or row tuples, since both are already used in existing sno code.

More optimised version of this code could be written for reading thousands of features quickly, but this is not my first priority.