### PR TITLE
Make json and geojson diffs streaming

### DIFF
--- a/sno/diff_structs.py
+++ b/sno/diff_structs.py
@@ -8,7 +8,6 @@ class Conflict(Exception):
 class KeyValue(namedtuple("KeyValue", ("key", "value"))):
     """
     A key-value pair. A delta is made of two of these - one old, one new.
-
     """
 
     @staticmethod
@@ -29,11 +28,11 @@ class KeyValue(namedtuple("KeyValue", ("key", "value"))):
 
         try:
             # Look for memoized value.
-            return self._value
+            return self._cached_value
         except AttributeError:
             # Time to evaluate and memoize.
-            self._value = self.value()
-            return self._value
+            self._cached_value = self.value()
+            return self._cached_value
 
 
 class Delta(namedtuple("Delta", ("old", "new"))):

--- a/sno/merge_util.py
+++ b/sno/merge_util.py
@@ -565,7 +565,7 @@ class RichConflictVersion:
         elif output_format == "json":
             return json_row(self.feature)
         elif output_format == "geojson":
-            return geojson_row(self.feature, self.pk_field)
+            return geojson_row(self.feature, self.pk)
 
     def matches_filter(self, repo_filter):
         if repo_filter == UNFILTERED:

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import time
-from collections import defaultdict, deque
+from collections import deque
 
 import click
 import pygit2


### PR DESCRIPTION
![](https://media0.giphy.com/media/vxXj8zguPhSgkZE8sw/giphy.gif)

## Description

Make JSON diffs stream, just as text diffs already do. This means creating a large serialisable structure where pieces of the structure are only loaded when they are serialised. These pieces are loaded when __json__() is called - an extended serialiser calls __json__() during serialisation on any object that is not natively serialisable.

## Related links:

https://github.com/koordinates/sno/issues/156

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
