### PR TITLE
Use pytest-xdist to speed tests up massively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,8 @@ ci-test:
 		--cov-report term \
 		--cov-report html:test-results/coverage/ \
 		--junit-xml=test-results/junit.xml \
-		--benchmark-enable
+		--benchmark-enable \
+		--numprocesses=0
 
 # Cleanup
 

--- a/makefile.vc
+++ b/makefile.vc
@@ -67,7 +67,8 @@ ci-test:
 		--cov-report term \
 		--cov-report html:test-results\coverage/ \
 		--junit-xml=test-results\junit.xml \
-		--benchmark-enable
+		--benchmark-enable \
+		--numprocesses=0
 
 # Packaging
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,10 @@ addopts = -ra
           # override this with --benchmark-enable if you want to run benchmarks
           --benchmark-disable
 
+          # python-xdist: Parallelise to all cores.
+          # Override this with `-n 0` to use breakpoints
+          --numprocesses=auto
+
 testpaths = tests
 norecursedirs = .* build dist CVS _darcs *.egg venv *.git data tests/data
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,12 +7,14 @@
 apipkg==1.5               # via -r requirements/test.txt, execnet
 appnope==0.1.0            # via ipython
 aspectlib==1.5.1          # via -r requirements/test.txt, pytest-benchmark
+atomicwrites==1.4.0       # via -r requirements/test.txt
 attrs==19.3.0             # via -r requirements/../requirements.txt, -r requirements/test.txt, jsonschema, pytest
 backcall==0.2.0           # via ipython
 cached-property==1.5.1    # via -r requirements/../requirements.txt, -r requirements/test.txt
 certifi==2020.6.20        # via -r requirements/../requirements.txt, -r requirements/test.txt
 cffi==1.14.1              # via -r requirements/../requirements.txt, -r requirements/test.txt
 click==7.1.2              # via -r requirements/../requirements.txt, -r requirements/test.txt
+colorama==0.4.3           # via -r requirements/test.txt
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
 decorator==4.4.2          # via ipython, traitlets
 execnet==1.7.1            # via -r requirements/test.txt, pytest-xdist

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,9 +4,9 @@
 #
 #    make py-requirements
 #
+apipkg==1.5               # via -r requirements/test.txt, execnet
 appnope==0.1.0            # via ipython
 aspectlib==1.5.1          # via -r requirements/test.txt, pytest-benchmark
-atomicwrites==1.4.0       # via -r requirements/test.txt, pytest
 attrs==19.3.0             # via -r requirements/../requirements.txt, -r requirements/test.txt, jsonschema, pytest
 backcall==0.2.0           # via ipython
 cached-property==1.5.1    # via -r requirements/../requirements.txt, -r requirements/test.txt
@@ -15,13 +15,15 @@ cffi==1.14.1              # via -r requirements/../requirements.txt, -r requirem
 click==7.1.2              # via -r requirements/../requirements.txt, -r requirements/test.txt
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
 decorator==4.4.2          # via ipython, traitlets
+execnet==1.7.1            # via -r requirements/test.txt, pytest-xdist
 fields==5.0.0             # via -r requirements/test.txt, aspectlib
 gprof2dot==2019.11.30     # via -r requirements/test.txt, pytest-profiling
 html5lib==1.1             # via -r requirements/test.txt
 importlib-metadata==1.7.0  # via -r requirements/../requirements.txt, -r requirements/test.txt, jsonschema, pluggy, pytest
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 ipdb==0.13.3              # via -r requirements/dev.in
 ipython-genutils==0.2.0   # via traitlets
-ipython==7.16.1           # via -r requirements/dev.in, ipdb
+ipython==7.17.0           # via -r requirements/dev.in, ipdb
 jedi==0.17.2              # via ipython
 jsonschema==3.2.0         # via -r requirements/../requirements.txt, -r requirements/test.txt
 lovely-pytest-docker==0.1.0  # via -r requirements/test.txt
@@ -35,22 +37,25 @@ pluggy==0.13.1            # via -r requirements/test.txt, pytest
 prompt-toolkit==3.0.5     # via ipython
 ptyprocess==0.6.0         # via pexpect
 py-cpuinfo==7.0.0         # via -r requirements/test.txt, pytest-benchmark
