### PR TITLE
Odds & ends: make working-copy diff work for datasets v2

### DIFF
--- a/sno/dataset1.py
+++ b/sno/dataset1.py
@@ -181,10 +181,7 @@ class Dataset1(DatasetStructure):
 
     def get_feature(self, pk_value, *, ogr_geoms=True):
         blob = self._get_feature(pk_value)
-        return (
-            blob.name,
-            self.repo_feature_to_dict(blob.name, blob.data, ogr_geoms=ogr_geoms),
-        )
+        return self.repo_feature_to_dict(blob.name, blob.data, ogr_geoms=ogr_geoms)
 
     def get_feature_tuples(self, pk_values, col_names, *, ignore_missing=False):
         tupleizer = self.build_feature_tupleizer(col_names)
@@ -407,7 +404,7 @@ class Dataset1(DatasetStructure):
                 )
                 continue
 
-            _, existing_feature = self.get_feature(old_pk, ogr_geoms=False)
+            existing_feature = self.get_feature(old_pk, ogr_geoms=False)
             if geom_column_name:
                 # FIXME: actually compare the geometries here.
                 # Turns out this is quite hard - geometries are hard to compare sanely.
@@ -487,7 +484,7 @@ class Dataset1(DatasetStructure):
 
                 self.L.debug("diff(): D %s (%s)", d.old_file.path, my_pk)
 
-                _, my_obj = this.get_feature(my_pk, ogr_geoms=False)
+                my_obj = this.get_feature(my_pk, ogr_geoms=False)
 
                 candidates_del[str(my_pk)].append((str(my_pk), my_obj))
             elif d.status == pygit2.GIT_DELTA_MODIFIED:
@@ -504,8 +501,8 @@ class Dataset1(DatasetStructure):
                     other_pk,
                 )
 
-                _, my_obj = this.get_feature(my_pk, ogr_geoms=False)
-                _, other_obj = other.get_feature(other_pk, ogr_geoms=False)
+                my_obj = this.get_feature(my_pk, ogr_geoms=False)
+                other_obj = other.get_feature(other_pk, ogr_geoms=False)
 
                 candidates_upd[str(my_pk)] = (my_obj, other_obj)
             elif d.status == pygit2.GIT_DELTA_ADDED:
@@ -515,7 +512,7 @@ class Dataset1(DatasetStructure):
 
                 self.L.debug("diff(): A %s (%s)", d.new_file.path, other_pk)
 
-                _, other_obj = other.get_feature(other_pk, ogr_geoms=False)
+                other_obj = other.get_feature(other_pk, ogr_geoms=False)
 
                 candidates_ins[str(other_pk)].append(other_obj)
             else:

--- a/sno/merge_util.py
+++ b/sno/merge_util.py
@@ -541,7 +541,7 @@ class RichConflictVersion:
     @property
     def feature(self):
         assert self.is_feature
-        _, feature = self.dataset.get_feature(self.pk, ogr_geoms=False)
+        feature = self.dataset.get_feature(self.pk, ogr_geoms=False)
         return feature
 
     @property

--- a/sno/query.py
+++ b/sno/query.py
@@ -75,7 +75,7 @@ def query(ctx, path, command, params):
             lookup = params[0]
 
         t0 = time.monotonic()
-        results = dataset.get_feature(lookup)[1]
+        results = dataset.get_feature(lookup)
         t1 = time.monotonic()
 
     elif command == "geo-nearest":
@@ -93,9 +93,7 @@ def query(ctx, path, command, params):
 
         index = dataset.get_spatial_index(path)
         t0 = time.monotonic()
-        results = [
-            dataset.get_feature(pk)[1] for pk in index.nearest(coordinates, limit)
-        ]
+        results = [dataset.get_feature(pk) for pk in index.nearest(coordinates, limit)]
         t1 = time.monotonic()
 
     elif command == "geo-intersects":
@@ -109,7 +107,7 @@ def query(ctx, path, command, params):
 
         index = dataset.get_spatial_index(path)
         t0 = time.monotonic()
-        results = [dataset.get_feature(pk)[1] for pk in index.intersection(coordinates)]
+        results = [dataset.get_feature(pk) for pk in index.intersection(coordinates)]
         t1 = time.monotonic()
 
     elif command == "geo-count":

--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -325,7 +325,10 @@ class WorkingCopyGPKG(WorkingCopy):
                 dbcur.execute(sql, values)
 
     def read_meta(self, dataset):
-        yield ("version", {"version": dataset.version})
+        if dataset.version == "1.0":
+            # TODO: we shouldn't be diffing dataset version to working copy version.
+            # Instead, we should just be helping the user upgrade to the latest version.
+            yield ("version", {"version": dataset.version})
         with self.session() as db:
             yield from gpkg.get_meta_info(db, dataset.name)
 
