### PR TITLE
Make PRIMARY KEY columns AUTOINCREMENT for generated GPKG

### DIFF
--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -172,6 +172,10 @@ class WorkingCopyGPKG(WorkingCopy):
             if col["pk"]:
                 col_spec += " PRIMARY KEY"
                 pk_field = col["name"]
+                # TODO: Should INTEGER PRIMARY KEYs ever be non-AUTOINCREMENT?
+                # See https://github.com/koordinates/sno/issues/188
+                if col['type'] == "INTEGER":
+                    col_spec += " AUTOINCREMENT"
             if col["notnull"]:
                 col_spec += " NOT NULL"
             cols[col["name"]] = col_spec

--- a/tests/test_workingcopy.py
+++ b/tests/test_workingcopy.py
@@ -7,8 +7,9 @@ import apsw
 import pygit2
 
 import sno.checkout
-from sno.working_copy import WorkingCopy
 from sno.exceptions import INVALID_ARGUMENT, INVALID_OPERATION
+from sno.structure import RepositoryStructure
+from sno.working_copy import WorkingCopy
 
 
 H = pytest.helpers.helpers()
@@ -66,6 +67,11 @@ def test_checkout_workingcopy(
 
         wc = WorkingCopy.open(repo)
         assert wc.assert_db_tree_match(head_tree)
+
+        rs = RepositoryStructure(repo)
+        cols, pk_col = wc._get_columns(rs[table])
+        expected_col_spec = f'"{pk_col}" INTEGER PRIMARY KEY AUTOINCREMENT'
+        assert cols[pk_col] in (expected_col_spec, f"{expected_col_spec} NOT NULL")
 
 
 def test_checkout_detached(data_working_copy, cli_runner, geopackage):


### PR DESCRIPTION
As in title: ArcPro probably won't work with our GPKG's unless we put AUTOINCREMENT in our PRIMARY KEY columns.
There seems no real downside to doing so at the moment so this PR does so.

## Related links:

https://github.com/koordinates/sno/issues/188

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
