### PR TITLE
get_meta_item and iter_meta_item updated for V2

### DIFF
--- a/sno/gpkg_adapter.py
+++ b/sno/gpkg_adapter.py
@@ -8,7 +8,7 @@ GPKG_META_ITEMS = (
     "gpkg_geometry_columns",
     "gpkg_spatial_ref_sys",
     "sqlite_table_info",
-    "gkpg_metadata",
+    "gpkg_metadata",
     "gpkg_metadata_reference",
 )
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -228,8 +228,8 @@ def _compare_ogr_and_gpkg_meta_items(dataset, gpkg_dataset):
     There are all sorts of caveats to the meta item emulation, and this attempts
     to avoid them when comparing.
     """
-    meta_items = dict(dataset.iter_meta_items())
-    gpkg_meta_items = dict(gpkg_dataset.iter_meta_items())
+    meta_items = dict(dataset.iter_meta_items(include_hidden=True))
+    gpkg_meta_items = dict(gpkg_dataset.iter_meta_items(include_hidden=True))
 
     # we don't implement XML metadata for non-gpkg formats
     del gpkg_meta_items['gpkg_metadata']
@@ -508,7 +508,7 @@ def test_shp_import_meta(
         tree = repo.head.peel(pygit2.Tree) / path
         dataset = structure.DatasetStructure.instantiate(tree, path)
 
-        meta_items = dict(dataset.iter_meta_items())
+        meta_items = dict(dataset.iter_meta_items(include_hidden=True))
         assert set(meta_items) == {
             'gpkg_contents',
             'gpkg_geometry_columns',
@@ -637,7 +637,7 @@ def test_pg_import(
         tree = repo.head.peel(pygit2.Tree) / path
         dataset = structure.DatasetStructure.instantiate(tree, path)
 
-        meta_items = dict(dataset.iter_meta_items())
+        meta_items = dict(dataset.iter_meta_items(include_hidden=True))
         assert set(meta_items.keys()) == {
             'fields/geom',
             'version',


### PR DESCRIPTION
![](https://media3.giphy.com/media/gY5sEujrJbCve/giphy.gif)

get_meta_item now:
- works for both v1 and v2 
- always return JSON serialisable objects
- never returns JSON embedded in strings
- generates adapted items on the fly when it is possible to do so

iter_meta_item now:
- works for both v1 and v2
- doesn't require the caller to know which items are "internal-only" and should be excluded - automatically excludes internal-only data.
- is now mostly only used by the `sno meta get` (show all metadata) - other callers mostly know which metadata they need and request it specifically, which is preferable since datasets already have redundant metadata and might have even more later (eg the same metadata in xml / json / geopackage / postgres format)

`sno meta get` now:
- doesn't iterate through iter_meta_items to find a single item

Also:
Moved common versions of these functions into dataset superclass, or empty definitions that raise NotImplementedError