### PR TITLE
import: Add `--replace-existing` option

### DIFF
--- a/sno/init.py
+++ b/sno/init.py
@@ -14,7 +14,7 @@ from .cli_util import call_and_exit_flag, MutexOption, StringFromFile, JsonFromF
 from .exceptions import InvalidOperation
 from .import_source import ImportSource
 from .ogr_import_source import OgrImportSource, FORMAT_TO_OGR_MAP
-from .fast_import import fast_import_tables
+from .fast_import import fast_import_tables, ReplaceExisting
 from .structure import RepositoryStructure
 from .repository_version import (
     write_repo_version_config,
@@ -254,7 +254,9 @@ def import_table(
             import_sources,
             message=message,
             max_delta_depth=max_delta_depth,
-            replace_existing=replace_existing,
+            replace_existing=ReplaceExisting.GIVEN
+            if replace_existing
+            else ReplaceExisting.NONE,
         )
 
     rs = RepositoryStructure(repo)

--- a/sno/init.py
+++ b/sno/init.py
@@ -40,7 +40,7 @@ def list_import_formats(ctx, param, value):
         click.echo(n)
 
 
-def _add_datasets_to_working_copy(repo, *datasets):
+def _add_datasets_to_working_copy(repo, *datasets, replace_existing=False):
     wc = WorkingCopy.get(repo, create_if_missing=True)
     if not wc:
         return
@@ -53,6 +53,8 @@ def _add_datasets_to_working_copy(repo, *datasets):
         click.echo(f'Updating {wc.path} ...')
 
     for dataset in datasets:
+        if replace_existing:
+            wc.drop_table(commit, dataset)
         wc.write_full(commit, dataset)
 
 
@@ -146,6 +148,11 @@ def temporary_branch(repo):
     help="Which field to use as the primary key. Must be unique. Auto-detected when possible.",
 )
 @click.option(
+    "--replace-existing",
+    is_flag=True,
+    help="Replace existing dataset(s) of the same name.",
+)
+@click.option(
     "--max-delta-depth",
     hidden=True,
     default=0,
@@ -162,6 +169,7 @@ def import_table(
     source,
     tables,
     table_info,
+    replace_existing,
     max_delta_depth,
 ):
     """
@@ -218,6 +226,20 @@ def import_table(
             description=info.get('description'),
             xml_metadata=info.get('xmlMetadata'),
         )
+        if replace_existing:
+            rs = RepositoryStructure(repo)
+            try:
+                existing_ds = rs[dest_path]
+            except KeyError:
+                # no such existing dataset. no problems
+                pass
+            else:
+                # Align the column IDs to the existing schema.
+                # This is important, otherwise importing the same data twice
+                # will result in a new schema object, and thus a new blob for every feature.
+                import_source.schema = existing_ds.schema.align_to_self(
+                    import_source.schema
+                )
         import_source.dest_path = dest_path
         import_sources.append(import_source)
 
@@ -228,11 +250,19 @@ def import_table(
 
     with ctx:
         fast_import_tables(
-            repo, import_sources, message=message, max_delta_depth=max_delta_depth,
+            repo,
+            import_sources,
+            message=message,
+            max_delta_depth=max_delta_depth,
+            replace_existing=replace_existing,
         )
 
     rs = RepositoryStructure(repo)
-    _add_datasets_to_working_copy(repo, *[rs[s.dest_path] for s in import_sources])
+    _add_datasets_to_working_copy(
+        repo,
+        *[rs[s.dest_path] for s in import_sources],
+        replace_existing=replace_existing,
+    )
 
 
 @click.command()

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -69,6 +69,8 @@ class RepositoryStructure:
 
     def __getitem__(self, path):
         """ Get a specific dataset by path """
+        if self.tree is None:
+            raise KeyError(path)
         return self.get_at(path, self.tree)
 
     def __eq__(self, other):
@@ -105,6 +107,8 @@ class RepositoryStructure:
         return (dataset_path,) + self.get(dataset_path).decode_path(rel_path)
 
     def get(self, path):
+        if self.tree is None:
+            return None
         try:
             return self.get_at(path, self.tree)
         except KeyError:

--- a/sno/upgrade/__init__.py
+++ b/sno/upgrade/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from . import upgrade_v0, upgrade_v1
 from sno import checkout, context
 from sno.exceptions import InvalidOperation
-from sno.fast_import import fast_import_tables
+from sno.fast_import import fast_import_tables, ReplaceExisting
 from sno.repository_version import get_repo_version, write_repo_version_config
 
 
@@ -143,7 +143,7 @@ def _upgrade_commit(
     fast_import_tables(
         dest_repo,
         sources,
-        incremental=False,
+        replace_existing=ReplaceExisting.ALL,
         quiet=True,
         header=header,
         # We import every commit onto refs/heads/master, even though not all commits are related - this means

--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -774,7 +774,7 @@ class WorkingCopyGPKG(WorkingCopy):
                 if dataset.has_geometry:
                     self._drop_spatial_index(dataset)
 
-                dbcur.execute(f"""DROP TABLE {gpkg.ident(table)};""")
+                dbcur.execute(f"""DROP TABLE IF EXISTS {gpkg.ident(table)};""")
                 self.delete_meta(dataset)
 
                 dbcur.execute(


### PR DESCRIPTION
## Description

Adds `--replace-existing` option to the `import` command.

Replaces existing dataset(s) with the same name.

All meta and features are replaced. Git takes care of deduplicating the feature objects, so this can be used as a way of adding versioning to third-party data (as long as it was produced with a stable primary key field)

## Related links:

Fixes #112 

## Checklist:

- [ ] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
