### PR TITLE
Report progress in push, pull, fetch, clone.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 * `merge`, `commit`, `init`, `import` commands can now take commit messages as files with `--message=@filename.txt`. This replaces the `sno commit -F` option.
 * `import`: Added `--table-info` option to set dataset metadata, when it can't be autodetected from the source database
 * packaging: Fix issue with broken git component paths in packages on macOS and Linux (#143)
+* `pull`, `push, `fetch`, `clone` commands now show progress - disabled with `--quiet` (#144)
 
 ## 0.4.0
 

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -177,18 +177,52 @@ def log(ctx, args):
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.pass_context
+@click.option(
+    "--progress/--quiet",
+    "do_progress",
+    is_flag=True,
+    default=True,
+    help="Whether to report progress to stderr",
+)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
-def push(ctx, args):
+def push(ctx, do_progress, args):
     """ Update remote refs along with associated objects """
-    execvp("git", ["git", "-C", ctx.obj.repo.path, "push"] + list(args))
+    execvp(
+        "git",
+        [
+            "git",
+            "-C",
+            ctx.obj.repo.path,
+            "push",
+            "--progress" if do_progress else "--quiet",
+        ]
+        + list(args),
+    )
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.pass_context
+@click.option(
+    "--progress/--quiet",
+    "do_progress",
+    is_flag=True,
+    default=True,
+    help="Whether to report progress to stderr",
+)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
-def fetch(ctx, args):
+def fetch(ctx, do_progress, args):
     """ Download objects and refs from another repository """
-    execvp("git", ["git", "-C", ctx.obj.repo.path, "fetch"] + list(args))
+    execvp(
+        "git",
+        [
+            "git",
+            "-C",
+            ctx.obj.repo.path,
+            "fetch",
+            "--progress" if do_progress else "--quiet",
+        ]
+        + list(args),
+    )
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))

--- a/sno/clone.py
+++ b/sno/clone.py
@@ -35,13 +35,20 @@ def get_directory_from_url(url):
     default=True,
     help="Whether to checkout a working copy in the repository",
 )
+@click.option(
+    "--progress/--quiet",
+    "do_progress",
+    is_flag=True,
+    default=True,
+    help="Whether to report progress to stderr",
+)
 @click.argument("url", nargs=1)
 @click.argument(
     "directory",
     type=click.Path(exists=False, file_okay=False, writable=True),
     required=False,
 )
-def clone(ctx, do_checkout, url, directory):
+def clone(ctx, do_checkout, do_progress, url, directory):
     """ Clone a repository into a new directory """
 
     repo_path = Path(directory or get_directory_from_url(url))
@@ -52,6 +59,7 @@ def clone(ctx, do_checkout, url, directory):
         [
             "git",
             "clone",
+            "--progress" if do_progress else "--quiet",
             "--bare",
             "--config",
             "remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*",


### PR DESCRIPTION
### Description
These commands delegate to git commands internally, so the git `--progress` option is sufficient to show progress.

### Related links:
https://github.com/koordinates/sno/issues/145

Changelog is updated.
Existing tests pass.