### PR TITLE
Add a `meta get` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.5.0 (UNRELEASED)
+
+* Added a `sno meta get` command for viewing dataset metadata.
+
 ## 0.4.0
 
 ### Major changes in this release

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -19,6 +19,7 @@ from . import (
     init,
     fsck,
     merge,
+    meta,
     pull,
     resolve,
     show,
@@ -144,6 +145,7 @@ cli.add_command(fsck.fsck)
 cli.add_command(init.import_table)
 cli.add_command(init.init)
 cli.add_command(merge.merge)
+cli.add_command(meta.meta)
 cli.add_command(pull.pull)
 cli.add_command(resolve.resolve)
 cli.add_command(show.show)

--- a/sno/meta.py
+++ b/sno/meta.py
@@ -1,0 +1,75 @@
+import click
+
+from .output_util import dump_json_output, format_json_for_output, resolve_output_path
+from .structure import RepositoryStructure
+
+# Changing these items would generally break the repo;
+# we disallow that.
+READONLY_ITEMS = {
+    'primary_key',
+    'sqlite_table_info',
+    'fields',
+}
+
+
+@click.group()
+@click.pass_context
+def meta(ctx, **kwargs):
+    """
+    Read and update meta values for a dataset.
+    """
+
+
+@meta.command(name='get')
+@click.option(
+    "--output-format", "-o", type=click.Choice(["text", "json"]), default="text",
+)
+@click.option(
+    "--json-style",
+    type=click.Choice(["extracompact", "compact", "pretty"]),
+    default="pretty",
+    help="How to format the JSON output. Only used with -o json",
+)
+@click.option(
+    "--include-readonly/--exclude-readonly",
+    is_flag=True,
+    default=True,
+    help="Include readonly meta items",
+)
+@click.argument('dataset')
+@click.argument('keys', required=False, nargs=-1)
+@click.pass_context
+def meta_get(ctx, output_format, json_style, include_readonly, dataset, keys):
+    """
+    Prints the value of meta keys for the given dataset.
+    If no keys are given, all available values are printed.
+    """
+
+    rs = RepositoryStructure(ctx.obj.repo)
+
+    try:
+        ds = rs[dataset]
+    except KeyError:
+        raise click.UsageError(f"No such dataset: {dataset}")
+
+    exclude = () if include_readonly else READONLY_ITEMS
+    items = ds.iter_meta_items(exclude=exclude)
+    if keys:
+        items = [(k, v) for (k, v) in items if k in keys]
+        if len(items) != len(keys):
+            missing_keys = set(keys) - set(dict(items).keys())
+            raise click.UsageError(
+                f"Couldn't find items: {', '.join(sorted(missing_keys))}"
+            )
+
+    fp = resolve_output_path('-')
+    if output_format == 'text':
+        indent = '    '
+        for k, value in items:
+            click.secho(k, bold=True)
+            serialized = format_json_for_output(value, fp, json_style=json_style)
+            lines = serialized.splitlines()
+            for i, line in enumerate(lines):
+                fp.write(f"{indent}{line}\n")
+    else:
+        dump_json_output(dict(items), fp, json_style=json_style)

--- a/sno/output_util.py
+++ b/sno/output_util.py
@@ -14,13 +14,13 @@ JSON_PARAMS = {
 }
 
 
-def dump_json_output(output, output_path, json_style="pretty"):
+def format_json_for_output(output, fp, json_style="pretty"):
     """
-    Dumps the output to JSON in the output file.
+    Serializes JSON for writing to the given filelike object.
+    Doesn't actually write the JSON, just returns it.
+
+    Adds syntax highlighting if appropriate.
     """
-
-    fp = resolve_output_path(output_path)
-
     if json_style == 'pretty' and fp == sys.stdout and fp.isatty():
         # Add syntax highlighting
         from pygments import highlight
@@ -28,10 +28,19 @@ def dump_json_output(output, output_path, json_style="pretty"):
         from pygments.formatters import TerminalFormatter
 
         dumped = json.dumps(output, **JSON_PARAMS[json_style])
-        highlighted = highlight(dumped.encode(), JsonLexer(), TerminalFormatter())
-        fp.write(highlighted)
+        return highlight(dumped.encode(), JsonLexer(), TerminalFormatter())
     else:
-        json.dump(output, fp, **JSON_PARAMS[json_style])
+        # pygments adds a newline, best we do that here too for consistency
+        return json.dumps(output, **JSON_PARAMS[json_style]) + '\n'
+
+
+def dump_json_output(output, output_path, json_style="pretty"):
+    """
+    Dumps the output to JSON in the output file.
+    """
+
+    fp = resolve_output_path(output_path)
+    fp.write(format_json_for_output(output, fp, json_style=json_style))
 
 
 def resolve_output_path(output_path):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,76 @@
+import json
+import pytest
+
+
+class TestMetaGet:
+    def test_errors(self, data_archive_readonly, cli_runner):
+        with data_archive_readonly("points"):
+            r = cli_runner.invoke(["meta", "get", "nonexistent_dataset"])
+            assert r.exit_code == 2, r
+            assert 'No such dataset: nonexistent_dataset' in r.stderr
+
+            r = cli_runner.invoke(
+                ["meta", "get", "nz_pa_points_topo_150k", "nonexistent_meta"]
+            )
+            assert r.exit_code == 2, r
+            assert "Couldn't find items: nonexistent_meta" in r.stderr
+
+    @pytest.mark.parametrize("output_format", ("text", "json"))
+    def test_all(self, output_format, data_archive_readonly, cli_runner):
+        with data_archive_readonly("points"):
+            r = cli_runner.invoke(
+                ["meta", "get", "nz_pa_points_topo_150k", "-o", output_format]
+            )
+            assert r.exit_code == 0, r
+            if output_format == 'text':
+                assert 'fields/name_ascii\n    3\nfields/t50_fid\n    2' in r.stdout
+            else:
+                output = json.loads(r.stdout)
+                assert output['fields/name_ascii'] == 3
+
+    @pytest.mark.parametrize("output_format", ("text", "json"))
+    def test_all_exclude_readonly(
+        self, output_format, data_archive_readonly, cli_runner
+    ):
+        with data_archive_readonly("points"):
+            r = cli_runner.invoke(
+                [
+                    "meta",
+                    "get",
+                    "nz_pa_points_topo_150k",
+                    "-o",
+                    output_format,
+                    "--exclude-readonly",
+                ]
+            )
+            assert r.exit_code == 0, r
+            if output_format == 'text':
+                assert 'gpkg_contents\n' in r.stdout
+                assert 'fields/name_ascii' not in r.stdout
+            else:
+                output = json.loads(r.stdout)
+                assert 'gpkg_contents' in output
+                assert 'fields/name_ascii' not in output
+
+    @pytest.mark.parametrize("output_format", ("text", "json"))
+    def test_keys(self, output_format, data_archive_readonly, cli_runner):
+        with data_archive_readonly("points"):
+            r = cli_runner.invoke(
+                [
+                    "meta",
+                    "get",
+                    "nz_pa_points_topo_150k",
+                    "-o",
+                    output_format,
+                    "gpkg_contents",
+                    "fields/name_ascii",
+                ]
+            )
+            assert r.exit_code == 0, r
+            if output_format == 'text':
+                assert 'fields/name_ascii\n    3' in r.stdout
+                assert 'fields/t50_fid' not in r.stdout
+            else:
+                output = json.loads(r.stdout)
+                assert output['fields/name_ascii'] == 3
+                assert 'fields/t50_fid' not in output


### PR DESCRIPTION
## Description

I added a `meta` command that lets you view the `meta/` blobs in the repository.

In future we'll add write commands (I'm thinking (`add`, `replace`, `delete`) that will allow changes to the meta blobs. Some blobs are required to read the repo features, so those will be blacklisted from modification.

### Usage info:
```
$ sno meta --help
Usage: sno meta [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  get  Prints the value of meta keys for the given dataset.
```


```
$ sno meta get --help
Usage: sno meta get [OPTIONS] DATASET [KEYS]...

  Prints the value of meta keys for the given dataset. If no keys are given,
  all available values are printed.

Options:
  -o, --output-format [text|json]
  --json-style [extracompact|compact|pretty]
                                  How to format the JSON output. Only used
                                  with -o json

  --include-readonly / --exclude-readonly
                                  Include readonly meta items
  --help                          Show this message and exit.
```

### Output
<img width="1485" alt="Screen Shot 2020-06-25 at 11 37 57 AM" src="https://user-images.githubusercontent.com/32112/85637850-657b6c00-b6d8-11ea-8b7b-96fe26fe76f5.png">


## Related links:

This works towards #102 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
