### PR TITLE
clone/show: Support shallow clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,11 @@ _When adding new entries to the changelog, please include issue/PR numbers where
     - However, new repositories are still V1 repositories unless V2 is explicitly requested, since V2 is not yet full featured.
     - Tracking issue [#72](https://github.com/koordinates/sno/issues/72)
 
-### Using Datasets V1
+#### Using Datasets V1
 
  * Unless specific action is taken, existing repositories will remain V1, and new repositories still default to V1.
 
-### Using Datasets V2
+#### Using Datasets V2
 
  * An entire repository must be either V1 or V2, so to use V2, all data must be imported as V2.
  * Data can be imported as V2 using `sno init --import=<data> --version=2` or `sno import <data> --version=2`
@@ -34,6 +34,10 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
  * Geometry storage format is not yet finalised.
  * Schema / meta changes cannot be committed or diffed (note: also missing from V1).
+
+### Other changes in this release
+
+ * `sno clone` now support shallow clones (`--depth N`) to avoid cloning a repo's entire history [#174](https://github.com/koordinates/sno/issues/174)
 
 ## 0.4.1
 

--- a/sno/show.py
+++ b/sno/show.py
@@ -42,10 +42,18 @@ def show(ctx, *, refish, output_format, json_style, **kwargs):
     # Ensures we were given a reference to a commit, and not a tree or something
     commit = CommitWithReference.resolve(repo, refish).commit
 
-    if commit.parents:
-        parent = f"{refish}^"
-    else:
+    try:
+        parents = commit.parents
+    except KeyError:
+        # one or more parents doesn't exist.
+        # This is okay if this is the first commit of a shallow clone.
+        # (how to tell?)
         parent = EMPTY_TREE_SHA
+    else:
+        if parents:
+            parent = f"{refish}^"
+        else:
+            parent = EMPTY_TREE_SHA
     patch_writer = globals()[f"patch_output_{output_format}"]
 
     return diff.diff_with_writer(

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1401,3 +1401,15 @@ def test_show_json_format(data_archive_readonly, cli_runner):
         assert r.exit_code == 0, r
         # output is compact, no indentation
         assert '"sno.diff/v1+hexwkb": {"' in r.stdout
+
+
+def test_show_shallow_clone(data_archive_readonly, cli_runner, tmp_path, chdir):
+    # just checking you can 'show' the first commit of a shallow clone
+    with data_archive_readonly("points") as original_path:
+        clone_path = tmp_path / "shallow-clone"
+        r = cli_runner.invoke(["clone", "--depth=1", original_path, clone_path])
+        assert r.exit_code == 0, r
+
+        with chdir(clone_path):
+            r = cli_runner.invoke(["show"])
+            assert r.exit_code == 0, r


### PR DESCRIPTION
## Description

Adds `--depth` to `clone` command, so we can do shallow clones.

This option is passed directly to git and works the same way.

I also added a fix for an exception I found in `show` when the target commit is the first commit in a shallow clone.


## Related links:

https://git-scm.com/docs/git-clone

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
