### PR TITLE
Add support for json output to `sno log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ### Other changes in this release
 
  * `sno clone` now support shallow clones (`--depth N`) to avoid cloning a repo's entire history [#174](https://github.com/koordinates/sno/issues/174)
+ * `sno log` now supports JSON output with `--output-format json`
 
 ## 0.4.1
 

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -16,8 +16,9 @@ from . import (
     conflicts,
     commit,
     diff,
-    init,
     fsck,
+    init,
+    log,
     merge,
     meta,
     pull,
@@ -144,6 +145,7 @@ cli.add_command(diff.diff)
 cli.add_command(fsck.fsck)
 cli.add_command(init.import_table)
 cli.add_command(init.init)
+cli.add_command(log.log)
 cli.add_command(merge.merge)
 cli.add_command(meta.meta)
 cli.add_command(pull.pull)
@@ -165,14 +167,6 @@ def reset(ctx):
 
 
 # straight process-replace commands
-
-
-@cli.command(context_settings=dict(ignore_unknown_options=True))
-@click.pass_context
-@click.argument("args", nargs=-1, type=click.UNPROCESSED)
-def log(ctx, args):
-    """ Show commit logs """
-    execvp("git", ["git", "-C", ctx.obj.repo.path, "log"] + list(args))
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))

--- a/sno/log.py
+++ b/sno/log.py
@@ -1,0 +1,172 @@
+from datetime import datetime, timezone, timedelta
+import itertools
+import subprocess
+import sys
+
+import click
+
+from .exec import execvp
+from .exceptions import SubprocessError
+from .output_util import dump_json_output
+from .timestamps import datetime_to_iso8601_utc, timedelta_to_iso8601_tz
+
+
+@click.command(context_settings=dict(ignore_unknown_options=True,))
+@click.pass_context
+@click.option(
+    "--output-format",
+    "-o",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help=(
+        "Output format. 'quiet' disables all output and implies --exit-code.\n"
+        "'html' attempts to open a browser unless writing to stdout ( --output=- )"
+    ),
+)
+@click.option(
+    "--json-style",
+    type=click.Choice(["extracompact", "compact", "pretty"]),
+    default="pretty",
+    help="How to format the output. Only used with --output-format=json",
+)
+@click.option(
+    "--dataset-changes",
+    "do_dataset_changes",
+    is_flag=True,
+    help="Shows which datasets were changed at each commit. Only works with --output-format-json",
+    hidden=True,
+)
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def log(ctx, output_format, json_style, do_dataset_changes, args):
+    """ Show commit logs """
+    if output_format == "text":
+        execvp("git", ["git", "-C", ctx.obj.repo.path, "log"] + list(args))
+
+    elif output_format == "json":
+        repo = ctx.obj.repo
+        try:
+            cmd = ["git", "-C", repo.path, "log", "--pretty=format:%H,%D",] + list(args)
+            r = subprocess.run(cmd, encoding="utf8", check=True, capture_output=True)
+        except subprocess.CalledProcessError as e:
+            raise SubprocessError(
+                f"There was a problem with git log: {e}", called_process_error=e
+            )
+
+        commit_ids_and_refs_log = _parse_git_log_output(r.stdout.splitlines())
+        if do_dataset_changes:
+            dataset_changes_log = get_dataset_changes_log(repo, args)
+        else:
+            dataset_changes_log = itertools.cycle([None])
+
+        commit_log = [
+            commit_obj_to_json(repo[commit_id], refs, dataset_changes)
+            for (commit_id, refs), dataset_changes in zip(
+                commit_ids_and_refs_log, dataset_changes_log
+            )
+        ]
+        dump_json_output(commit_log, sys.stdout, json_style)
+
+
+def _parse_git_log_output(lines):
+    for line in lines:
+        commit_id, *refs = line.split(",")
+        if not any(refs):
+            refs = []
+        yield commit_id, refs
+
+
+def commit_obj_to_json(commit, refs, dataset_changes=None):
+    """Given a commit object, returns a dict ready for dumping as JSON."""
+    author = commit.author
+    committer = commit.committer
+    author_time = datetime.fromtimestamp(author.time, timezone.utc)
+    author_time_offset = timedelta(minutes=author.offset)
+    commit_time = datetime.fromtimestamp(commit.commit_time, timezone.utc)
+    commit_time_offset = timedelta(minutes=commit.commit_time_offset)
+
+    result = {
+        "commit": commit.id.hex,
+        "abbrevCommit": commit.short_id,
+        "message": commit.message,
+        "refs": refs,
+        "authorName": author.name,
+        "authorEmail": author.email,
+        "authorTime": datetime_to_iso8601_utc(author_time),
+        "authorTimeOffset": timedelta_to_iso8601_tz(author_time_offset),
+        "committerEmail": committer.email,
+        "committerName": committer.name,
+        "commitTime": datetime_to_iso8601_utc(commit_time),
+        "commitTimeOffset": timedelta_to_iso8601_tz(commit_time_offset),
+        "parents": [p.id.hex for p in commit.parents],
+        "abbrevParents": [p.short_id for p in commit.parents],
+    }
+    if dataset_changes is not None:
+        result["datasetChanges"] = dataset_changes
+    return result
+
+
+def get_dataset_changes_log(repo, args):
+    # TODO - git log isn't really designed to efficiently tell us which datasets changed.
+    # So this code is a bit more complex that would be ideal, and a bit less efficient.
+    for percentage in (90, 10, 1):
+        directory_changes_log = _get_directory_changes_log(repo, percentage, args)
+        if all(_enough_detail(d) for d in directory_changes_log):
+            break
+
+    return [_get_datasets(d) for d in directory_changes_log]
+
+
+def _enough_detail(directories):
+    return all("/.sno-table/" in d for d in directories)
+
+
+def _get_datasets(directories):
+    datasets = set()
+    for d in directories:
+        parts = d.split("/.sno-table/", 1)
+        if len(parts) == 2:
+            datasets.add(parts[0])
+    return list(datasets)
+
+
+_SEPARATOR = "=" * 20
+
+
+def _get_directory_changes_log(repo, percentage, args):
+    try:
+        cmd = [
+            "git",
+            "-C",
+            repo.path,
+            "log",
+            f"--pretty=format:{_SEPARATOR}",
+            "--shortstat",
+            f"--dirstat=files,cumulative,{percentage}",
+        ] + list(args)
+        r = subprocess.run(cmd, encoding="utf8", check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        raise SubprocessError(
+            f"There was a problem with git log: {e}", called_process_error=e
+        )
+    raw_log = r.stdout.split(f"{_SEPARATOR}\n")[1:]
+    return [_get_directories(r) for r in raw_log]
+
+
+def _get_directories(raw_output):
+    raw_output = raw_output.strip()
+    if not raw_output:
+        return []  # Empty change.
+
+    directories = set()
+    for line in raw_output.splitlines()[1:]:
+        line = line.strip()
+        if not line:
+            continue
+        directory = line.split("% ", 1)[1]
+        directories.add(directory)
+
+    if not directories:
+        # Non-empty change, but dirstat didn't return any particular directory.
+        directories.add("/")
+
+    return directories

--- a/sno/show.py
+++ b/sno/show.py
@@ -1,7 +1,5 @@
 import contextlib
-import json
 from datetime import datetime, timezone, timedelta
-from io import StringIO
 
 import click
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,24 +1,65 @@
+import json
 import pytest
 
 
 H = pytest.helpers.helpers()
 
 
-def test_log(data_archive_readonly, cli_runner):
+@pytest.mark.parametrize("output_format", ["text", "json"])
+def test_log(output_format, data_archive_readonly, cli_runner):
     """ review commit history """
     with data_archive_readonly("points"):
-        r = cli_runner.invoke(["log"])
+        extra_args = ["--dataset-changes"] if output_format == "json" else []
+        r = cli_runner.invoke(["log", f"--output-format={output_format}"] + extra_args)
         assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
-            "commit 2a1b7be8bdef32aea1510668e3edccbc6d454852",
-            "Author: Robert Coup <robert@coup.net.nz>",
-            "Date:   Thu Jun 20 15:28:33 2019 +0100",
-            "",
-            "    Improve naming on Coromandel East coast",
-            "",
-            "commit 63a9492dd785b1f04dfc446330fa017f9459db4f",
-            "Author: Robert Coup <robert@coup.net.nz>",
-            "Date:   Tue Jun 11 12:03:58 2019 +0100",
-            "",
-            "    Import from nz-pa-points-topo-150k.gpkg",
-        ]
+        if output_format == "text":
+            assert r.stdout.splitlines() == [
+                "commit 2a1b7be8bdef32aea1510668e3edccbc6d454852",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                "Date:   Thu Jun 20 15:28:33 2019 +0100",
+                "",
+                "    Improve naming on Coromandel East coast",
+                "",
+                "commit 63a9492dd785b1f04dfc446330fa017f9459db4f",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                "Date:   Tue Jun 11 12:03:58 2019 +0100",
+                "",
+                "    Import from nz-pa-points-topo-150k.gpkg",
+            ]
+        else:
+            assert json.loads(r.stdout) == [
+                {
+                    'commit': '2a1b7be8bdef32aea1510668e3edccbc6d454852',
+                    'abbrevCommit': '2a1b7be',
+                    'message': 'Improve naming on Coromandel East coast',
+                    'refs': ['HEAD -> master'],
+                    'authorEmail': 'robert@coup.net.nz',
+                    'authorName': 'Robert Coup',
+                    'authorTime': '2019-06-20T14:28:33Z',
+                    'authorTimeOffset': '+01:00',
+                    'commitTime': '2019-06-20T14:28:33Z',
+                    'commitTimeOffset': '+01:00',
+                    'committerEmail': 'robert@coup.net.nz',
+                    'committerName': 'Robert Coup',
+                    'parents': ['63a9492dd785b1f04dfc446330fa017f9459db4f'],
+                    'abbrevParents': ['63a9492'],
+                    'datasetChanges': ['nz_pa_points_topo_150k'],
+                },
+                {
+                    'commit': '63a9492dd785b1f04dfc446330fa017f9459db4f',
+                    'abbrevCommit': '63a9492',
+                    'message': 'Import from nz-pa-points-topo-150k.gpkg',
+                    'refs': [],
+                    'authorEmail': 'robert@coup.net.nz',
+                    'authorName': 'Robert Coup',
+                    'authorTime': '2019-06-11T11:03:58Z',
+                    'authorTimeOffset': '+01:00',
+                    'commitTime': '2019-06-11T11:03:58Z',
+                    'commitTimeOffset': '+01:00',
+                    'committerEmail': 'robert@coup.net.nz',
+                    'committerName': 'Robert Coup',
+                    'parents': [],
+                    'abbrevParents': [],
+                    'datasetChanges': ['nz_pa_points_topo_150k'],
+                },
+            ]


### PR DESCRIPTION
![](https://media3.giphy.com/media/xUOxfbAOLZmR356YgM/giphy.gif)

## Description

`sno log` now supports JSON output - the JSON produced is very similar to other commands like `sno show` or `sno status`.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
