### PR TITLE
Fix merge / conflicts / resolve for V2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,24 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
  * A new repository structure/layout, which will support schema changes. Internally known as Datasets V2.
     - Unlike Datasets V1, the schema can be modified without rewriting every row in a dataset.
-    - However, new repositories are still V1 repositories unless V2 is explicitly requested, since V2 is nowhere near full featured.
-    - Repositories (not datasets) are now versioned. When the first dataset is imported, the repository is marked as either V1 or V2.
+    - However, new repositories are still V1 repositories unless V2 is explicitly requested, since V2 is not yet full featured.
     - Tracking issue [#72](https://github.com/koordinates/sno/issues/72)
 
-### Progress on the new structure/layout (Datasets V2)
+### Using Datasets V1
 
- * Data can be imported into Datasets V2.
- * Repositories can be upgraded from V1 to V2 with `sno upgrade 02-05`.
- * A working copy can be checked out and features can be modified, diffed and committed.
+ * Unless specific action is taken, existing repositories will remain V1, and new repositories still default to V1.
+
+### Using Datasets V2
+
+ * An entire repository must be either V1 or V2, so to use V2, all data must be imported as V2.
+ * Data can be imported as V2 using `sno init --import=<data> --version=2` or `sno import <data> --version=2`
+ * Entire repositories can be upgraded from V1 to V2 with `sno upgrade 02-05 <old_repo> <new_repo>`.
+ * Most functionality from V1 is available in V2, but there may be some bugs.
 
 #### Important missing functionality in Datasets V2
 
  * Geometry storage format is not yet finalised.
- * Merges and conflicts don't work properly.
+ * Schema / meta changes cannot be committed or diffed (note: also missing from V1).
 
 ## 0.4.1
 

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -279,7 +279,12 @@ def merge_status_to_text(jdict, fresh):
                 "(Not actually merging due to --dry-run)"
             )
         else:
-            no_conflicts_text = f"No conflicts!\nMerge commited as {commit}"
+            if fresh:
+                no_conflicts_text = f"No conflicts!\nMerge commited as {commit}"
+            else:
+                no_conflicts_text = (
+                    f"No conflicts!\nUse `sno merge --continue` to complete the merge"
+                )
         return "\n".join([merging_text, no_conflicts_text])
 
     conflicts_header = "Conflicts found:" if fresh else "Conflicts:"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -715,10 +715,13 @@ def update(request, cli_runner):
 
 
 @pytest.fixture
-def create_conflicts(data_working_copy, geopackage, cli_runner, update, insert):
+def create_conflicts(
+    data_working_copy, geopackage, cli_runner, update, insert,
+):
     @contextlib.contextmanager
-    def ctx(data):
-        with data_working_copy(data.ARCHIVE) as (repo_path, wc):
+    def ctx(data, structure_version=1):
+        archive = f"{data.ARCHIVE}2" if structure_version == 2 else data.ARCHIVE
+        with data_working_copy(archive) as (repo_path, wc):
             repo = pygit2.Repository(str(repo_path))
             sample_pks = data.SAMPLE_PKS
 

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -7,9 +7,13 @@ from sno.structs import CommitWithReference
 H = pytest.helpers.helpers()
 
 
-def test_merge_index_roundtrip(create_conflicts, cli_runner):
+V1_OR_V2 = ("structure_version", ["1", "2"])
+
+
+@pytest.mark.parametrize(*V1_OR_V2)
+def test_merge_index_roundtrip(structure_version, create_conflicts, cli_runner):
     # Difficult to create conflict indexes directly - easier to create them by doing a merge:
-    with create_conflicts(H.POLYGONS) as repo:
+    with create_conflicts(H.POLYGONS, structure_version) as repo:
         ancestor = CommitWithReference.resolve(repo, "ancestor_branch")
         ours = CommitWithReference.resolve(repo, "ours_branch")
         theirs = CommitWithReference.resolve(repo, "theirs_branch")
@@ -52,9 +56,10 @@ def test_merge_index_roundtrip(create_conflicts, cli_runner):
         assert r2 == r1
 
 
-def test_summarise_conflicts(create_conflicts, cli_runner):
+@pytest.mark.parametrize(*V1_OR_V2)
+def test_summarise_conflicts(structure_version, create_conflicts, cli_runner):
     # Difficult to create conflict indexes directly - easier to create them by doing a merge:
