### PR TITLE
Streaming of diffs (text output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `sno clone` now support shallow clones (`--depth N`) to avoid cloning a repo's entire history [#174](https://github.com/koordinates/sno/issues/174)
  * `sno log` now supports JSON output with `--output-format json`
  * Fixed some column datatype conversion issues during import and checkout.
+ * Streaming diffs: less time until first change is shown when diffing large changes
 
 ## 0.4.1
 

--- a/tests/test_dataset2.py
+++ b/tests/test_dataset2.py
@@ -99,7 +99,7 @@ def test_raw_feature_roundtrip():
     tree = DictTree({legend_path: legend_data, feature_path: feature_data})
 
     dataset2 = Dataset2(tree / DATASET_PATH, DATASET_PATH)
-    roundtripped = dataset2.get_raw_feature_dict(full_path=feature_path)
+    roundtripped = dataset2.get_raw_feature_dict(path=feature_path)
     assert roundtripped is not raw_feature_dict
     assert roundtripped == raw_feature_dict
 
@@ -117,7 +117,7 @@ def test_raw_feature_roundtrip():
     tree = DictTree({legend_path: legend_data, feature_path: empty_feature_data})
 
     dataset2 = Dataset2(tree / DATASET_PATH, DATASET_PATH)
-    roundtripped = dataset2.get_raw_feature_dict(full_path=feature_path)
+    roundtripped = dataset2.get_raw_feature_dict(path=feature_path)
     # Overwriting the old feature with an empty feature at the same path only
     # clears the non-pk values, since the pk values are part of the path.
     assert roundtripped == {
@@ -190,11 +190,11 @@ def test_feature_roundtrip(gen_uuid):
     )
 
     dataset2 = Dataset2(tree / DATASET_PATH, DATASET_PATH)
-    roundtripped_tuple = dataset2.get_feature(full_path=feature_path, keys=False)
+    roundtripped_tuple = dataset2.get_feature(path=feature_path, keys=False)
     assert roundtripped_tuple is not feature_tuple
     assert roundtripped_tuple == feature_tuple
 
-    roundtripped_dict = dataset2.get_feature(full_path=feature_path, keys=True)
+    roundtripped_dict = dataset2.get_feature(path=feature_path, keys=True)
     assert roundtripped_dict is not feature_dict
     assert roundtripped_dict == feature_dict
 
@@ -252,9 +252,9 @@ def test_schema_change_roundtrip(gen_uuid):
     dataset2 = Dataset2(tree / DATASET_PATH, DATASET_PATH)
     # Old columns that are not present in the new schema are gone.
     # New columns that are not present in the old schema have 'None's.
-    roundtripped = dataset2.get_feature(full_path=feature_path, keys=False)
+    roundtripped = dataset2.get_feature(path=feature_path, keys=False)
     assert roundtripped == (7, None, "Bloggs", "Joe", None)
-    roundtripped = dataset2.get_feature(full_path=feature_path, keys=True)
+    roundtripped = dataset2.get_feature(path=feature_path, keys=True)
     assert roundtripped == {
         "personnel_id": 7,
         "tax_file_number": None,

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -774,7 +774,7 @@ def test_feature_find_decode_performance(
         if import_version == "1":
             benchmark(dataset.repo_feature_to_dict, feature_path, feature_data)
         elif import_version == "2":
-            benchmark(dataset.get_feature, full_path=feature_path, data=feature_data)
+            benchmark(dataset.get_feature, path=feature_path, data=feature_data)
     else:
         raise NotImplementedError(f"Unknown profile: {profile}")
 


### PR DESCRIPTION
![](https://miro.medium.com/max/1280/1*_RoxXvtsFo-sBRrZrPJjMg.gif)

## Description

This greatly reduces the time until the first change is shown for large diffs with lots of changes, eg the first import - by not reading the relevant blob from the repo until it is needed to show the change.

Currently only works for text output - for json and geojson, a dict containing the entire diff is generated first before json.dump is called. This can be fixed, will work on it in a follow up PR.

Rename detection in revision<>revision diffs is removed as of this change - it seems that is has never worked anyway. Will also re-add that in a follow up PR.

## Related links:

https://github.com/koordinates/sno/issues/156

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
