### PR TITLE
Use workingcopy V2 when repo is V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
     - However, new repositories are still V1 repositories unless V2 is explicitly requested, since V2 is still in development.
     - Tracking issue [#72](https://github.com/koordinates/sno/issues/72)
     - Diffs, commits and patches all support meta changes
+    - Working copy tracking tables have been renamed [#63](https://github.com/koordinates/sno/issues/63)
 
 #### Using Datasets V1
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -1093,6 +1093,9 @@ def init(
     if any(repo_path.iterdir()):
         raise InvalidOperation(f'"{repo_path}" isn\'t empty', param_hint="directory")
 
+    if wc_version is None:
+        wc_version = version
+
     if import_from:
         check_git_user(repo=None)
         source_loader = OgrImporter.open(import_from, None)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -309,6 +309,7 @@ def test_init_import(
     import_version,
 ):
     """ Import the GeoPackage (eg. `kx-foo-layer.gpkg`) into a Sno repository. """
+    meta_prefix = 'gpkg_sno_' if import_version == '2' else '.sno-'
     with data_archive(archive) as data:
         # list tables
         repo_path = tmp_path / "data.sno"
@@ -341,7 +342,7 @@ def test_init_import(
         assert wc.exists() and wc.is_file()
         print("workingcopy at", wc)
 
-        assert repo.config["sno.workingcopy.version"] == "1"
+        assert repo.config["sno.workingcopy.version"] == str(import_version)
         assert repo.config["sno.workingcopy.path"] == f"{wc.name}"
 
         db = geopackage(wc)
@@ -350,7 +351,7 @@ def test_init_import(
         wc_tree_id = (
             db.cursor()
             .execute(
-                """SELECT value FROM ".sno-meta" WHERE table_name='*' AND key='tree';"""
+                f"""SELECT value FROM "{meta_prefix}meta" WHERE table_name='*' AND key='tree';"""
             )
             .fetchone()[0]
         )

--- a/tests/test_workingcopy.py
+++ b/tests/test_workingcopy.py
@@ -27,13 +27,15 @@ H = pytest.helpers.helpers()
         pytest.param("table", H.TABLE.LAYER, H.TABLE.HEAD_SHA, id="table"),
     ],
 )
-@pytest.mark.parametrize("version", ["1.0", "2.0"])
+@pytest.mark.parametrize("version", ["1", "2"])
 def test_checkout_workingcopy(
     version, archive, table, commit_sha, data_archive, tmp_path, cli_runner, geopackage
 ):
     """ Checkout a working copy to edit """
-    if version == "2.0":
+    meta_prefix = '.sno-'
+    if version == "2":
         archive += "2"
+        meta_prefix = 'gpkg_sno_'
 
     with data_archive(archive) as repo_path:
         H.clear_working_copy()
@@ -57,7 +59,7 @@ def test_checkout_workingcopy(
         wc_tree_id = (
             db.cursor()
             .execute(
-                """SELECT value FROM ".sno-meta" WHERE table_name='*' AND key='tree';"""
+                f"""SELECT value FROM "{meta_prefix}meta" WHERE table_name='*' AND key='tree';"""
             )
             .fetchone()[0]
         )


### PR DESCRIPTION
## Description

This renames the meta/track tables so they're not presented by OGR and
QGIS as datasets. The new tables are
 * `gpkg_sno_meta`
 * `gpkg_sno_track`

When using V1 repos, working copy is unchanged.

## Related links:

Fixes #63


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
