### PR TITLE
Add `meta set`, and add meta changes in `apply`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
     - Unlike Datasets V1, the schema can be modified without rewriting every row in a dataset.
     - However, new repositories are still V1 repositories unless V2 is explicitly requested, since V2 is still in development.
     - Tracking issue [#72](https://github.com/koordinates/sno/issues/72)
+    - Diffs, commits and patches all support meta changes
 
 #### Using Datasets V1
 

--- a/sno/meta.py
+++ b/sno/meta.py
@@ -1,5 +1,11 @@
+import json
+import io
+
 import click
 
+from .apply import apply_patch
+from .cli_util import StringFromFile
+from .exceptions import InvalidOperation
 from .output_util import dump_json_output, format_json_for_output, resolve_output_path
 from .structure import RepositoryStructure
 
@@ -71,3 +77,79 @@ def meta_get(ctx, output_format, json_style, dataset, keys):
                 fp.write(f"{indent}{line}\n")
     else:
         dump_json_output(items, fp, json_style=json_style)
+
+
+class KeyValueType(click.ParamType):
+    name = "key=value"
+
+    def convert(self, value, param, ctx):
+        value = tuple(value.split('=', 1))
+        if len(value) != 2:
+            self.fail(f"{value} should be of the form KEY=VALUE", param, ctx)
+
+        key, value = value
+        if not key:
+            self.fail(f"Key should not be empty", param, ctx)
+
+        return key, value
+
+
+@meta.command(name='set')
+@click.option(
+    "--message",
+    "-m",
+    help="Use the given message as the commit message",
+    type=StringFromFile(encoding="utf-8"),
+)
+@click.argument('dataset')
+@click.argument(
+    'items',
+    type=KeyValueType(),
+    required=True,
+    nargs=-1,
+    metavar='KEY=VALUE [KEY=VALUE...]',
+)
+@click.pass_context
+def meta_set(ctx, message, dataset, items):
+    """
+    Prints the value of meta keys for the given dataset.
+    """
+    rs = RepositoryStructure(ctx.obj.repo)
+
+    try:
+        ds = rs[dataset]
+    except KeyError:
+        raise click.UsageError(f"No such dataset: {dataset}")
+
+    if ds.version < 2:
+        raise InvalidOperation(
+            "This repo doesn't support meta changes, use `sno upgrade`"
+        )
+
+    if message is None:
+        message = f'Update metadata for {dataset}'
+
+    existing_meta_items = dict(ds.iter_meta_items())
+
+    def _meta_change_dict(key, value):
+        change = {
+            '+': value,
+        }
+        if key in existing_meta_items:
+            change['-'] = existing_meta_items[key]
+        return change
+
+    patch = {
+        "sno.diff/v1+hexwkb": {
+            dataset: {
+                "meta": {key: _meta_change_dict(key, value) for (key, value) in items}
+            }
+        },
+        "sno.patch/v1": {"message": message},
+    }
+    patch_file = io.StringIO()
+    json.dump(patch, patch_file)
+    patch_file.seek(0)
+    apply_patch(
+        repo=ctx.obj.repo, commit=True, patch_file=patch_file, allow_empty=False
+    )


### PR DESCRIPTION

## Description

Non-schema metadata changes can now flow through commit/diff/show/apply
commands correctly.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