-py==1.9.0                 # via -r requirements/test.txt, pytest
+py==1.9.0                 # via -r requirements/test.txt, pytest, pytest-forked
 pycparser==2.20           # via -r requirements/../requirements.txt, -r requirements/test.txt, cffi
 pygments==2.6.1           # via -r requirements/../requirements.txt, -r requirements/test.txt, ipython
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pyrsistent==0.16.0        # via -r requirements/../requirements.txt, -r requirements/test.txt, jsonschema
 pytest-benchmark[aspect]==3.2.3  # via -r requirements/test.txt
 pytest-cov==2.10.0        # via -r requirements/test.txt
+pytest-forked==1.3.0      # via -r requirements/test.txt, pytest-xdist
 pytest-helpers-namespace==2019.1.8  # via -r requirements/test.txt
 pytest-profiling==1.7.0   # via -r requirements/test.txt
 pytest-sugar==0.9.4       # via -r requirements/test.txt
-pytest==4.6.11            # via -r requirements/test.txt, lovely-pytest-docker, pytest-benchmark, pytest-cov, pytest-helpers-namespace, pytest-profiling, pytest-sugar
+pytest-xdist==1.34.0      # via -r requirements/test.txt
+pytest==6.0.1             # via -r requirements/test.txt, lovely-pytest-docker, pytest-benchmark, pytest-cov, pytest-forked, pytest-helpers-namespace, pytest-profiling, pytest-sugar, pytest-xdist
 rtree==0.9.4              # via -r requirements/../requirements.txt, -r requirements/test.txt
-six==1.15.0               # via -r requirements/../requirements.txt, -r requirements/test.txt, html5lib, jsonschema, packaging, pyrsistent, pytest, pytest-profiling, traitlets
+six==1.15.0               # via -r requirements/../requirements.txt, -r requirements/test.txt, html5lib, jsonschema, packaging, pyrsistent, pytest-profiling, pytest-xdist, traitlets
 termcolor==1.1.0          # via -r requirements/test.txt, pytest-sugar
+toml==0.10.1              # via -r requirements/test.txt, pytest
 traitlets==4.3.3          # via ipython
-wcwidth==0.2.5            # via -r requirements/test.txt, prompt-toolkit, pytest
+wcwidth==0.2.5            # via prompt-toolkit
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
 zipp==3.1.0               # via -r requirements/../requirements.txt, -r requirements/test.txt, importlib-metadata
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,10 +1,11 @@
 -r ../requirements.txt
 
-pytest~=4.3
+pytest
 pytest-cov
 pytest-sugar
 pytest-helpers-namespace
 pytest-benchmark[aspect]
 pytest-profiling
+pytest-xdist
 lovely-pytest-docker
 html5lib

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,6 +1,10 @@
 -r ../requirements.txt
 
 pytest
+    # pytest 6+ depends on these on windows, but we generally run pip-compile on macOS...
+    # So we add them explicitly
+    atomicwrites>=1.0
+    colorama
 pytest-cov
 pytest-sugar
 pytest-helpers-namespace

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,18 +4,20 @@
 #
 #    make py-requirements
 #
+apipkg==1.5               # via execnet
 aspectlib==1.5.1          # via pytest-benchmark
-atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via -r requirements/../requirements.txt, jsonschema, pytest
 cached-property==1.5.1    # via -r requirements/../requirements.txt
 certifi==2020.6.20        # via -r requirements/../requirements.txt
 cffi==1.14.1              # via -r requirements/../requirements.txt
 click==7.1.2              # via -r requirements/../requirements.txt
 coverage==5.2.1           # via pytest-cov
+execnet==1.7.1            # via pytest-xdist
 fields==5.0.0             # via aspectlib
 gprof2dot==2019.11.30     # via pytest-profiling
 html5lib==1.1             # via -r requirements/test.in
 importlib-metadata==1.7.0  # via -r requirements/../requirements.txt, jsonschema, pluggy, pytest
+iniconfig==1.0.1          # via pytest
 jsonschema==3.2.0         # via -r requirements/../requirements.txt
 lovely-pytest-docker==0.1.0  # via -r requirements/test.in
 more-itertools==8.4.0     # via pytest
