### PR TITLE
Add curl-style commit message from file option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.5.0 (UNRELEASED)
 
 * Added a `sno meta get` command for viewing dataset metadata.
+* `merge`, `commit`, `init`, `import` commands can now take commit messages as files with `--message=@filename.txt`. This replaces the `sno commit -F` option.
 
 ## 0.4.0
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -1,5 +1,4 @@
 import functools
-import json
 import os
 import re
 import sys
@@ -13,7 +12,7 @@ from osgeo import gdal, ogr
 from sno import is_windows
 from . import gpkg, checkout, structure
 from .core import check_git_user
-from .cli_util import call_and_exit_flag, MutexOption
+from .cli_util import call_and_exit_flag, MutexOption, StringFromFile
 from .exceptions import (
     InvalidOperation,
     NotFound,
@@ -684,7 +683,10 @@ def list_import_formats(ctx, param, value):
     exclusive_with=["do_list", "tables"],
 )
 @click.option(
-    "--message", "-m", help="Commit message. By default this is auto-generated.",
+    "--message",
+    "-m",
+    type=StringFromFile(encoding='utf-8'),
+    help="Commit message. By default this is auto-generated.",
 )
 @click.option(
     "--list",
@@ -806,6 +808,7 @@ def import_table(
 @click.option(
     "--message",
     "-m",
+    type=StringFromFile(encoding='utf-8'),
     help="Commit message (when used with --import). By default this is auto-generated.",
 )
 @click.option(

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -4,7 +4,7 @@ import sys
 import click
 
 from . import commit
-from .cli_util import call_and_exit_flag
+from .cli_util import call_and_exit_flag, StringFromFile
 from .conflicts import (
     list_conflicts,
     conflicts_json_as_text,
@@ -335,7 +335,10 @@ def merge_status_to_text(jdict, fresh):
     help="Don't perform a merge - just show what would be done",
 )
 @click.option(
-    "--message", "-m", help="Use the given message as the commit message.",
+    "--message",
+    "-m",
+    type=StringFromFile(encoding='utf-8'),
+    help="Use the given message as the commit message.",
 )
 @click.option(
     "--output-format", "-o", type=click.Choice(["text", "json"]), default="text",

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -224,16 +224,18 @@ def test_commit_message(
             f.write("\ni am a message\n\n\n")
             f.flush()
 
-        r = cli_runner.invoke(["commit", "--allow-empty", "-F", f_commit_message])
+        r = cli_runner.invoke(
+            ["commit", "--allow-empty", f"--message=@{f_commit_message}"]
+        )
         assert r.exit_code == 0, r
         assert last_message() == "i am a message"
 
         # E: conflict
         r = cli_runner.invoke(
-            ["commit", "--allow-empty", "-F", f_commit_message, "-m", "foo"]
+            ["commit", "--allow-empty", f"--message=@{f_commit_message}", "-m", "foo"]
         )
-        assert r.exit_code == INVALID_ARGUMENT, r
-        assert "exclusive" in r.stderr
+        assert r.exit_code == 0, r
+        assert last_message() == "i am a message\n\nfoo"
 
         # multiple
         r = cli_runner.invoke(


### PR DESCRIPTION
## Description

Curl-style options were proposed at #102, and seem
useful for large text things like commit messages 👌

## Related links:

- #102 
- https://curl.haxx.se/docs/manpage.html (see `-F`)

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
