### PR TITLE
`meta get`: Dump text values as text, not json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * Added `sno create-patch <refish>` - creates a JSON patch file, which can be applied using `sno apply` [#210](https://github.com/koordinates/sno/issues/210)
  * `sno clone` now support shallow clones (`--depth N`) to avoid cloning a repo's entire history [#174](https://github.com/koordinates/sno/issues/174)
  * `sno log` now supports JSON output with `--output-format json` [#170](https://github.com/koordinates/sno/issues/170)
+ * `sno meta get` now prints text items as text (not encoded as JSON) [#211](https://github.com/koordinates/sno/issues/211)
  * Streaming diffs: less time until first change is shown when diffing large changes. [#156](https://github.com/koordinates/sno/issues/156)
  * Working copies are now created automatically. [#192](https://github.com/koordinates/sno/issues/192)
  * Commands which are misspelled now suggest the correct spelling [#199](https://github.com/koordinates/sno/issues/199)

--- a/sno/meta.py
+++ b/sno/meta.py
@@ -71,8 +71,9 @@ def meta_get(ctx, output_format, json_style, dataset, keys):
         indent = '    '
         for key, value in items.items():
             click.secho(key, bold=True)
-            serialized = format_json_for_output(value, fp, json_style=json_style)
-            lines = serialized.splitlines()
+            if key == "schema" or key.endswith('.json') or not isinstance(value, str):
+                value = format_json_for_output(value, fp, json_style=json_style)
+            lines = value.splitlines()
             for i, line in enumerate(lines):
                 fp.write(f"{indent}{line}\n")
     else:


### PR DESCRIPTION

## Description

Makes it easier to read long text values. We have `-o json` if you
really want structured output.

## Related links:

none


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)? (there are existing tests for this, they pass)
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