@@ -23,21 +25,23 @@ msgpack==0.6.2            # via -r requirements/../requirements.txt
 packaging==20.4           # via pytest, pytest-sugar
 pluggy==0.13.1            # via pytest
 py-cpuinfo==7.0.0         # via pytest-benchmark
-py==1.9.0                 # via pytest
+py==1.9.0                 # via pytest, pytest-forked
 pycparser==2.20           # via -r requirements/../requirements.txt, cffi
 pygments==2.6.1           # via -r requirements/../requirements.txt
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via -r requirements/../requirements.txt, jsonschema
 pytest-benchmark[aspect]==3.2.3  # via -r requirements/test.in
 pytest-cov==2.10.0        # via -r requirements/test.in
+pytest-forked==1.3.0      # via pytest-xdist
 pytest-helpers-namespace==2019.1.8  # via -r requirements/test.in
 pytest-profiling==1.7.0   # via -r requirements/test.in
 pytest-sugar==0.9.4       # via -r requirements/test.in
-pytest==4.6.11            # via -r requirements/test.in, lovely-pytest-docker, pytest-benchmark, pytest-cov, pytest-helpers-namespace, pytest-profiling, pytest-sugar
+pytest-xdist==1.34.0      # via -r requirements/test.in
+pytest==6.0.1             # via -r requirements/test.in, lovely-pytest-docker, pytest-benchmark, pytest-cov, pytest-forked, pytest-helpers-namespace, pytest-profiling, pytest-sugar, pytest-xdist
 rtree==0.9.4              # via -r requirements/../requirements.txt
-six==1.15.0               # via -r requirements/../requirements.txt, html5lib, jsonschema, packaging, pyrsistent, pytest, pytest-profiling
+six==1.15.0               # via -r requirements/../requirements.txt, html5lib, jsonschema, packaging, pyrsistent, pytest-profiling, pytest-xdist
 termcolor==1.1.0          # via pytest-sugar
-wcwidth==0.2.5            # via pytest
+toml==0.10.1              # via pytest
 webencodings==0.5.1       # via html5lib
 zipp==3.1.0               # via -r requirements/../requirements.txt, importlib-metadata
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,11 +6,13 @@
 #
 apipkg==1.5               # via execnet
 aspectlib==1.5.1          # via pytest-benchmark
+atomicwrites==1.4.0       # via -r requirements/test.in
 attrs==19.3.0             # via -r requirements/../requirements.txt, jsonschema, pytest
 cached-property==1.5.1    # via -r requirements/../requirements.txt
 certifi==2020.6.20        # via -r requirements/../requirements.txt
 cffi==1.14.1              # via -r requirements/../requirements.txt
 click==7.1.2              # via -r requirements/../requirements.txt
+colorama==0.4.3           # via -r requirements/test.in
 coverage==5.2.1           # via pytest-cov
 execnet==1.7.1            # via pytest-xdist
 fields==5.0.0             # via aspectlib

--- a/sno/pull.py
+++ b/sno/pull.py
@@ -78,7 +78,7 @@ def pull(ctx, ff, ff_only, do_progress, repository, refspecs):
                 )
 
     # do the fetch
-    L.debug("Running fetch:", repository, refspecs)
+    L.debug("Running fetch: %s %s", repository, refspecs)
     # remote.fetch((refspecs or None))
     # Call git fetch since it supports --progress.
     subprocess.check_call(

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -541,7 +541,7 @@ class DatasetStructure:
                         new_pk,
                     )
                 elif d.status == pygit2.GIT_DELTA_DELETED:
-                    self.L.debug("diff(): delete %s (%s) -> %s (%s)", old_path, old_pk)
+                    self.L.debug("diff(): delete %s %s", old_path, old_pk)
 
                 if d.status in self._UPDATE_DELETE:
                     old_feature_promise = functools.partial(


### PR DESCRIPTION
## Description

On my laptop (12 cores, or possibly only 6?) this yields a 6x speedup (~300s --> ~50s)

Disabled in CI for maximum reproducability.

I also upgraded pytest to 6.0.1 since I couldn't find any reason we had it pinned to 4.x

## Related links:

https://github.com/pytest-dev/pytest-xdist

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?


seems unnecessary to add changelog for this IMO since it's not a user facing change