### PR TITLE
Rewrite working_copy.reset to fix issue 191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * New structure to `sno diff` output:
     - Text output: Features are now labelled as `<dataset>:feature:<primary_key>`, consistent with meta items that are labelled as `<dataset>:meta:<meta_item_name>`
     - JSON output also uses "feature" and "meta" as keys for the different types of changes, instead of "featureChanges" and "metaChanges".
+  * Meta changes are now included in `sno diff` output:
+    - Eg title, description and schema changes.
+    - This is true for Datasets V1 and for Datasets V2 (see below), but meta changes can only be committed in datasets V2.
 
 ### Major changes in this release
 

--- a/sno/apply.py
+++ b/sno/apply.py
@@ -134,7 +134,7 @@ def apply_patch(*, repo, commit, patch_file, allow_empty, **kwargs):
         # oid refers to either a commit or tree
         wc_target = repo.get(oid)
         click.echo(f"Updating {wc.path} ...")
-        wc.reset(wc_target, update_meta=commit)
+        wc.reset(wc_target, track_changes_as_dirty=not commit)
 
 
 @click.command()

--- a/sno/checkout.py
+++ b/sno/checkout.py
@@ -232,10 +232,7 @@ def restore(ctx, source, pathspec):
         raise NotFound(f"{source} is not a commit or tree", exit_code=NO_COMMIT)
 
     working_copy.reset(
-        commit_or_tree,
-        force=True,
-        update_meta=(head_commit.id == commit_or_tree.id),
-        paths=pathspec,
+        commit_or_tree, force=True, track_changes_as_dirty=True, paths=pathspec,
     )
 
 

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -464,6 +464,9 @@ class DatasetStructure:
         If reverse is true, generates a diff from other -> self.
         """
 
+        ds_diff = DatasetDiff()
+        ds_diff["meta"] = self.diff_meta(other, reverse=reverse)
+
         ds_filter = ds_filter or UNFILTERED
         pk_filter = ds_filter.get("feature", ())
 
@@ -494,13 +497,6 @@ class DatasetStructure:
             old, new = other, self
         else:
             old, new = self, other
-
-        ds_diff = DatasetDiff()
-
-        if self.version == 2:
-            meta_old = dict(old.iter_meta_items()) if old else {}
-            meta_new = dict(new.iter_meta_items()) if new else {}
-            ds_diff["meta"] = DeltaDiff.diff_dicts(meta_old, meta_new)
 
         feature_diff = DeltaDiff()
 
@@ -576,6 +572,20 @@ class DatasetStructure:
 
         ds_diff["feature"] = feature_diff
         return ds_diff
+
+    def diff_meta(self, other, reverse=False):
+        """
+        Generates a diff from self -> other, but only for meta items.
+        If reverse is true, generates a diff from other -> self.
+        """
+        if reverse:
+            old, new = other, self
+        else:
+            old, new = self, other
+
+        meta_old = dict(old.iter_meta_items()) if old else {}
+        meta_new = dict(new.iter_meta_items()) if new else {}
+        return DeltaDiff.diff_dicts(meta_old, meta_new)
 
     def write_index(self, dataset_diff, index, repo):
         """

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1371,19 +1371,34 @@ def test_show_polygons_initial(
         assert r.exit_code == 0, r
 
         if output_format == 'text':
-            assert r.stdout.splitlines()[0:11] == [
+            lines = r.stdout.splitlines()
+
+            assert lines[0:6] == [
                 'commit 1fb58eb54237c6e7bfcbd7ea65dc999a164b78ec',
                 'Author: Robert Coup <robert@coup.net.nz>',
                 'Date:   Mon Jul 22 12:05:39 2019 +0100',
                 '',
                 '    Import from nz-waca-adjustments.gpkg',
                 '',
+            ]
+
+            assert '+++ nz_waca_adjustments:meta:title' in lines
+            index = lines.index('+++ nz_waca_adjustments:meta:title')
+            assert lines[index : index + 2] == [
+                '+++ nz_waca_adjustments:meta:title',
+                '+ "NZ WACA Adjustments"',
+            ]
+
+            assert '+++ nz_waca_adjustments:feature:1424927' in lines
+            index = lines.index('+++ nz_waca_adjustments:feature:1424927')
+            assert lines[index : index + 5] == [
                 '+++ nz_waca_adjustments:feature:1424927',
                 '+                                     geom = MULTIPOLYGON(...)',
                 '+                            date_adjusted = 2011-03-25T07:30:45Z',
                 '+                         survey_reference = ␀',
                 '+                           adjusted_nodes = 1122',
             ]
+
         elif output_format == 'json':
             j = json.loads(r.stdout)
             assert 'sno.diff/v1+hexwkb' in j


### PR DESCRIPTION
## Description

A working copy has a dataset at a particular revision which is its "base"  - this is found by looking up the tree in the sno-meta table.
The working copy can differ from its base in two ways.
1) it can have meta or structural changes from its base. We can't track those, so we need to generate a full diff of them.
2) it can have feature changes. To save us diffing 1000s of features, we maintain a tracking table of which features have been edited since the table was last reset.

Before meta changes were supported, the logic for resetting a WC to a given target dataset was as follows:

1. If we are not okay with discarding changes: Make sure nothing is in the tracking table 
2. Reset everything in the tracking table to match the base dataset and delete the tracking records
3. Make all feature changes that are in the diff from base dataset to target dataset. 
4. Either record these as edits in the tracking table, or update the WC's base to be the target dataset.

Now that we support meta changes, there's more to do:

1. If we are not okay with discarding changes: Make sure nothing is in the tracking table 
AND: Make sure there are no meta changes
2. Revert any meta changes so that we match the base dataset
3. Reset everything in the tracking table to match the base dataset and delete the tracking records 
(this is only guaranteed to work now that the schema matches the base dataset)
4. Make all meta changes that are in the diff from base dataset to target dataset
5. Make all feature changes that are in the diff from base dataset to target dataset. 
6. Either record these as edits in the tracking table, or update the WC's base to be the target dataset.

Even so, this doesn't always work - if the schema changes in any non-trivial way, we just have to delete and recreate
the dataset. In that case, we don't yet support tracking the edits we made to the dataset - so 
`sno restore <commit-C>` doesn't work if commit C has a schema that differs from ours in some way other than just column renames. But, you `sno reset <commit-C>` or `sno checkout <commit-C>` will work at least.

Side effects:
This code fixes meta diff generation so it can detect when metadata has changed and apply those changes to the working copy. As a side effect, meta diffs now work everywhere, even for V1 datasets.

## Related links:

https://github.com/koordinates/sno/issues/191

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
