### PR TITLE
Basic meta (title/description) in checkout

### DIFF
--- a/sno/dataset1.py
+++ b/sno/dataset1.py
@@ -78,6 +78,11 @@ class Dataset1(DatasetStructure):
 
     @property
     @functools.lru_cache(maxsize=1)
+    def feature_tree(self):
+        return self.tree
+
+    @property
+    @functools.lru_cache(maxsize=1)
     def cid_field_map(self):
         cid_map = {}
         for te in self.meta_tree / "fields":

--- a/sno/dataset2.py
+++ b/sno/dataset2.py
@@ -73,6 +73,11 @@ class Dataset2(DatasetStructure):
     def version(self):
         return 2
 
+    @property
+    @functools.lru_cache(maxsize=1)
+    def feature_tree(self):
+        return self.tree / self.FEATURE_PATH
+
     def get_data_at(self, rel_path, missing_ok=False, as_memoryview=False):
         """
         Return the data at the given relative path from within this dataset.


### PR DESCRIPTION


## Description

GPKG working copies now set `gpkg_contents.identifier` and `gpkg_contents.description` from changes in the `title` and `description` meta items when checking out.

Other meta items are ignored during checkout, because the working copy
probably doesn't care about them.

Schema changes specifically still aren't supported and will throw an error during checkout.

## Related links:
none
## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
