### PR TITLE
Add support for storing + modifying XML metadata in V2

### DIFF
--- a/sno/gpkg.py
+++ b/sno/gpkg.py
@@ -66,7 +66,7 @@ def db(path, **kwargs):
     return db
 
 
-def get_meta_info(db, layer, exclude_keys=()):
+def get_meta_info(db, layer, keys=None):
     """
     Returns metadata from the gpkg_* tables about this GPKG.
     Keep this in sync with OgrImporter.iter_gpkg_meta for other datasource types.
@@ -128,7 +128,7 @@ def get_meta_info(db, layer, exclude_keys=()):
     }
     try:
         for key, (sql, params, rtype) in QUERIES.items():
-            if key in exclude_keys:
+            if keys is not None and key not in keys:
                 continue
             # check table exists, the metadata ones may not
             if not key.startswith("sqlite_"):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -356,6 +356,29 @@ def test_init_import(
         )
         assert wc_tree_id == repo.head.peel(pygit2.Tree).hex
 
+        xml_metadata = (
+            db.cursor()
+            .execute(
+                f"""
+            SELECT m.metadata
+            FROM gpkg_metadata m JOIN gpkg_metadata_reference r
+            ON m.id = r.md_file_id
+            WHERE r.table_name = '{table}'
+            """
+            )
+            .fetchone()
+        )
+        if table == "nz_pa_points_topo_150k":
+            assert xml_metadata[0].startswith(
+                '<gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco"'
+            )
+        elif table == "nz_waca_adjustments":
+            assert xml_metadata[0].startswith(
+                '<GDALMultiDomainMetadata>\n  <Metadata>\n    <MDI key="GPKG_METADATA_ITEM_1">'
+            )
+        else:
+            assert not xml_metadata
+
         H.verify_gpkg_extent(db, table)
         with chdir(repo_path):
             # check that we can view the commit we created

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -67,17 +67,17 @@ def test_upgrade_02_05(archive, layer, data_archive, cli_runner, tmp_path, chdir
 
         if layer == H.POINTS.LAYER:
             assert r.stdout.splitlines() == [
-                "commit b11f5f69aa28c0024cc3929c343f3a5de1e7517e",
-                "Author: Robert Coup <robert@coup.net.nz>",
-                "Date:   Thu Jun 20 15:28:33 2019 +0100",
-                "",
-                "    Improve naming on Coromandel East coast",
-                "",
-                "commit 83d4b028acabe4e61a97c09515909d099a038e93",
-                "Author: Robert Coup <robert@coup.net.nz>",
-                "Date:   Tue Jun 11 12:03:58 2019 +0100",
-                "",
-                "    Import from nz-pa-points-topo-150k.gpkg",
+                'commit f71be15862ca2eae1c7c65d822270cae891f6253',
+                'Author: Robert Coup <robert@coup.net.nz>',
+                'Date:   Thu Jun 20 15:28:33 2019 +0100',
+                '',
+                '    Improve naming on Coromandel East coast',
+                '',
+                'commit 93e6f8c03ad5e8d5a30b199b1cbf42bc24f29858',
+                'Author: Robert Coup <robert@coup.net.nz>',
+                'Date:   Tue Jun 11 12:03:58 2019 +0100',
+                '',
+                '    Import from nz-pa-points-topo-150k.gpkg',
             ]
 
         r = cli_runner.invoke(["status", "--output-format=json"])


### PR DESCRIPTION
![](https://media1.giphy.com/media/9LIzdSmzvq8vu/giphy.gif)

## Description

Datasets V1 stores XML (or similar) metadata according to the GPKG spec - in two tables / meta-items called "gpkg_metadata" and "gpkg_metadata_reference".

As of this PR, datasets V2 can store the same information in a JSON file per dataset called "metadata/dataset.json" with the following structure:
```
{
  "http://www.isotc211.org/2005/gmd": {
    "text/xml": "<gmd:MD_Metadata …"
  }
}
```

Committing changes to this metadata and checking out branches with differing metadata is also supported.

## Related links:

https://github.com/koordinates/sno/issues/202

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- No update to changelog - subfeature of main v0.5 change, v2 datasets.
