### PR TITLE
import: Options to set dataset metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 * Added a `sno meta get` command for viewing dataset metadata.
 * `merge`, `commit`, `init`, `import` commands can now take commit messages as files with `--message=@filename.txt`. This replaces the `sno commit -F` option.
+* `import`: Added `--table-info` option to set dataset metadata, when it can't be autodetected from the source database
 
 ## 0.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,22 @@
 #
 #    make py-requirements
 #
+attrs==19.3.0             # via jsonschema
 cached-property==1.5.1    # via pygit2
 certifi==2020.6.20        # via -r requirements/requirements.in
 cffi==1.14.0              # via pygit2
 click==7.1.2              # via -r requirements/requirements.in
+importlib-metadata==1.6.1  # via jsonschema
+jsonschema==3.2.0         # via -r requirements/requirements.in
 msgpack==0.6.2            # via -r requirements/requirements.in
 #psycopg2==2.8.5           # via -r requirements/requirements.in
 pycparser==2.20           # via cffi
 #pygit2==1.1.0             # via -r requirements/requirements.in
 pygments==2.6.1           # via -r requirements/requirements.in
+pyrsistent==0.16.0        # via jsonschema
 rtree==0.9.4              # via -r requirements/requirements.in
+six==1.15.0               # via jsonschema, pyrsistent
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@
 appnope==0.1.0            # via ipython
 aspectlib==1.5.1          # via -r requirements/test.txt, pytest-benchmark
 atomicwrites==1.4.0       # via -r requirements/test.txt, pytest
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+attrs==19.3.0             # via -r requirements/../requirements.txt, -r requirements/test.txt, jsonschema, pytest
 backcall==0.2.0           # via ipython
 cached-property==1.5.1    # via -r requirements/../requirements.txt, -r requirements/test.txt
 certifi==2020.6.20        # via -r requirements/../requirements.txt, -r requirements/test.txt
@@ -17,12 +17,13 @@ coverage==5.1             # via -r requirements/test.txt, pytest-cov
 decorator==4.4.2          # via ipython, traitlets
 fields==5.0.0             # via -r requirements/test.txt, aspectlib
 gprof2dot==2019.11.30     # via -r requirements/test.txt, pytest-profiling
-html5lib==1.0.1           # via -r requirements/test.txt
-importlib-metadata==1.6.1  # via -r requirements/test.txt, pluggy, pytest
-ipdb==0.13.2              # via -r requirements/dev.in
+html5lib==1.1             # via -r requirements/test.txt
+importlib-metadata==1.6.1  # via -r requirements/../requirements.txt, -r requirements/test.txt, jsonschema, pluggy, pytest
+ipdb==0.13.3              # via -r requirements/dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.15.0           # via -r requirements/dev.in, ipdb
 jedi==0.17.1              # via ipython
+jsonschema==3.2.0         # via -r requirements/../requirements.txt, -r requirements/test.txt
 lovely-pytest-docker==0.1.0  # via -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 msgpack==0.6.2            # via -r requirements/../requirements.txt, -r requirements/test.txt
@@ -34,10 +35,11 @@ pluggy==0.13.1            # via -r requirements/test.txt, pytest
 prompt-toolkit==3.0.5     # via ipython
 ptyprocess==0.6.0         # via pexpect
 py-cpuinfo==6.0.0         # via -r requirements/test.txt, pytest-benchmark
-py==1.8.2                 # via -r requirements/test.txt, pytest
+py==1.9.0                 # via -r requirements/test.txt, pytest
 pycparser==2.20           # via -r requirements/../requirements.txt, -r requirements/test.txt, cffi
 pygments==2.6.1           # via -r requirements/../requirements.txt, -r requirements/test.txt, ipython
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
+pyrsistent==0.16.0        # via -r requirements/../requirements.txt, -r requirements/test.txt, jsonschema
 pytest-benchmark[aspect]==3.2.3  # via -r requirements/test.txt
 pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-helpers-namespace==2019.1.8  # via -r requirements/test.txt
@@ -45,12 +47,12 @@ pytest-profiling==1.7.0   # via -r requirements/test.txt
 pytest-sugar==0.9.3       # via -r requirements/test.txt
 pytest==4.6.11            # via -r requirements/test.txt, lovely-pytest-docker, pytest-benchmark, pytest-cov, pytest-helpers-namespace, pytest-profiling, pytest-sugar
 rtree==0.9.4              # via -r requirements/../requirements.txt, -r requirements/test.txt
-six==1.15.0               # via -r requirements/test.txt, html5lib, packaging, pytest, pytest-profiling, traitlets
+six==1.15.0               # via -r requirements/../requirements.txt, -r requirements/test.txt, html5lib, jsonschema, packaging, pyrsistent, pytest, pytest-profiling, traitlets
 termcolor==1.1.0          # via -r requirements/test.txt, pytest-sugar
 traitlets==4.3.3          # via ipython
-wcwidth==0.2.4            # via -r requirements/test.txt, prompt-toolkit, pytest
+wcwidth==0.2.5            # via -r requirements/test.txt, prompt-toolkit, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
-zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
+zipp==3.1.0               # via -r requirements/../requirements.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,6 +3,7 @@ msgpack~=0.6.1
 Rtree~=0.9.4
 certifi
 Pygments
