### PR TITLE
Don't create deltas when doing imports

### DIFF
--- a/sno/fast_import.py
+++ b/sno/fast_import.py
@@ -25,6 +25,7 @@ def fast_import_tables(
     message=None,
     limit=None,
     max_pack_size="2G",
+    max_delta_depth=0,
     extra_blobs=(),
 ):
     structure_version = int(structure_version)
@@ -55,6 +56,7 @@ def fast_import_tables(
         "--quiet",
         "--done",
         f"--max-pack-size={max_pack_size}",
+        f"--depth={max_delta_depth}",
     ]
 
     if header is None:

--- a/sno/init.py
+++ b/sno/init.py
@@ -898,6 +898,13 @@ def list_import_formats(ctx, param, value):
     "--primary-key",
     help="Which field to use as the primary key. Must be unique. Auto-detected when possible.",
 )
+@click.option(
+    "--max-delta-depth",
+    hidden=True,
+    default=0,
+    type=click.INT,
+    help="--depth option to git-fast-import (advanced users only)",
+)
 def import_table(
     ctx,
     all_tables,
@@ -909,6 +916,7 @@ def import_table(
     source,
     tables,
     table_info,
+    max_delta_depth,
 ):
     """
     Import data into a repository.
@@ -969,7 +977,13 @@ def import_table(
             xml_metadata=info.get('xmlMetadata'),
         )
 
-    fast_import_tables(repo, loaders, message=message, structure_version=version)
+    fast_import_tables(
+        repo,
+        loaders,
+        message=message,
+        structure_version=version,
+        max_delta_depth=max_delta_depth,
+    )
     rs = structure.RepositoryStructure(repo)
     if rs.working_copy:
         # Update working copy with new datasets
@@ -1007,7 +1021,14 @@ def import_table(
     default=str(DEFAULT_STRUCTURE_VERSION),
     hidden=True,
 )
-def init(ctx, do_checkout, message, directory, version, import_from):
+@click.option(
+    "--max-delta-depth",
+    hidden=True,
+    default=0,
+    type=click.INT,
+    help="--depth option to git-fast-import (advanced users only)",
+)
+def init(ctx, do_checkout, message, directory, version, import_from, max_delta_depth):
     """
     Initialise a new repository and optionally import data.
     DIRECTORY must be empty. Defaults to the current directory.
@@ -1036,7 +1057,13 @@ def init(ctx, do_checkout, message, directory, version, import_from):
     repo = pygit2.init_repository(str(repo_path), bare=True)
 
     if import_from:
-        fast_import_tables(repo, loaders, message=message, structure_version=version)
+        fast_import_tables(
+            repo,
+            loaders,
+            message=message,
+            structure_version=version,
+            max_delta_depth=max_delta_depth,
+        )
 
         if do_checkout:
             # Checkout a working copy


### PR DESCRIPTION

## Description

Creating deltas slows down imports by quite a lot.
It may also cause checkouts to perform suboptimally, especially when
iterating over all features (checkouts, large diffs, etc).

In #159 this improved checkout speed by 250%.

This is likely inferior to doing `git gc --aggressive` after
importing, but also *much* faster.

If the caller wants to do an aggressive gc *after* the import to improve
the efficiency of the repo even more, that's their prerogative.

## Related links:

- #159 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