@@ -691,12 +694,13 @@ class WorkingCopy_GPKG_1(WorkingCopyGPKG):
             candidates_ins = collections.defaultdict(list)
             candidates_upd = {}
             candidates_del = collections.defaultdict(list)
+
             for row in dbcur:
                 track_pk = row[0]
                 db_obj = {k: row[k] for k in row.keys() if k != ".__track_pk"}
 
                 try:
-                    _, repo_obj = dataset.get_feature(track_pk, ogr_geoms=False)
+                    repo_obj = dataset.get_feature(track_pk, ogr_geoms=False)
                 except KeyError:
                     repo_obj = None
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -29,9 +29,11 @@ def _check_html_output(s):
 
 
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)
-def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
+@pytest.mark.parametrize("version", ["1.0", "2.0"])
+def test_diff_points(version, output_format, data_working_copy, geopackage, cli_runner):
     """ diff the working copy against HEAD """
-    with data_working_copy("points") as (repo, wc):
+    data_archive = "points2" if version == "2.0" else "points"
+    with data_working_copy(data_archive) as (repo, wc):
         # empty
         r = cli_runner.invoke(
             ["diff", f"--output-format={output_format}", "--output=-", "--exit-code"]
@@ -277,9 +279,13 @@ def test_diff_points(output_format, data_working_copy, geopackage, cli_runner):
 
 
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)
-def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner):
+@pytest.mark.parametrize("version", ["1.0", "2.0"])
+def test_diff_polygons(
+    version, output_format, data_working_copy, geopackage, cli_runner
+):
     """ diff the working copy against HEAD """
-    with data_working_copy("polygons") as (repo, wc):
+    data_archive = "polygons2" if version == "2.0" else "polygons"
+    with data_working_copy(data_archive) as (repo, wc):
         # empty
         r = cli_runner.invoke(
             ["diff", f"--output-format={output_format}", "--output=-", "--exit-code"]
@@ -611,9 +617,11 @@ def test_diff_polygons(output_format, data_working_copy, geopackage, cli_runner)
 
 
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)
-def test_diff_table(output_format, data_working_copy, geopackage, cli_runner):
+@pytest.mark.parametrize("version", ["1.0", "2.0"])
+def test_diff_table(version, output_format, data_working_copy, geopackage, cli_runner):
     """ diff the working copy against HEAD """
-    with data_working_copy("table") as (repo, wc):
+    data_archive = "table2" if version == "2.0" else "table"
+    with data_working_copy(data_archive) as (repo, wc):
         # empty
         r = cli_runner.invoke(
             ["diff", f"--output-format={output_format}", "--output=-", "--exit-code"]

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -28,7 +28,7 @@ def delete_remaining_conflicts(cli_runner):
 
 def get_json_feature(rs, layer, pk):
     try:
-        _, feature = rs[layer].get_feature(pk, ogr_geoms=False)
+        feature = rs[layer].get_feature(pk, ogr_geoms=False)
         return json_row(feature, H.POLYGONS.LAYER_PK)
     except KeyError:
         return None

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -777,7 +777,8 @@ def test_feature_find_decode_performance(
             feature_data = (tree / dataset.get_feature_path(pk)).data
             benchmark(dataset.repo_feature_to_dict, feature_path, feature_data)
         elif import_version == "2.0":
-            feature_path = dataset.encode_pk_values_to_path(pk)
+            pk_values = dataset.schema.sanitise_pk_values(pk)
+            feature_path = dataset.encode_pk_values_to_path(pk_values)
             feature_data = dataset.get_data_at(feature_path)
             benchmark(dataset.get_feature, path=feature_path, data=feature_data)
     else:


### PR DESCRIPTION
![](https://media2.giphy.com/media/xULW8mDtDwNL1C1N7i/giphy-downsized-medium.gif)
## Description

Datasets v1 and v2 interfaces are pretty similar (eventually they should either have the same public interface, or v1 should be deleted, whichever comes first). They were almost similar enough for the dataset<->gpkg-working-copy diff code to work. I have made a few more changes now so that it does, and enabled those tests.

### Still TODO
(in the area of diffs specifically):
- meta item diffs (needs to be rewritten)
- writing commits (which is based on diffs)

### Changes to v2 datasets
- a few new methods, some of which hopefully won't stay in the interface forever:
    `primary_key(self)` `encode_feature_blob(self, feature)`
- handle primary key values that should be ints, but arrived as strings
- accept `ogr_geoms` flag even though it's not supported

### Changes to v1 datasets
- `get_feature` now just returns a feature, not a `(path, feature)` tuple - none of the callers were using the path anyway.