+jsonschema
 
 # these are only here for dependencies
 psycopg2==2.8.5

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 aspectlib==1.5.1          # via pytest-benchmark
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
+attrs==19.3.0             # via -r requirements/../requirements.txt, jsonschema, pytest
 cached-property==1.5.1    # via -r requirements/../requirements.txt
 certifi==2020.6.20        # via -r requirements/../requirements.txt
 cffi==1.14.0              # via -r requirements/../requirements.txt
@@ -14,18 +14,20 @@ click==7.1.2              # via -r requirements/../requirements.txt
 coverage==5.1             # via pytest-cov
 fields==5.0.0             # via aspectlib
 gprof2dot==2019.11.30     # via pytest-profiling
-html5lib==1.0.1           # via -r requirements/test.in
-importlib-metadata==1.6.1  # via pluggy, pytest
+html5lib==1.1             # via -r requirements/test.in
+importlib-metadata==1.6.1  # via -r requirements/../requirements.txt, jsonschema, pluggy, pytest
+jsonschema==3.2.0         # via -r requirements/../requirements.txt
 lovely-pytest-docker==0.1.0  # via -r requirements/test.in
 more-itertools==8.4.0     # via pytest
 msgpack==0.6.2            # via -r requirements/../requirements.txt
 packaging==20.4           # via pytest, pytest-sugar
 pluggy==0.13.1            # via pytest
 py-cpuinfo==6.0.0         # via pytest-benchmark
-py==1.8.2                 # via pytest
+py==1.9.0                 # via pytest
 pycparser==2.20           # via -r requirements/../requirements.txt, cffi
 pygments==2.6.1           # via -r requirements/../requirements.txt
 pyparsing==2.4.7          # via packaging
+pyrsistent==0.16.0        # via -r requirements/../requirements.txt, jsonschema
 pytest-benchmark[aspect]==3.2.3  # via -r requirements/test.in
 pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-helpers-namespace==2019.1.8  # via -r requirements/test.in
@@ -33,11 +35,11 @@ pytest-profiling==1.7.0   # via -r requirements/test.in
 pytest-sugar==0.9.3       # via -r requirements/test.in
 pytest==4.6.11            # via -r requirements/test.in, lovely-pytest-docker, pytest-benchmark, pytest-cov, pytest-helpers-namespace, pytest-profiling, pytest-sugar
 rtree==0.9.4              # via -r requirements/../requirements.txt
-six==1.15.0               # via html5lib, packaging, pytest, pytest-profiling
+six==1.15.0               # via -r requirements/../requirements.txt, html5lib, jsonschema, packaging, pyrsistent, pytest, pytest-profiling
 termcolor==1.1.0          # via pytest-sugar
-wcwidth==0.2.4            # via pytest
+wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via html5lib
-zipp==3.1.0               # via importlib-metadata
+zipp==3.1.0               # via -r requirements/../requirements.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Description

Adds a `--table-info` option which adds extra dataset metadata via a JSON object. Fixes #102

The JSON object is a bit smelly, but I tried hard to think of a better way and couldn't. Because the `import` command now imports multiple tables at once, we need a way to set title, description and xml metadata for multiple layers at once.

Some alternatives I tried:

1. `sno import SRC table1 --title=title2 table2 --title=title2`

This would probably be the nicest approach in terms of having a flat schema to the command line arguments, though it's a little at odds with how these commands _generally_ work I think.

I couldn't find any _simple_ way to do this in click. It's possible we could abuse [multi-command chaining](https://click.palletsprojects.com/en/7.x/commands/#multi-command-chaining) to do it if we tried really hard, but it'd be a hack.

2. `sno import SRC dataset1 dataset2 --dataset1-title title1 --dataset2-title title2`

This would work but it once again seems hard to do in click. We'd basically have to give up on the parser and accept _everything_ and handle validation ourselves.

3. this approach.

```
  --table-info JSON               Specifies overrides for imported tables, in
                                  a nested JSON object.  Each key is a dataset
                                  name, and each value is an object.  Valid
                                  overrides are 'title', 'description' and
                                  'xmlMetadata'. e.g.:  --table-
                                  info='{"land_parcels": {"title": "Land
                                  Parcels 1:50k"}' To import from a file,
                                  prefix with `@`, e.g. `--table-
                                  info=@filename.json`
```

<img width="1488" alt="Screen Shot 2020-06-26 at 4 38 58 PM" src="https://user-images.githubusercontent.com/32112/85820939-8ffa2180-b7cb-11ea-9a15-7027fae3df54.png">


The JSON validates to a schema, so if you do something unexpected, you'll get a verbose but slightly helpful error message:
<img width="1492" alt="Screen Shot 2020-06-26 at 4 37 48 PM" src="https://user-images.githubusercontent.com/32112/85820885-64773700-b7cb-11ea-9d33-db0e9a3c7b17.png">


## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/sno/issues) etc, link them here. -->

## Checklist:

- [ ] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
