### PR TITLE
Implements `sno data ls` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ### Other changes in this release
 
  * Added `sno create-patch <refish>` - creates a JSON patch file, which can be applied using `sno apply` [#210](https://github.com/koordinates/sno/issues/210)
+ * Added `sno data ls` - shows a list of datasets in the sno repository [#203](https://github.com/koordinates/sno/issues/203)
  * `sno clone` now support shallow clones (`--depth N`) to avoid cloning a repo's entire history [#174](https://github.com/koordinates/sno/issues/174)
  * `sno log` now supports JSON output with `--output-format json` [#170](https://github.com/koordinates/sno/issues/170)
  * `sno meta get` now prints text items as text (not encoded as JSON) [#211](https://github.com/koordinates/sno/issues/211)

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -15,6 +15,7 @@ from . import (
     clone,
     conflicts,
     commit,
+    data,
     diff,
     fsck,
     init,
@@ -164,6 +165,7 @@ cli.add_command(checkout.create_workingcopy)
 cli.add_command(clone.clone)
 cli.add_command(conflicts.conflicts)
 cli.add_command(commit.commit)
+cli.add_command(data.data)
 cli.add_command(diff.diff)
 cli.add_command(fsck.fsck)
 cli.add_command(init.import_table)

--- a/sno/data.py
+++ b/sno/data.py
@@ -1,0 +1,44 @@
+import json
+import sys
+
+import click
+
+from . import status
+from .output_util import dump_json_output
+from .structure import RepositoryStructure
+from .repo_files import RepoState
+
+
+# Changing these items would generally break the repo;
+# we disallow that.
+
+
+@click.group()
+@click.pass_context
+def data(ctx, **kwargs):
+    """Information about the datasets in a repository."""
+
+
+@data.command(name='ls')
+@click.option(
+    "--output-format", "-o", type=click.Choice(["text", "json"]), default="text",
+)
+@click.pass_context
+def data_ls(ctx, output_format):
+    """List all of the datasets in the sno repository"""
+    repo = ctx.obj.get_repo(allowed_states=RepoState.ALL_STATES)
+    if repo.is_empty:
+        ds_paths = []
+    else:
+        rs = RepositoryStructure.lookup(repo, "HEAD")
+        ds_paths = [ds.path for ds in rs]
+
+    if output_format == "text":
+        if ds_paths:
+            for ds_path in ds_paths:
+                click.echo(ds_path)
+        else:
+            ctx.invoke(status.status)
+
+    elif output_format == "json":
+        dump_json_output({"sno.data.ls/v1": ds_paths}, sys.stdout)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,39 @@
+import json
+import pytest
+
+
+@pytest.mark.parametrize("output_format", ("text", "json"))
+@pytest.mark.parametrize(
+    "archive_name", [pytest.param("points", id="1",), pytest.param("points2", id="2")],
+)
+def test_data_ls(archive_name, output_format, data_archive_readonly, cli_runner):
+    # All datasets now support getting metadata in either V1 or V2 format,
+    # but if you don't specify a particular item, they will show all V2 items -
+    # these are more self-explanatory to an end-user.
+    with data_archive_readonly(archive_name):
+        r = cli_runner.invoke(["data", "ls", "-o", output_format])
+        assert r.exit_code == 0, r
+        if output_format == 'text':
+            assert r.stdout.splitlines() == ["nz_pa_points_topo_150k"]
+        else:
+            output = json.loads(r.stdout)
+            assert output == {'sno.data.ls/v1': ['nz_pa_points_topo_150k']}
+
+
+@pytest.mark.parametrize("output_format", ("text", "json"))
+@pytest.mark.parametrize("structure_version", ["1", "2"])
+def test_data_ls_empty(structure_version, output_format, tmp_path, cli_runner, chdir):
+    repo_path = tmp_path / 'emptydir'
+    r = cli_runner.invoke(["init", repo_path, "--version", structure_version])
+    assert r.exit_code == 0
+    with chdir(repo_path):
+        r = cli_runner.invoke(["data", "ls", "-o", output_format])
+        assert r.exit_code == 0, r
+        if output_format == 'text':
+            assert r.stdout.splitlines() == [
+                'Empty repository.',
+                '  (use "sno import" to add some data)',
+            ]
+        else:
+            output = json.loads(r.stdout)
+            assert output == {'sno.data.ls/v1': []}


### PR DESCRIPTION
![](https://media0.giphy.com/media/QQKhpfeRQqz6M/giphy.gif)

## Description

`sno data ls` simply lists all datasets in the current repo at HEAD. Supports text and json output.

## Related links:

https://github.com/koordinates/sno/issues/203

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
