### PR TITLE
import: Don't barf `fast-import` output to stderr

### DIFF
--- a/sno/output_util.py
+++ b/sno/output_util.py
@@ -2,6 +2,11 @@ import io
 import json
 import sys
 
+from contextlib import contextmanager
+import os
+from threading import Thread
+
+
 JSON_PARAMS = {
     "compact": {},
     "pretty": {"indent": 2, "sort_keys": True},
@@ -69,3 +74,23 @@ def is_empty_stream(stream):
             return True
         stream.seek(pos)
     return False
+
+
+@contextmanager
+def logpipe(logger, level):
+    """
+    Context manager.
+    Yields a writable file-like object that pipes text to a logger.
+
+    Uses threads to avoid deadlock when this is passed to a subprocess.
+    """
+    fd_read, fd_write = os.pipe()
+
+    def run():
+        with os.fdopen(fd_read) as fo_read:
+            for line in iter(fo_read.readline, ''):
+                logger.log(level, line.strip('\n'))
+
+    Thread(target=run).start()
+    with os.fdopen(fd_write, 'w') as f_write:
+        yield f_write


### PR DESCRIPTION
Redirects it to the `sno.structure` logger. Users are unlikely to be interested in the noisy fast-import stats when doing an import.

Fixes #124