### PR TITLE
Suggest fixes for typoed commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `sno log` now supports JSON output with `--output-format json` [#170](https://github.com/koordinates/sno/issues/170)
  * Streaming diffs: less time until first change is shown when diffing large changes. [#156](https://github.com/koordinates/sno/issues/156)
  * Working copies are now created automatically. [#192](https://github.com/koordinates/sno/issues/192)
+ * Commands which are misspelled now suggest the correct spelling [#199](https://github.com/koordinates/sno/issues/199)
  * Bugfix: operations that should immediately fail due to dirty working copy no longer partially succeed. [#181](https://github.com/koordinates/sno/issues/181)
  * Bugfix: some column datatype conversion issues during import and checkout.
 

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -83,13 +83,36 @@ def print_version(ctx):
     ctx.exit()
 
 
-class PdbGroup(click.Group):
+class SnoGroup(click.Group):
+    def get_command(self, ctx, cmd_name):
+        rv = super().get_command(ctx, cmd_name)
+        if rv is not None:
+            return rv
+
+        # typo? Suggest similar commands.
+        import difflib
+
+        matches = difflib.get_close_matches(
+            cmd_name, list(self.list_commands(ctx)), n=3
+        )
+
+        fail_message = f"sno: '{cmd_name}' is not a sno command. See 'sno --help'.\n"
+        if matches:
+            if len(matches) == 1:
+                fail_message += '\nThe most similar command is\n'
+            else:
+                fail_message += '\nThe most similar commands are\n'
+            for m in matches:
+                fail_message += f'\t{m}\n'
+        ctx.fail(fail_message)
+
     def invoke(self, ctx):
         try:
             import ipdb as pdb
         except ImportError:
             # ipdb is only installed in dev venvs, not releases
             import pdb
+
         if ctx.params.get('post_mortem'):
             try:
                 return super().invoke(ctx)
@@ -100,7 +123,7 @@ class PdbGroup(click.Group):
             return super().invoke(ctx)
 
 
-@click.group(cls=PdbGroup)
+@click.group(cls=SnoGroup)
 @click.option(
     "-C",
     "--repo",


### PR DESCRIPTION
## Description

If you typo a command, this suggests the right command. git does this and it's handy.

<img width="754" alt="Screen Shot 2020-08-11 at 1 43 59 PM" src="https://user-images.githubusercontent.com/32112/89847716-be478b00-dbd8-11ea-8d60-bc3603086183.png">


## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
