### PR TITLE
Use fast import for 0.2 -> 0.5 upgrade

### DIFF
--- a/sno/dataset2.py
+++ b/sno/dataset2.py
@@ -64,17 +64,16 @@ def _bytes(data):
     return data
 
 
-def walk_tree_blobs(tree, path="", max_depth=4):
+def find_blobs_in_tree(tree, max_depth=4):
     """
-    Recursively yields all possible (file_path, file_data) tuples
-    in the given directory tree, up to a given max_depth.
+    Recursively yields possible blobs in the given directory tree,
+    up to a given max_depth.
     """
     for entry in tree:
-        entry_path = f"{path}/{entry.name}" if path else entry.name
         if hasattr(entry, "data"):
-            yield entry_path, entry.data
+            yield entry
         elif max_depth > 0:
-            yield from walk_tree_blobs(entry, entry_path, max_depth - 1)
+            yield from find_blobs_in_tree(entry, max_depth - 1)
 
 
 class Legend:
@@ -481,11 +480,9 @@ class Dataset2(DatasetStructure):
         # (but this is the interface shared by dataset1 at the moment.)
         if self.FEATURE_PATH not in self.tree:
             return
-        for feature_path, feature_data in walk_tree_blobs(
-            self.tree / self.FEATURE_PATH
-        ):
-            yield feature_path, self.get_feature(
-                path=feature_path, data=feature_data, keys=keys
+        for blob in find_blobs_in_tree(self.tree / self.FEATURE_PATH):
+            yield blob.name, self.get_feature(
+                path=blob.name, data=blob.data, keys=keys
             ),
 
     @classmethod

--- a/sno/fast_import.py
+++ b/sno/fast_import.py
@@ -1,0 +1,150 @@
+import logging
+import subprocess
+import time
+from pathlib import Path
+
+import click
+import pygit2
+
+from .exceptions import SubprocessError
+from .structure import DatasetStructure
+
+L = logging.getLogger("sno.fast_import")
+
+
+def fast_import_tables(
+    repo,
+    sources,
+    *,
+    version,
+    incremental=True,
+    quiet=False,
+    header=None,
+    message=None,
+    limit=None,
+    max_pack_size="2G",
+):
+    for path, source in sources.items():
+        if not source.table:
+            raise ValueError("No table specified")
+
+        if not repo.is_empty and incremental:
+            if path in repo.head.peel(pygit2.Tree):
+                raise ValueError(f"{path}/ already exists")
+
+    cmd = [
+        "git",
+        "fast-import",
+        "--quiet",
+        "--done",
+        f"--max-pack-size={max_pack_size}",
+    ]
+
+    if header is None:
+        header = generate_header(repo, sources, message)
+        cmd.append("--date-format=now")
+
+    if not quiet:
+        click.echo("Starting git-fast-import...")
+
+    p = subprocess.Popen(cmd, cwd=repo.path, stdin=subprocess.PIPE,)
+    try:
+        p.stdin.write(header.encode("utf8"))
+
+        if not repo.is_empty and incremental:
+            # start with the existing tree/contents
+            p.stdin.write(b"from refs/heads/master^0\n")
+
+        for path, source in sources.items():
+            dataset = DatasetStructure.for_version(version)(tree=None, path=path)
+
+            with source:
+                if limit:
+                    num_rows = min(limit, source.row_count)
+                    click.echo(
+                        f"Importing {num_rows:,d} of {source.row_count:,d} features from {source} to {path}/ ..."
+                    )
+                else:
+                    num_rows = source.row_count
+                    if not quiet:
+                        click.echo(
+                            f"Importing {num_rows:,d} features from {source} to {path}/ ..."
+                        )
+
+                for i, blob_path in write_blobs_to_stream(
+                    p.stdin, dataset.import_iter_meta_blobs(repo, source)
+                ):
+                    pass
+
+                # features
+                t1 = time.monotonic()
+                src_iterator = source.iter_features()
+
+                for i, blob_path in write_blobs_to_stream(
+                    p.stdin, dataset.import_iter_feature_blobs(src_iterator, source)
+                ):
+                    if i and i % 100000 == 0 and not quiet:
+                        click.echo(f"  {i:,d} features... @{time.monotonic()-t1:.1f}s")
+
+                    if limit is not None and i == (limit - 1):
+                        click.secho(f"  Stopping at {limit:,d} features", fg="yellow")
+                        break
+                t2 = time.monotonic()
+                if not quiet:
+                    click.echo(f"Added {num_rows:,d} Features to index in {t2-t1:.1f}s")
+                    click.echo(
+                        f"Overall rate: {(num_rows/(t2-t1 or 1E-3)):.0f} features/s)"
+                    )
+
+        p.stdin.write(b"\ndone\n")
+    except BrokenPipeError:
+        # if git-fast-import dies early, we get an EPIPE here
+        # we'll deal with it below
+        pass
+    else:
+        p.stdin.close()
+    p.wait()
+    if p.returncode != 0:
+        raise SubprocessError(
+            f"git-fast-import error! {p.returncode}", exit_code=p.returncode
+        )
+    t3 = time.monotonic()
+    if not quiet:
+        click.echo(f"Closed in {(t3-t2):.0f}s")
+
+
+def write_blobs_to_stream(stream, blobs):
+    for i, (blob_path, blob_data) in enumerate(blobs):
+        stream.write(
+            f"M 644 inline {blob_path}\ndata {len(blob_data)}\n".encode("utf8")
+        )
+        stream.write(blob_data)
+        stream.write(b"\n")
+        yield i, blob_path
+
+
+def generate_header(repo, sources, message):
+    if message is None:
+        message = generate_message(sources)
+
+    user = repo.default_signature
+    return (
+        "commit refs/heads/master\n"
+        f"committer {user.name} <{user.email}> now\n"
+        f"data {len(message.encode('utf8'))}\n{message}\n"
+    )
+
+
+def generate_message(sources):
+    if len(sources) == 1:
+        for path, source in sources.items():
+            message = f"Import from {Path(source.source).name} to {path}/"
+    else:
+        source = next(iter(sources.values()))
+        message = f"Import {len(sources)} datasets from '{Path(source.source).name}':\n"
+        for path, source in sources.items():
+            if path == source.table:
+                message += f"\n* {path}/"
+            else:
+                message += f"\n* {path} (from {source.table})"
+    return message

--- a/sno/init.py
+++ b/sno/init.py
@@ -21,6 +21,7 @@ from .exceptions import (
     NO_IMPORT_SOURCE,
     NO_TABLE,
 )
+from .fast_import import fast_import_tables
 from .ogr_util import adapt_value_noop, get_type_value_adapter
 from .output_util import dump_json_output, get_input_mode, InputMode
 from .timestamps import datetime_to_iso8601_utc
@@ -962,7 +963,7 @@ def import_table(
             xml_metadata=info.get('xmlMetadata'),
         )
 
-    structure.fast_import_tables(repo, loaders, message=message, version=version)
+    fast_import_tables(repo, loaders, message=message, version=version)
     rs = structure.RepositoryStructure(repo)
     if rs.working_copy:
         # Update working copy with new datasets
@@ -1029,7 +1030,7 @@ def init(ctx, do_checkout, message, directory, version, import_from):
     repo = pygit2.init_repository(str(repo_path), bare=True)
 
     if import_from:
-        structure.fast_import_tables(repo, loaders, message=message, version=version)
+        fast_import_tables(repo, loaders, message=message, version=version)
 
         if do_checkout:
             # Checkout a working copy


### PR DESCRIPTION
![](https://media1.giphy.com/media/3oAt1NNFH378qnqPKM/giphy.gif)

It is 3 to 4 times faster, but also, it means we don't need to have duplicated code -

- code for creating a v2 Dataset given a v1 Dataset (upgrade)
- code for creating a v2 Dataset, given an arbitrary list of features from an import source (import)

The upgrade case is just a special case of import, so making upgrade a type of import means less code - all of the creating v2 dataset code is deduplicated. And of course, it now uses fast-import which is fast.

Tested: upgraded dataset has the same hash as before the change, but works much faster. 