### PR TITLE
Stricter reset of wc tracking table on commit

### DIFF
--- a/sno/commit.py
+++ b/sno/commit.py
@@ -106,7 +106,7 @@ def commit(ctx, message, allow_empty, output_format, filters):
     new_commit_id = rs.commit(wc_diff, commit_msg, allow_empty=allow_empty)
     new_commit = repo[new_commit_id].peel(pygit2.Commit)
 
-    working_copy.reset_tracking_table(wc_diff.to_filter())
+    working_copy.reset_tracking_table(commit_filter)
     working_copy.update_state_table_tree(new_commit.peel(pygit2.Tree).id.hex)
 
     jdict = commit_obj_to_json(new_commit, repo, wc_diff)


### PR DESCRIPTION
## Description

Right now we have a tracking table that MUST contain every feature that is dirty.
It MAY contain features that are not dirty - basically anytime the user edits a feature and then puts it back how it was.

When generating a diff or deciding if the WC is dirty, we use the tracking table as a starting point - we find the subset of the features that are listed there that actually differ from the base dataset.

When committing we currently do the following:
1. Generate a diff of all the changes that match the user-supplied commit filter
2. Commit those changes
3. Clear those changes from the tracking table

However, this means that spurious changes in the tracking table - features that have not actually changed - are never deleted from it, and continue to cost us extra compute time going forward. The worst case would be if the user accidentally modified every feature in a table, but managed to undo this operation without using sno. In this case, sno would be tracking every feature in the whole table as a possible edit, and we lose the utility of even having a tracking table.

The fix is clear things from the tracking table more often. Eg on commit, we could:
1. Generate a diff of all the changes that match the user-supplied commit filter
2. Commit those changes
3. Clear all changes that match the user-supplied commit filter from the tracking table

Since most commits are just "commit everything" or at least "commit everything in dataset D", this will mean most commits will reset the tracking table so that its efficient again.

This is a one line change.