-    with create_conflicts(H.POLYGONS) as repo:
+    with create_conflicts(H.POLYGONS, structure_version) as repo:
         r = cli_runner.invoke(["merge", "theirs_branch"])
 
         r = cli_runner.invoke(["conflicts", "-s"])
@@ -94,8 +99,9 @@ def test_summarise_conflicts(create_conflicts, cli_runner):
         }
 
 
-def test_list_conflicts(create_conflicts, cli_runner):
-    with create_conflicts(H.POINTS) as repo:
+@pytest.mark.parametrize(*V1_OR_V2)
+def test_list_conflicts(structure_version, create_conflicts, cli_runner):
+    with create_conflicts(H.POINTS, structure_version) as repo:
         r = cli_runner.invoke(["merge", "theirs_branch"])
 
         expected_text = [

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -17,18 +17,22 @@ from sno.repo_files import (
 
 H = pytest.helpers.helpers()
 
+V1_OR_V2 = ("structure_version", ["1", "2"])
+
 
 @pytest.mark.parametrize(
-    "archive",
+    "data",
     [
-        pytest.param("points", id="points"),
-        pytest.param("polygons", id="polygons"),
-        pytest.param("table", id="table"),
+        pytest.param(H.POINTS, id="points",),
+        pytest.param(H.POLYGONS, id="polygons",),
+        pytest.param(H.TABLE, id="table"),
     ],
 )
+@pytest.mark.parametrize(*V1_OR_V2)
 def test_merge_fastforward(
-    archive, data_working_copy, geopackage, cli_runner, insert, request
+    structure_version, data, data_working_copy, geopackage, cli_runner, insert, request
 ):
+    archive = f"{data.ARCHIVE}2" if structure_version == 2 else data.ARCHIVE
     with data_working_copy(archive) as (repo_path, wc):
         repo = pygit2.Repository(str(repo_path))
         # new branch
@@ -64,16 +68,25 @@ def test_merge_fastforward(
 
 
 @pytest.mark.parametrize(
-    "archive",
+    "data",
     [
-        pytest.param("points", id="points"),
-        pytest.param("polygons", id="polygons"),
-        pytest.param("table", id="table"),
+        pytest.param(H.POINTS, id="points",),
+        pytest.param(H.POLYGONS, id="polygons",),
+        pytest.param(H.TABLE, id="table"),
     ],
 )
+@pytest.mark.parametrize(*V1_OR_V2)
 def test_merge_fastforward_noff(
-    archive, data_working_copy, geopackage, cli_runner, insert, request, disable_editor
+    structure_version,
+    data,
+    data_working_copy,
+    geopackage,
+    cli_runner,
+    insert,
+    request,
+    disable_editor,
 ):
+    archive = f"{data.ARCHIVE}2" if structure_version == 2 else data.ARCHIVE
     with data_working_copy(archive) as (repo_path, wc):
         repo = pygit2.Repository(str(repo_path))
         # new branch
@@ -114,17 +127,17 @@ def test_merge_fastforward_noff(
 
 
 @pytest.mark.parametrize(
-    "archive,layer,pk_field",
+    "data",
     [
-        pytest.param("points", H.POINTS.LAYER, H.POINTS.LAYER_PK, id="points"),
-        pytest.param("polygons", H.POLYGONS.LAYER, H.POLYGONS.LAYER_PK, id="polygons"),
-        pytest.param("table", H.TABLE.LAYER, H.TABLE.LAYER_PK, id="table"),
+        pytest.param(H.POINTS, id="points",),
+        pytest.param(H.POLYGONS, id="polygons",),
+        pytest.param(H.TABLE, id="table"),
     ],
 )
+@pytest.mark.parametrize(*V1_OR_V2)
 def test_merge_true(
-    archive,
-    layer,
-    pk_field,
+    structure_version,
+    data,
     data_working_copy,
     geopackage,
     cli_runner,
@@ -132,6 +145,7 @@ def test_merge_true(
     request,
     disable_editor,
 ):
+    archive = f"{data.ARCHIVE}2" if structure_version == 2 else data.ARCHIVE
     with data_working_copy(archive) as (repo_path, wc):
         repo = pygit2.Repository(str(repo_path))
         # new branch
@@ -180,7 +194,7 @@ def test_merge_true(
         # check the database state
         num_inserts = len(insert.inserted_fids)
         dbcur.execute(
-            f"SELECT COUNT(*) FROM {layer} WHERE {pk_field} IN ({','.join(['?']*num_inserts)});",
+            f"SELECT COUNT(*) FROM {data.LAYER} WHERE {data.LAYER_PK} IN ({','.join(['?']*num_inserts)});",
             insert.inserted_fids,
         )
         assert dbcur.fetchone()[0] == num_inserts
@@ -200,10 +214,11 @@ def test_merge_true(
 @pytest.mark.parametrize(
     "dry_run", [pytest.param(False, id=""), pytest.param(True, id="dryrun")],
 )
+@pytest.mark.parametrize(*V1_OR_V2)
 def test_merge_conflicts(
-    data, output_format, dry_run, create_conflicts, cli_runner,
+    structure_version, data, output_format, dry_run, create_conflicts, cli_runner,
 ):
-    with create_conflicts(data) as repo:
+    with create_conflicts(data, structure_version) as repo:
         ancestor = CommitWithReference.resolve(repo, "ancestor_branch")
         ours = CommitWithReference.resolve(repo, "ours_branch")
         theirs = CommitWithReference.resolve(repo, "theirs_branch")
@@ -288,8 +303,9 @@ def test_merge_conflicts(
         assert not repo_file_exists(repo, MERGE_INDEX)
 
 
-def test_merge_state_lock(create_conflicts, cli_runner):
-    with create_conflicts(H.POINTS) as repo:
+@pytest.mark.parametrize(*V1_OR_V2)
+def test_merge_state_lock(structure_version, create_conflicts, cli_runner):
+    with create_conflicts(H.POINTS, structure_version) as repo:
         # Repo state: normal
         # sno checkout works, but sno conflicts and sno resolve do not.
         assert RepoState.get_state(repo) == RepoState.NORMAL

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -10,6 +10,8 @@ from sno.structure import RepositoryStructure
 
 H = pytest.helpers.helpers()
 
+V1_OR_V2 = ("structure_version", ["1", "2"])
+
 
 def get_conflict_ids(cli_runner):
     r = cli_runner.invoke(["conflicts", "-s", "--flat", "-o", "json"])
@@ -34,8 +36,11 @@ def get_json_feature(rs, layer, pk):
         return None
 
 
-def test_resolve_with_version(create_conflicts, cli_runner, disable_editor):
-    with create_conflicts(H.POLYGONS) as repo:
+@pytest.mark.parametrize(*V1_OR_V2)
+def test_resolve_with_version(
+    structure_version, create_conflicts, cli_runner, disable_editor
+):
+    with create_conflicts(H.POLYGONS, structure_version) as repo:
         r = cli_runner.invoke(["merge", "theirs_branch", "-o", "json"])
         assert r.exit_code == 0, r
         assert json.loads(r.stdout)["sno.merge/v1"]["conflicts"]
@@ -105,8 +110,11 @@ def test_resolve_with_version(create_conflicts, cli_runner, disable_editor):
         assert get_json_feature(merged, l, pk3) is None
 
 
-def test_resolve_with_file(create_conflicts, cli_runner, disable_editor):
-    with create_conflicts(H.POLYGONS) as repo:
+@pytest.mark.parametrize(*V1_OR_V2)
+def test_resolve_with_file(
+    structure_version, create_conflicts, cli_runner, disable_editor
+):
+    with create_conflicts(H.POLYGONS, structure_version) as repo:
         r = cli_runner.invoke(["diff", "ancestor_branch..ours_branch", "-o", "geojson"])
         assert r.exit_code == 0, r
         ours_geojson = json.loads(r.stdout)["features"][0]


### PR DESCRIPTION
![](https://media2.giphy.com/media/l09Cqx9PUMCPi8H65V/giphy.gif)

## Description

Moved decode_path into dataset superclass, which was enough to get `sno merge`, `sno conflicts` and `sno resolve` working.

Conversely, moved `cast_primary_key` out of datasets superclass and into v1 - datasets V2 has its own, schema.sanitise_pk_values, and right now these are not part of the public interface.

## Related links:

https://github.com/koordinates/sno/issues/72

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
