### PR TITLE
Support tables being added / deleted / structurally changed during checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,11 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 #### Important missing functionality in Datasets V2
 
- * Schemas can be changed at HEAD and the new schemas committed, but checking out commits where the schema is different to the current working copy is generally not yet supported. 
-     - It works when columns are renamed.
-     - It does not work when columns are inserted, deleted, reordered, or the types or primary keys are changed.
  * Geometry storage format is not yet finalised.
+ * String primary keys and tables without primary keys are not yet supported.
+ * Changing the primary key column is not yet fully supported.
+ * Schema changes might not be correctly interpreted if too many changes are made at once.
+    - It is safest to commit changes to any existing columns, then commit any new columns, then commit any feature changes.
 
 ### Other changes in this release
 

--- a/sno/schema.py
+++ b/sno/schema.py
@@ -444,5 +444,5 @@ class Schema:
             "pk_updates": pk_updates,
         }
 
-    def diff_counts(self, new_schema):
+    def diff_type_counts(self, new_schema):
         return {k: len(v) for k, v in self.diff_types(new_schema).items()}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -73,7 +73,7 @@ def test_align_schema(gen_uuid):
         "last_name": "last_name",
     }
 
-    diff_counts = old_schema.diff_counts(aligned_schema)
+    diff_counts = old_schema.diff_type_counts(aligned_schema)
     assert diff_counts == {
         "inserts": 2,
         "deletes": 1,


### PR DESCRIPTION
![](https://media0.giphy.com/media/l0IpXP8BwnMXvcOze/giphy.gif)

## Description

Working copies are now able to follow along when checking out commits that have completely different structure to HEAD, including when: 
- tables that exist at HEAD need to be deleted
- tables that do not exist at HEAD need to be created and fully written
- tables have structural changes that can't be done without rewriting the entire table

The only change to schema that can be done without rewriting the entire table is when a column is renamed. The reasons for this are the following:
- if a new column is inserted, we need to rewrite every row. Simply executing an ALTER TABLE ... ADD COLUMN statement would create the column, but wouldn't populate it - and, it would only work if the column is after every other column.
- if an existing column is deleted, we need to recreate the table. Sqlite doesn't support ALTER TABLE ... DROP COLUMN.

Although there could be optimisations where we only sort-of rewrite the entire table, depending on whether columns are added, dropped, or both, this is the easiest solution for now.

Still TODO: maybe optimise the cases where the only schema changes are new columns at the end of the schema, or, the schema has been structurally changed but there are no new columns.

## Related links:

https://github.com/koordinates/sno/issues/72

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
