### PR TITLE
`log`: Fix KeyError for shallow clones

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -63,3 +63,48 @@ def test_log(output_format, data_archive_readonly, cli_runner):
                     'datasetChanges': ['nz_pa_points_topo_150k'],
                 },
             ]
+
+
+@pytest.mark.parametrize("output_format", ["text", "json"])
+def test_log_shallow_clone(
+    output_format, data_archive_readonly, cli_runner, tmp_path, chdir
+):
+    """ review commit history """
+    with data_archive_readonly("points") as path:
+
+        clone_path = tmp_path / "shallow.clone"
+        clone_path.mkdir()
+        cli_runner.invoke(
+            ["clone", "--bare", "--depth=1", f"file://{path}", str(clone_path)]
+        )
+        with chdir(clone_path):
+            r = cli_runner.invoke(["log", f"--output-format={output_format}"])
+            assert r.exit_code == 0, r.stderr
+
+        if output_format == "text":
+            assert r.stdout.splitlines() == [
+                "commit 2a1b7be8bdef32aea1510668e3edccbc6d454852",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                "Date:   Thu Jun 20 15:28:33 2019 +0100",
+                "",
+                "    Improve naming on Coromandel East coast",
+            ]
+        else:
+            assert json.loads(r.stdout) == [
+                {
+                    'commit': '2a1b7be8bdef32aea1510668e3edccbc6d454852',
+                    'abbrevCommit': '2a1b7be',
+                    'message': 'Improve naming on Coromandel East coast',
+                    'refs': ['grafted', ' HEAD -> master', ' origin/master'],
+                    'authorEmail': 'robert@coup.net.nz',
+                    'authorName': 'Robert Coup',
+                    'authorTime': '2019-06-20T14:28:33Z',
+                    'authorTimeOffset': '+01:00',
+                    'commitTime': '2019-06-20T14:28:33Z',
+                    'commitTimeOffset': '+01:00',
+                    'committerEmail': 'robert@coup.net.nz',
+                    'committerName': 'Robert Coup',
+                    'parents': ['63a9492dd785b1f04dfc446330fa017f9459db4f'],
+                    'abbrevParents': ['63a9492dd785b1f04dfc446330fa017f9459db4f'],
+                },
+            ]


### PR DESCRIPTION

## Description

Objects in a shallow clone aren't necessarily present. Since the short ID relies on consulting the object database, it can't be  easily retrieved if the objects aren't present.

I considered just not including it (`"abbrevParents": null`) but it seemed better to just include the full refs in this case.

## Related links:
Fixes #195.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?

I didnt' add a changelog entry since this was only present since 354e1c0fe6a526a68ed115edf3429c95510ff91b and doesn't exist in the last release.