### PR TITLE
Linux packaging update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * Commands which are misspelled now suggest the correct spelling [#199](https://github.com/koordinates/sno/issues/199)
  * Bugfix: operations that should immediately fail due to dirty working copy no longer partially succeed. [#181](https://github.com/koordinates/sno/issues/181)
  * Bugfix: some column datatype conversion issues during import and checkout.
+ * Linux: Add openssh client dependency into rpm & deb packages [#121](https://github.com/koordinates/sno/issues/121)
 
 ## 0.4.1
 

--- a/platforms/linux/fpm.sh
+++ b/platforms/linux/fpm.sh
@@ -14,6 +14,13 @@ find ${WORKDIR} -maxdepth 1 -type f -not -name sno_cli -exec chmod -x {} \;
 # symlink executable
 ln -sf /opt/sno/sno_cli ${WORKDIR}/usr/bin/sno
 
+OPTS=
+if [ "$TYPE" = "deb" ]; then
+    OPTS+="--depends openssh-client"
+elif [ "$TYPE" = "rpm" ]; then
+    OPTS+="--depends openssh-clients"
+fi
+
 # build package
 fpm \
     --verbose \
@@ -23,7 +30,9 @@ fpm \
     --name sno \
     --version "${VERSION}" \
     --url "https://sno.earth" \
+    --license "GPLv2" \
     --architecture amd64 \
     --package /src/dist/ \
     --force \
+    $OPTS \
     .


### PR DESCRIPTION
## Description

* Add `openssh-client` (deb) and `openssh-clients` (rpm) dependency to packages.
* Add license info into packages
* install the ssh dependencies during E2E archive tests
* add Ubuntu Focal as the latest Ubuntu LTS/rolling release, and drop Eoan since it's out of support

## Related links:

Fixes #121 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
