### PR TITLE
Windows: vendor: use a cached copy of spatialite

### DIFF
--- a/vendor/makefile.vc
+++ b/vendor/makefile.vc
@@ -65,7 +65,9 @@ git: $(git)
 
 # Spatialite
 
-SPATIALITE_URL = 'http://www.gaia-gis.it/gaia-sins/windows-bin-NEXTGEN-amd64/mod_spatialite-NG-win-amd64.7z'
+# TODO: upgrade to v5.0 when a mod_spatialite build is available
+#SPATIALITE_URL = 'http://www.gaia-gis.it/gaia-sins/windows-bin-NEXTGEN-amd64/mod_spatialite-NG-win-amd64.7z'
+SPATIALITE_URL = 'https://s3-us-west-1.amazonaws.com/build-artifacts.sno.earth/vendor/mod_spatialite-NG-win-amd64.7z'
 spatialite=dist\env\lib
 
 spatialite\mod_spatialite.7z:


### PR DESCRIPTION
The v5-beta files have been removed from the upstream [spatialite site](http://www.gaia-gis.it/gaia-sins/), and there's no `mod_spatialite` build variant for the 5.0.0RC1 release.

Use a copy of the previous build stashed onto S3.
