### PR TITLE
Fix git paths in packages (macOS/Linux)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,6 +298,7 @@ jobs:
         run: |
           sudo installer -pkg ${{ steps.package-Darwin.outputs.file }} -dumplog -target /
           readlink $(which sno)
+          tests/scripts/distcheck.sh
           PATH=/usr/local/opt/sqlite3/bin:$PATH tests/scripts/e2e-1.sh
 
       - name: "🐧 package: tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 * Added a `sno meta get` command for viewing dataset metadata.
 * `merge`, `commit`, `init`, `import` commands can now take commit messages as files with `--message=@filename.txt`. This replaces the `sno commit -F` option.
 * `import`: Added `--table-info` option to set dataset metadata, when it can't be autodetected from the source database
+* packaging: Fix issue with broken git component paths in packages on macOS and Linux (#143)
 
 ## 0.4.0
 
@@ -46,7 +47,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 * `sno diff`:
     - `a..b` now refers to the same changes as `sno log a..b` ([#116](https://github.com/koordinates/sno/issues/116))
     - can now diff against tree objects, particularly the empty tree ([#53](https://github.com/koordinates/sno/issues/53))
-    - can now view some subset of the changes by supplying filter args, ie `[dataset[:pk]]` 
+    - can now view some subset of the changes by supplying filter args, ie `[dataset[:pk]]`
 * `sno commit`:
     - can now commit some subset of the changes by supplying filter args, ie `[dataset[:pk]]` ([#69](https://github.com/koordinates/sno/issues/69))
 * removed `import-gpkg` command; use `import` instead ([#85](https://github.com/koordinates/sno/issues/85))

--- a/platforms/linux/test-archive.sh
+++ b/platforms/linux/test-archive.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
 HERE=$(dirname "$(readlink -f "$0")")
 USAGE="Usage: $0 deb|rpm ARCHIVE [target-distribution...]"
@@ -61,6 +61,7 @@ for DIST in ${TARGETS[*]}; do
 			command -v sno
 
 			sno --version
+			/src/tests/scripts/distcheck.sh
 			/src/tests/scripts/e2e-1.sh
 		EOF
 done

--- a/tests/scripts/distcheck.sh
+++ b/tests/scripts/distcheck.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eu
+
+if ! command -v realpath >/dev/null; then
+    # MacOS doesn't have realpath or readlink -f by default
+    function realpath() {
+        python -c 'import os, sys; print os.path.realpath(sys.argv[1])' "$1"
+    }
+fi
+
+SNO_PATH=$(dirname "$(realpath "$(command -v sno)")")
+if [ "$(uname)" = "Darwin" ] && [[ "$SNO_PATH" =~ ^/Applications ]]; then
+    SNO_PATH="$(realpath "$SNO_PATH/../..")"
+fi
+echo "Sno is at: ${SNO_PATH}"
+
+if ! command -v find >/dev/null; then
+    echo "⚠️ Skipping symlink checks, find isn't available"
+else
+    echo "Checking for any broken symlinks..."
+    BROKEN_LINKS=($(find "$SNO_PATH" -type l ! -exec test -e {} \; -print))
+    if (( ${#BROKEN_LINKS[@]} )); then
+        ls -l "${BROKEN_LINKS[@]}"
+        exit 1
+    fi
+fi
+
+echo "✅ Success"


### PR DESCRIPTION
## Description

On macOS, two git dependency libraries (libintl, libpcre) were symlinked from `/Sno.app/Contents/Resources/libexec/git-core/` via `../../lib/`, but that's broken in the dist packaging (needs to be `../../../MacOS/`).

Similarly on Linux in the dist packaging, the symlinked `git-*` binaries were pointing to `../../bin/git` instead of `../../git`.

Adds a test to find any broken symlinks in the built packages.

## Checklist:

- [X] Have you reviewed your own change?
- [X] Have you included test(s)?
- [X] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
