### PR TITLE
Add dataset:primary_key arg filters to sno commit, sno conflicts

### DIFF
--- a/sno/apply.py
+++ b/sno/apply.py
@@ -118,10 +118,6 @@ def apply_patch(*, repo, commit, patch_file, allow_empty, **kwargs):
                 offset=offset,
             ),
             allow_empty=allow_empty,
-            # Don't call WorkingCopy.commit_callback(), because it *assumes* the working
-            # copy already has the changes being committed. In this case the working copy
-            # does *not* have the changes yet. We tackle updating the working copy below.
-            update_working_copy_head=False,
         )
         click.echo(f"Commit {oid.hex}")
 

--- a/sno/dataset1.py
+++ b/sno/dataset1.py
@@ -356,7 +356,7 @@ class Dataset1(DatasetStructure):
 
             yield (feature_path, msgpack.packb(bin_feature, use_bin_type=True))
 
-    def write_index(self, dataset_diff, index, repo, callback=None):
+    def write_index(self, dataset_diff, index, repo):
         pk_field = self.primary_key
 
         conflicts = False
@@ -432,32 +432,6 @@ class Dataset1(DatasetStructure):
             raise InvalidOperation(
                 "Patch does not apply", exit_code=PATCH_DOES_NOT_APPLY,
             )
-        if callback:
-            for _, obj_old in dataset_diff["D"].items():
-                object_path = "/".join(
-                    [self.path, self.get_feature_path(obj_old[pk_field])]
-                )
-                callback(self, "D", object_path=object_path, obj_old=obj_old)
-
-            for obj_new in dataset_diff["I"]:
-                object_path = "/".join(
-                    [self.path, self.get_feature_path(obj_new[pk_field])]
-                )
-                callback(self, "I", object_path=object_path, obj_new=obj_new)
-
-            for _, (obj_old, obj_new) in dataset_diff["U"].items():
-                new_object_path = "/".join(
-                    [self.path, self.get_feature_path(obj_new[pk_field])]
-                )
-                callback(
-                    self,
-                    "U",
-                    object_path=new_object_path,
-                    obj_old=obj_old,
-                    obj_new=obj_new,
-                )
-
-            callback(self, "INDEX")
 
     def diff(self, other, pk_filter=UNFILTERED, reverse=False):
         candidates_ins = collections.defaultdict(list)

--- a/sno/show.py
+++ b/sno/show.py
@@ -52,7 +52,8 @@ def show(ctx, *, refish, output_format, json_style, **kwargs):
         ctx,
         patch_writer,
         exit_code=False,
-        args=[f"{parent}...{refish}"],
+        commit_spec=f"{parent}...{refish}",
+        filters=[],
         json_style=json_style,
     )
 


### PR DESCRIPTION
![](https://media2.giphy.com/media/lmufkORO4q3jKRf0Uo/giphy.gif)

```
$ sno diff
... 100 changes
$ sno commit -m partial_commit datasetA:1
[master d4b583e] partial_commit
  datasetA/
    modified:  1 feature
  Date: Tue Jun 23 09:44:24 2020 +1200
```
But perhaps more usefully, changes of one entire dataset can be committed without committing changes in other datasets:
```
sno commit -m datasetA_changes datasetA
```

Resolves https://github.com/koordinates/sno/issues/69 (last blocker for 0.4 release)

Also gets rid of the working copy callback - working copy changes must now be called in a regular kind of way, instead of as a callback. This is because -
- the callback wasn't very necessary - it was called hundreds of times during the commit operation with arguments of "I", "U", "D", but these were no-ops, and then it was called once or twice after the commit operation with arguments like "INDEX", "TREE" - these didn't need to be callbacks since they could just be called by the caller once the commit operation completed
- there was only one implementation of the callback, so we may as well make explicit that the callback is actually just the working copy object
- the callback had special semantics - ie, the commit code had to know to call the callback with arguments like "I", "U", "D", "INDEX", "TREE". It wasn't just an arbitrary function that could be called without knowing what it was. So again, we may as well make these different operations methods on the working copy, and call them explicitly at the appropriate time. (If we do ever need to reintroduce the callback, it should probably have an interface)