### PR TITLE
MutexOption: fix a bug and improve error msgs

### DIFF
--- a/sno/cli_util.py
+++ b/sno/cli_util.py
@@ -29,16 +29,16 @@ class MutexOption(click.Option):
 
     def handle_parse_result(self, ctx, opts, args):
         current_opt: bool = self.name in opts
-        for mutex_opt in self.exclusive_with:
-            if mutex_opt in opts:
+        for other_name in self.exclusive_with:
+
+            if other_name in opts:
                 if current_opt:
-                    raise click.UsageError(
-                        "Illegal usage: '"
-                        + str(self.name)
-                        + "' is mutually exclusive with "
-                        + str(mutex_opt)
-                        + "."
-                    )
+                    other = [x for x in ctx.command.params if x.name == other_name][0]
+                    if not other.value_is_missing(opts[other_name]):
+                        raise click.UsageError(
+                            f"Illegal usage: {self.get_error_hint(ctx)} "
+                            f"is mutually exclusive with {other.get_error_hint(ctx)}."
+                        )
                 else:
                     self.prompt = None
         return super().handle_parse_result(ctx, opts, args)


### PR DESCRIPTION
Before this, imports with `--list` or `--all-tables` failed with:

```
$ sno import ./census2016_sdhca_ot_short.gpkg --list abc
Error: Illegal usage: 'do_list' is mutually exclusive with tables.
```

This happened even if no tables were specified, because `tables` is an
argument so it was still in the context:

```
$ sno import ./census2016_sdhca_ot_short.gpkg --list
Error: Illegal usage: 'do_list' is mutually exclusive with tables.
```

That's now fixed, and also the error output makes more sense (uses the
option names instead of the internal variable names):

```
$ sno import ./census2016_sdhca_ot_short.gpkg --list abc
Error: Illegal usage: '--list' is mutually exclusive with '[TABLES]...'.
```