### PR TITLE
Speed up feature iteration using memoryviews

### DIFF
--- a/sno/dataset1.py
+++ b/sno/dataset1.py
@@ -145,12 +145,12 @@ class Dataset1(DatasetStructure):
         feature_path = self.encode_1pk_to_path(pk)
         index.remove(feature_path)
 
-    def repo_feature_to_dict(self, blob_path, blob_data, ogr_geoms=False):
+    def repo_feature_to_dict(self, blob_path, blob_memoryview, ogr_geoms=False):
         feature = {
             self.primary_key: self.decode_path_to_1pk(blob_path),
         }
         bin_feature = msgpack.unpackb(
-            blob_data,
+            blob_memoryview,
             ext_hook=self._msgpack_unpack_ext_ogr
             if ogr_geoms
             else self._msgpack_unpack_ext,
@@ -175,7 +175,9 @@ class Dataset1(DatasetStructure):
 
     def get_feature(self, pk_value, *, ogr_geoms=True):
         blob = self._get_feature(pk_value)
-        return self.repo_feature_to_dict(blob.name, blob.data, ogr_geoms=ogr_geoms)
+        return self.repo_feature_to_dict(
+            blob.name, memoryview(blob), ogr_geoms=ogr_geoms
+        )
 
     def get_feature_tuples(self, pk_values, col_names, *, ignore_missing=False):
         tupleizer = self.build_feature_tupleizer(col_names)
@@ -264,7 +266,9 @@ class Dataset1(DatasetStructure):
         return (
             (
                 blob.name,
-                self.repo_feature_to_dict(blob.name, blob.data, ogr_geoms=ogr_geoms),
+                self.repo_feature_to_dict(
+                    blob.name, memoryview(blob), ogr_geoms=ogr_geoms
+                ),
             )
             for blob in self._iter_feature_blobs(fast=False)
         )

--- a/tests/test_dataset2.py
+++ b/tests/test_dataset2.py
@@ -7,6 +7,17 @@ DATASET_PATH = "path/to/dataset"
 EMPTY_DATASET = Dataset2(None, DATASET_PATH)
 
 
+def _blob_to_memoryview(blob):
+    return memoryview(blob.data)
+
+
+@pytest.fixture(autouse=True)
+def blob_memoryview(monkeypatch):
+    from sno import dataset2
+
+    monkeypatch.setattr(dataset2, '_blob_to_memoryview', _blob_to_memoryview)
+
+
 class DictTree:
     """
     A fake directory tree structure.
@@ -23,6 +34,9 @@ class DictTree:
 
         if all_data.get(cur_path) is not None:
             self.data = all_data[cur_path]
+            self.type_str = 'blob'
+        else:
+            self.type_str = 'tree'
 
     def __truediv__(self, path):
         if self.cur_path:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -767,7 +767,7 @@ def test_feature_find_decode_performance(
 
     elif profile == "feature_to_dict":
         feature_path = dataset.encode_1pk_to_path(pk, relative=True)
-        feature_data = (tree / feature_path).data
+        feature_data = memoryview(tree / feature_path)
 
         # TODO: try to avoid two sets of code for two dataset versions -
         # either by making their interfaces more similar, or by deleting v1


### PR DESCRIPTION
## Description

This is a ~10% speedup for object-iteration commands (eg checkout / show / diff)

`blob.data` is slow, partly because it copies the data into a
bytestring.
But in most cases we throw away the bytestring after passing it through
`msgpack.unpackb()`. msgpack can accept a memoryview object instead,
so just switching to memoryview avoids the copy and thus gives us a
sizeable speedup.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
