### PR TITLE
diff/show: Add reprojection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `sno log` now supports JSON output with `--output-format json` [#170](https://github.com/koordinates/sno/issues/170)
  * `sno meta get` now prints text items as text (not encoded as JSON) [#211](https://github.com/koordinates/sno/issues/211)
  * `sno meta get` without arguments now outputs multiple datasets [#217](https://github.com/koordinates/sno/issues/217)
+ * `sno diff` and `sno show` now accept a `--crs` parameter to reproject output [#213](https://github.com/koordinates/sno/issues/213)
  * Streaming diffs: less time until first change is shown when diffing large changes. [#156](https://github.com/koordinates/sno/issues/156)
  * Working copies are now created automatically. [#192](https://github.com/koordinates/sno/issues/192)
  * Commands which are misspelled now suggest the correct spelling [#199](https://github.com/koordinates/sno/issues/199)

--- a/sno/dataset1.py
+++ b/sno/dataset1.py
@@ -116,7 +116,7 @@ class Dataset1(DatasetStructure):
     def crs_identifier(self):
         for col_dict in self.get_meta_item("schema.json"):
             if col_dict["dataType"] == "geometry":
-                return col_dict["geometrySRS"]
+                return col_dict["geometryCRS"]
         return None
 
     @property

--- a/sno/dataset1.py
+++ b/sno/dataset1.py
@@ -113,6 +113,14 @@ class Dataset1(DatasetStructure):
 
     @property
     @functools.lru_cache(maxsize=1)
+    def crs_identifier(self):
+        for col_dict in self.get_meta_item("schema.json"):
+            if col_dict["dataType"] == "geometry":
+                return col_dict["geometrySRS"]
+        return None
+
+    @property
+    @functools.lru_cache(maxsize=1)
     def primary_key_type(self):
         schema = self.get_meta_item("sqlite_table_info")
         field = next(f for f in schema if f["name"] == self.primary_key)

--- a/sno/dataset2.py
+++ b/sno/dataset2.py
@@ -175,6 +175,14 @@ class Dataset2(DatasetStructure):
         """Load the current schema from this dataset."""
         return Schema.loads(self.get_data_at(self.SCHEMA_PATH))
 
+    @property
+    @functools.lru_cache(maxsize=1)
+    def crs_identifier(self):
+        for col in self.schema:
+            if col.data_type == "geometry":
+                return col.extra_type_info["geometrySRS"]
+        return None
+
     def encode_schema(self, schema):
         """
         Given a schema, returns the path and the data which *should be written*

--- a/sno/dataset2.py
+++ b/sno/dataset2.py
@@ -145,10 +145,6 @@ class Dataset2(DatasetStructure):
                 return gpkg_adapter.generate_gpkg_meta_item(self, name)
             raise  # This meta-item doesn't exist at all.
 
-    def get_crs_definition(self, crs_name):
-        """Return the CRS definition stored with the given name."""
-        return self.get_meta_item(f"crs/{crs_name}.wkt")
-
     def crs_definitions(self):
         """Return all stored crs definitions in a dict."""
         for blob in find_blobs_in_tree(self.tree / self.CRS_PATH):
@@ -180,7 +176,7 @@ class Dataset2(DatasetStructure):
     def crs_identifier(self):
         for col in self.schema:
             if col.data_type == "geometry":
-                return col.extra_type_info["geometrySRS"]
+                return col.extra_type_info["geometryCRS"]
         return None
 
     def encode_schema(self, schema):

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -4,7 +4,9 @@ import sys
 from pathlib import Path
 
 import click
+from osgeo import osr
 
+from .cli_util import StringFromFile
 from .diff_output import (  # noqa - used from globals()
     diff_output_text,
     diff_output_json,
@@ -20,6 +22,7 @@ from .exceptions import (
     UNCATEGORIZED_ERROR,
 )
 from .filter_util import build_feature_filter, UNFILTERED
+from .geometry import make_crs
 from .repo_files import RepoState
 from .structure import RepositoryStructure
 
@@ -100,6 +103,7 @@ def diff_with_writer(
     json_style="pretty",
     commit_spec,
     filters,
+    target_crs=None,
 ):
     """
     Calculates the appropriate diff from the arguments,
@@ -114,6 +118,7 @@ def diff_with_writer(
       exit_code:   If True, the process will exit with code 1 if the diff is non-empty.
       commit_spec: The commit-ref or -refs to diff.
       filters:     Limit the diff to certain datasets or features.
+      target_crs:  An osr.SpatialReference object, or None
     """
     from .working_copy import WorkingCopy
 
@@ -161,6 +166,17 @@ def diff_with_writer(
         if feature_filter is not UNFILTERED:
             all_datasets = all_datasets.intersection(feature_filter.keys())
 
+        dataset_geometry_transforms = {}
+        if target_crs is not None:
+            for dataset_path in all_datasets:
+                dataset = base_rs.get(dataset_path) or target_rs.get(dataset_path)
+                crs_wkt = dataset.crs_wkt
+                if crs_wkt is not None:
+                    src_crs = make_crs(crs_wkt)
+                    dataset_geometry_transforms[
+                        dataset.name
+                    ] = osr.CoordinateTransformation(src_crs, target_crs)
+
         writer_params = {
             "repo": repo,
             "base": base_rs,
@@ -168,6 +184,7 @@ def diff_with_writer(
             "output_path": output_path,
             "dataset_count": len(all_datasets),
             "json_style": json_style,
+            "dataset_geometry_transforms": dataset_geometry_transforms,
         }
 
         L.debug(
@@ -209,6 +226,16 @@ def diff_with_writer(
             sys.exit(1)
 
 
+class CoordinateReferenceString(StringFromFile):
+    def convert(self, value, param, ctx):
+        value = super().convert(value, param, ctx)
+
+        try:
+            return make_crs(value)
+        except RuntimeError:
+            self.fail(f"Invalid or unknown coordinate reference system: {value}")
+
+
 @click.command()
 @click.pass_context
 @click.option(
@@ -227,6 +254,11 @@ def diff_with_writer(
     help="Make the program exit with codes similar to diff(1). That is, it exits with 1 if there were differences and 0 means no differences.",
 )
 @click.option(
+    "--crs",
+    type=CoordinateReferenceString(encoding="utf-8"),
+    help="Reproject geometries into the given coordinate reference system ('EPSG:<code>', proj text or WKT)",
+)
+@click.option(
     "--output",
     "output_path",
     help="Output to a specific file/directory instead of stdout.",
@@ -240,7 +272,9 @@ def diff_with_writer(
 )
 @click.argument("commit_spec", required=False, nargs=1)
 @click.argument("filters", nargs=-1)
-def diff(ctx, output_format, output_path, exit_code, json_style, commit_spec, filters):
+def diff(
+    ctx, output_format, crs, output_path, exit_code, json_style, commit_spec, filters
+):
     """
     Show changes between two commits, or between a commit and the working copy.
 
@@ -270,4 +304,5 @@ def diff(ctx, output_format, output_path, exit_code, json_style, commit_spec, fi
         json_style=json_style,
         commit_spec=commit_spec,
         filters=filters,
+        target_crs=crs,
     )

--- a/sno/merge_util.py
+++ b/sno/merge_util.py
@@ -563,7 +563,7 @@ class RichConflictVersion:
         if output_format == "text":
             return text_row(self.feature)
         elif output_format == "json":
-            return json_row(self.feature)
+            return json_row(self.feature, self.pk)
         elif output_format == "geojson":
             return geojson_row(self.feature, self.pk)
 

--- a/sno/show.py
+++ b/sno/show.py
@@ -42,13 +42,18 @@ def _get_parent(ctx, refish):
     help="Output format",
 )
 @click.option(
+    "--crs",
+    type=diff.CoordinateReferenceString(encoding="utf-8"),
+    help="Reproject geometries into the given coordinate reference system ('EPSG:<code>', proj text or WKT)",
+)
+@click.option(
     "--json-style",
     type=click.Choice(["extracompact", "compact", "pretty"]),
     default="pretty",
     help="How to format the output. Only used with --output-format=json",
 )
 @click.argument("refish", default='HEAD', required=False)
-def show(ctx, *, refish, output_format, json_style, **kwargs):
+def show(ctx, *, refish, output_format, crs, json_style, **kwargs):
     """
     Show the given commit, or HEAD
     """
@@ -58,6 +63,7 @@ def show(ctx, *, refish, output_format, json_style, **kwargs):
         ctx,
         show_writer,
         exit_code=False,
+        target_crs=crs,
         commit_spec=f"{parent}...{refish}",
         filters=[],
         json_style=json_style,

--- a/sno/show.py
+++ b/sno/show.py
@@ -44,7 +44,7 @@ def _get_parent(ctx, refish):
 @click.option(
     "--crs",
     type=diff.CoordinateReferenceString(encoding="utf-8"),
-    help="Reproject geometries into the given coordinate reference system ('EPSG:<code>', proj text or WKT)",
+    help="Reproject geometries into the given coordinate reference system. Accepts: 'EPSG:<code>'; proj text; OGC WKT; OGC URN; PROJJSON.)",
 )
 @click.option(
     "--json-style",

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -384,6 +384,10 @@ class DatasetStructure:
         meta_geom = self.get_meta_item("gpkg_geometry_columns")
         return meta_geom["column_name"] if meta_geom else None
 
+    def get_crs_definition(self, crs_name):
+        """Return the CRS definition stored with the given name."""
+        return self.get_meta_item(f"crs/{crs_name}.wkt")
+
     @property
     @functools.lru_cache(maxsize=1)
     def crs_wkt(self):
@@ -391,7 +395,7 @@ class DatasetStructure:
         if crs_identifier is None:
             return None
         else:
-            return self.get_meta_item(f"srs/{crs_identifier}.wkt")
+            return self.get_crs_definition(crs_identifier)
 
     def get_feature(self, pk_value):
         raise NotImplementedError()

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -384,6 +384,15 @@ class DatasetStructure:
         meta_geom = self.get_meta_item("gpkg_geometry_columns")
         return meta_geom["column_name"] if meta_geom else None
 
+    @property
+    @functools.lru_cache(maxsize=1)
+    def crs_wkt(self):
+        crs_identifier = self.crs_identifier
+        if crs_identifier is None:
+            return None
+        else:
+            return self.get_meta_item(f"srs/{crs_identifier}.wkt")
+
     def get_feature(self, pk_value):
         raise NotImplementedError()
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -267,10 +267,10 @@ def test_diff_points(
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)
 @pytest.mark.parametrize(*V1_OR_V2)
 def test_diff_reprojection(
-    structure_version, output_format, data_working_copy, geopackage, cli_runner
+    repo_version, output_format, data_working_copy, geopackage, cli_runner
 ):
     """ diff the working copy against HEAD """
-    data_archive = "points2" if structure_version == "2" else "points"
+    data_archive = "points2" if repo_version == "2" else "points"
     with data_working_copy(data_archive) as (repo, wc):
         # make some changes
         db = geopackage(wc)
@@ -302,18 +302,17 @@ def test_diff_reprojection(
                 5787640.540304652,
             ]
 
-        print("STDOUT", repr(r.stdout))
         if output_format == "quiet":
-            assert r.exit_code == 1, r
+            assert r.exit_code == 1, r.stderr
             assert r.stdout == ""
         elif output_format == "text":
-            assert r.exit_code == 0, r
+            assert r.exit_code == 0, r.stderr
         elif output_format == "geojson":
-            assert r.exit_code == 0, r
+            assert r.exit_code == 0, r.stderr
             featurecollection = json.loads(r.stdout)
             _check_geojson(featurecollection)
         elif output_format == "json":
-            assert r.exit_code == 0, r
+            assert r.exit_code == 0, r.stderr
             odata = json.loads(r.stdout)
             features = odata["sno.diff/v1+hexwkb"]["nz_pa_points_topo_150k"]["feature"]
             assert len(features) == 1

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -31,7 +31,7 @@ def delete_remaining_conflicts(cli_runner):
 def get_json_feature(rs, layer, pk):
     try:
         feature = rs[layer].get_feature(pk, ogr_geoms=False)
-        return json_row(feature)
+        return json_row(feature, pk)
     except KeyError:
         return None
 


### PR DESCRIPTION
## Description

diff/show: Add reprojection using the  `--crs` option.

The form of the argument is quite flexible. Equivalent forms:

* `--crs 2193`
* `--crs epsg:2193`
* `--crs EPSG:2193`

* `--crs '+proj=tmerc +lat_0=0 +lon_0=173 +k=0.9996 +x_0=1600000 +y_0=10000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'`
* `--crs 'PROJCS["NZGD2000 / New Zealand Transverse Mercator 2000",GEOGCS["NZGD2000",DATUM["New_Zealand_Geodetic_Datum_2000",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6167"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4167"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",173],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",1600000],PARAMETER["false_northing",10000000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AUTHORITY["EPSG","2193"]]'`
* `--crs @./nztm.wkt`
* `--crs @./nztm.prj`

I have not added any handling for cases where reprojection fails. The process will error (`RuntimeError` normally) in that case.


## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
