### PR TITLE
Fix upgrade for repos with multiple branches

### DIFF
--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 
@@ -52,6 +53,10 @@ def test_upgrade_00_02(archive, layer, data_archive, cli_runner, tmp_path, chdir
 )
 def test_upgrade_02_05(archive, layer, data_archive, cli_runner, tmp_path, chdir):
     with data_archive(archive) as source_path:
+        r = cli_runner.invoke(["status", "--output-format=json"])
+        assert r.exit_code == 0, r
+        src_branch = json.loads(r.stdout)["sno.status/v1"]["branch"]
+
         r = cli_runner.invoke(["upgrade", "02-05", source_path, tmp_path / "dest"])
         assert r.exit_code == 0, r
         assert r.stdout.splitlines()[-1] == "Upgrade complete"
@@ -74,6 +79,11 @@ def test_upgrade_02_05(archive, layer, data_archive, cli_runner, tmp_path, chdir
                 "",
                 "    Import from nz-pa-points-topo-150k.gpkg",
             ]
+
+        r = cli_runner.invoke(["status", "--output-format=json"])
+        assert r.exit_code == 0, r
+        dest_branch = json.loads(r.stdout)["sno.status/v1"]["branch"]
+        assert dest_branch == src_branch
 
 
 def test_upgrade_list(cli_runner):


### PR DESCRIPTION
Basically this bug was fixed by adding "--force" to the git-fast-import command. Fixed some other things too though:
- make sno import work when not on a branch (it didn't)
- make the dest repo be on the same branch as the source repo
- check out a working copy at the dest repo if one existed at the source repo