### PR TITLE
Add a `help` subcommand to all CLI groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
  * Added `sno create-patch <refish>` - creates a JSON patch file, which can be applied using `sno apply` [#210](https://github.com/koordinates/sno/issues/210)
  * Added `sno data ls` - shows a list of datasets in the sno repository [#203](https://github.com/koordinates/sno/issues/203)
+ * `sno help [command]` is a synonym for `sno [subcommand] --help` [#221](https://github.com/koordinates/sno/issues/221)
  * `sno clone` now support shallow clones (`--depth N`) to avoid cloning a repo's entire history [#174](https://github.com/koordinates/sno/issues/174)
  * `sno log` now supports JSON output with `--output-format json` [#170](https://github.com/koordinates/sno/issues/170)
  * `sno meta get` now prints text items as text (not encoded as JSON) [#211](https://github.com/koordinates/sno/issues/211)

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -29,7 +29,7 @@ from . import (
     query,
     upgrade,
 )
-from .cli_util import call_and_exit_flag
+from .cli_util import call_and_exit_flag, add_help_subcommand
 from .context import Context
 from .exec import execvp
 
@@ -124,6 +124,7 @@ class SnoGroup(click.Group):
             return super().invoke(ctx)
 
 
+@add_help_subcommand
 @click.group(cls=SnoGroup)
 @click.option(
     "-C",

--- a/sno/cli_util.py
+++ b/sno/cli_util.py
@@ -3,6 +3,20 @@ import click
 import jsonschema
 
 
+def add_help_subcommand(group):
+    @group.command(add_help_option=False, hidden=True)
+    @click.argument('topic', default=None, required=False, nargs=1)
+    @click.pass_context
+    def help(ctx, topic, **kw):
+        # https://www.burgundywall.com/post/having-click-help-subcommand
+        if topic is None:
+            print(ctx.parent.get_help())
+        else:
+            print(group.commands[topic].get_help(ctx))
+
+    return group
+
+
 class MutexOption(click.Option):
     """
     Mutually exclusive options

--- a/sno/data.py
+++ b/sno/data.py
@@ -1,9 +1,9 @@
-import json
 import sys
 
 import click
 
 from . import status
+from .cli_util import add_help_subcommand
 from .output_util import dump_json_output
 from .structure import RepositoryStructure
 from .repo_files import RepoState
@@ -13,6 +13,7 @@ from .repo_files import RepoState
 # we disallow that.
 
 
+@add_help_subcommand
 @click.group()
 @click.pass_context
 def data(ctx, **kwargs):

--- a/sno/meta.py
+++ b/sno/meta.py
@@ -4,7 +4,7 @@ import io
 import click
 
 from .apply import apply_patch
-from .cli_util import StringFromFile
+from .cli_util import StringFromFile, add_help_subcommand
 from .exceptions import InvalidOperation
 from .output_util import (
     dump_json_output,
@@ -23,6 +23,7 @@ READONLY_ITEMS = {
 }
 
 
+@add_help_subcommand
 @click.group()
 @click.pass_context
 def meta(ctx, **kwargs):

--- a/sno/upgrade/__init__.py
+++ b/sno/upgrade/__init__.py
@@ -1,8 +1,10 @@
 import click
 
 from . import upgrade_00_02, upgrade_02_05  # noqa
+from sno.cli_util import add_help_subcommand
 
 
+@add_help_subcommand
 @click.group()
 def upgrade():
     """ Upgrade repositories between versions of Sno """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,4 +17,6 @@ def test_version(cli_runner):
 def test_cli_help():
     click_app = cli.cli
     for name, cmd in click_app.commands.items():
+        if name == 'help':
+            continue
         assert cmd.help, f"`{name}` command has no help text"


### PR DESCRIPTION

## Description

This adds a `help` command to all CLI groups including `sno` itself.

Synonym examples:
`sno help` == `sno --help`
`sno help commit` == sno commit --help`
`sno data help` == `sno data --help`
`sno data help ls` == `sno data ls --help`

This can't be automatically valid for all commands because it could make
the meaning ambiguous. However, it can be valid for all *groups*, which
is probably 99% of the cases it's useful.

For instance, `sno diff help` doesn't make sense because `help` could be
the name of a dataset and thus there's an ambiguity here


## Related links:

Fixes #127

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
