### PR TITLE
Remove deprecated write_feature method from Dataset1

### DIFF
--- a/sno/resolve.py
+++ b/sno/resolve.py
@@ -35,11 +35,11 @@ def write_feature_to_dataset_entry(feature, dataset, repo):
     Returns the IndexEntry that refers to that blob - this IndexEntry still needs
     to be written to the repo to complete the write.
     """
-    pk = feature[dataset.primary_key]
-    object_path = "/".join([dataset.path, dataset.get_feature_path(pk)])
-    bin_feature = dataset.encode_feature(feature)
-    blob_id = repo.create_blob(bin_feature)
-    return pygit2.IndexEntry(object_path, blob_id, pygit2.GIT_FILEMODE_BLOB)
+    feature_path, feature_data = dataset.encode_feature(feature)
+    blob_id = repo.create_blob(feature_data)
+    return pygit2.IndexEntry(
+        f"{dataset.path}/{feature_path}", blob_id, pygit2.GIT_FILEMODE_BLOB
+    )
 
 
 def load_geojson_resolve(file_path, dataset, repo):

--- a/sno/upgrade/upgrade_00_02.py
+++ b/sno/upgrade/upgrade_00_02.py
@@ -167,14 +167,22 @@ def upgrade(source, dest, layer):
                             source_blob.data.decode("utf8")
                         )
 
-                dataset.write_feature(
-                    source_feature_dict,
-                    dest_repo,
-                    index,
-                    field_cid_map=field_cid_map,
-                    geom_cols=[geom_field],
-                    primary_key=pk_field,
+                kwargs = {
+                    "field_cid_map": field_cid_map,
+                    "geom_cols": [geom_field],
+                    "primary_key": pk_field,
+                    "cast_primary_key": False,
+                }
+
+                dest_path, dest_data = dataset.encode_feature(
+                    source_feature_dict, **kwargs
                 )
+                blob_id = dest_repo.create_blob(dest_data)
+                entry = pygit2.IndexEntry(
+                    f"{dataset.path}/{dest_path}", blob_id, pygit2.GIT_FILEMODE_BLOB
+                )
+                index.add(entry)
+
                 feature_count += 1
 
             elif top_path == "" or re.match(r"^features(/[a-f0-9]{4})?$", top_path):

--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -698,13 +698,15 @@ class WorkingCopy_GPKG_1(WorkingCopyGPKG):
 
                 if db_obj[pk_field] is None:
                     if repo_obj:  # ignore INSERT+DELETE
-                        blob_hash = pygit2.hash(dataset.encode_feature(repo_obj)).hex
+                        blob_hash = pygit2.hash(
+                            dataset.encode_feature_blob(repo_obj)
+                        ).hex
                         candidates_del[blob_hash].append((track_pk, repo_obj))
                     continue
 
                 elif not repo_obj:
                     # INSERT
-                    blob_hash = pygit2.hash(dataset.encode_feature(db_obj)).hex
+                    blob_hash = pygit2.hash(dataset.encode_feature_blob(db_obj)).hex
                     candidates_ins[blob_hash].append(db_obj)
 
                 else:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -880,13 +880,17 @@ def test_write_feature_performance(
                     "geom_cols": source.geom_cols,
                     "field_cid_map": source.field_cid_map,
                     "primary_key": source.primary_key,
-                    "path": dataset.path,
+                    "cast_primary_key": False,
                 }
 
                 def _write_feature():
-                    return dataset.write_feature(
-                        next(feature_iter), repo, index, **kwargs
+                    feature = next(feature_iter)
+                    dest_path, dest_data = dataset.encode_feature(feature, **kwargs)
+                    blob_id = repo.create_blob(dest_data)
+                    entry = pygit2.IndexEntry(
+                        f"{dataset.path}/{dest_path}", blob_id, pygit2.GIT_FILEMODE_BLOB
                     )
+                    index.add(entry)
 
                 benchmark(_write_feature)
 


### PR DESCRIPTION
Dataset1 has a method write_feature which is documented as only being needed for upgrade, and so should eventually be removed. It turned out to be possible to mostly remove it without losing any functionality:
- Some of the code in the method is duplicated elsewhere in Dataset1 anyway - eg, the code for converting a feature's primary key into a path
- Once this is removed, the rest of the code is mostly just calls to other Dataset1 functionality anyway. However, these calls are stuck together in a generally useful pattern that is also used when committing changes or when resolving a conflict - ie, given a feature, find the path to write and the data to write there.

This same functionality already exists in Dataset2 (see sno-v2-internal-data-format), where it is called encode_feature, and has the following signature: encode_feature(feature) -> feature_path, feature_data. Dataset1 and Dataset2 should eventually have the same API to implement the same interface - so far they do not, but Dataset2 is often simpler since it came later when it was mostly clear what was needed - so Dataset1 will generally benefit from being retrofitted to be more like Dataset2.

This being the case, I have deleted write_feature but replaced it with a method encode_feature that has the same signature as the one in Dataset2 so that their APIs converge. Unfortunately, Dataset1 already had an encode_feature method with a different signature that is used in one other place - this one is encode_feature(feature) -> feature_data, and for now I have renamed it to encode_feature_blob. I will try to clean this up more later.