### PR TITLE
`show -o json`: change header to `sno.show/v1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Existing commands are backward compatible with V1 datasets, however some new fun
  * New structure to `sno diff` output:
     - Text output: Features are now labelled as `<dataset>:feature:<primary_key>`, consistent with meta items that are labelled as `<dataset>:meta:<meta_item_name>`
     - JSON output also uses "feature" and "meta" as keys for the different types of changes, instead of "featureChanges" and "metaChanges".
+ * `sno show -o json` header key changed to `sno.show/v1`, which is not an applyable patch. Use `sno create-patch` to create a patch.
 
 ### Other changes in this release
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -104,7 +104,7 @@ def test_meta_set(data_archive, cli_runner):
         r = cli_runner.invoke(["show", "-o", "json"])
         assert r.exit_code == 0, r.stderr
         output = json.loads(r.stdout)
-        patch_info = output.pop('sno.patch/v1')
+        patch_info = output.pop('sno.show/v1')
         assert patch_info['message'] == 'Update metadata for nz_pa_points_topo_150k'
         meta = output['sno.diff/v1+hexwkb']['nz_pa_points_topo_150k']['meta']
         assert meta['title'] == {'-': 'NZ Pa Points (Topo, 1:50k)', '+': 'newtitle'}


### PR DESCRIPTION

## Description

Now that `show` supports geometry reprojection, we can't call the output
a 'patch' because it can't be applied to a dataset. We added the
`create-patch` command to produce patches. So this changes the key
so that `show` output is harder to confuse with an applyable patch.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
