### PR TITLE
Make `--replace-existing` efficient with minor schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Existing commands are backward compatible with V1 datasets, however some new fun
      - this includes column adds, drops, renames and reordering.
      - Notably, changing the primary key field of a dataset are not yet supported.
  * Meta changes are now supported (title, description and XML metadata for each dataset)
+ * `import` now has a `--replace-existing` flag to replace existing dataset(s).
 
 #### Missing functionality in Datasets V2
 

--- a/sno/dataset1.py
+++ b/sno/dataset1.py
@@ -358,7 +358,7 @@ class Dataset1(DatasetStructure):
                 json.dumps(value).encode("utf8"),
             )
 
-    def import_iter_feature_blobs(self, resultset, source):
+    def import_iter_feature_blobs(self, resultset, source, replacing_dataset=None):
         """For the given import source, yields the feature blobs that should be written."""
         pk_field = source.primary_key
 

--- a/sno/dataset2.py
+++ b/sno/dataset2.py
@@ -322,37 +322,51 @@ class Dataset2(DatasetStructure):
             content = json_pack(content) if is_json else ensure_bytes(content)
             yield self.full_path(rel_path), content
 
+    def iter_legend_blob_data(self):
+        """
+        Generates (full_path, blob_data) tuples for each legend in this dataset
+        """
+        legend_tree = self.meta_tree / 'legend'
+        for blob in legend_tree:
+            yield (
+                self.full_path(self.LEGEND_PATH + blob.name),
+                blob.data,
+            )
+
     def import_iter_feature_blobs(self, resultset, source, replacing_dataset=None):
         schema = source.schema
-        if replacing_dataset is not None:
-            # Optimisation to avoid bloated repos:
-            for feature in resultset:
-                pk_values = (feature[replacing_dataset.primary_key],)
-                rel_path = self.encode_pks_to_path(pk_values, relative=True)
-                try:
-                    existing_data = replacing_dataset.get_data_at(
-                        rel_path, as_memoryview=True
-                    )
-                except KeyError:
-                    # this feature isn't in the dataset we're replacing
-                    yield self.encode_feature(feature, schema)
-                    continue
+        if replacing_dataset is not None and replacing_dataset.schema != source.schema:
+            # Optimisation: Try to avoid rewriting features for compatible schema changes.
+            change_types = replacing_dataset.schema.diff_type_counts(source.schema)
+            if not change_types["pk_updates"]:
+                # We can probably avoid rewriting all features.
+                for feature in resultset:
+                    pk_values = (feature[replacing_dataset.primary_key],)
+                    rel_path = self.encode_pks_to_path(pk_values, relative=True)
+                    try:
+                        existing_data = replacing_dataset.get_data_at(
+                            rel_path, as_memoryview=True
+                        )
+                    except KeyError:
+                        # this feature isn't in the dataset we're replacing
+                        yield self.encode_feature(feature, schema)
+                        continue
 
-                existing_feature_raw_dict = replacing_dataset.get_raw_feature_dict(
-                    pk_values, data=existing_data
-                )
-                # This adapts the existing feature to the new schema
-                existing_feature = schema.feature_from_raw_dict(
-                    existing_feature_raw_dict
-                )
-                if existing_feature == feature:
-                    # Nothing changed? No need to rewrite the feature blob
-                    yield self.encode_pks_to_path(pk_values), existing_data
-                else:
-                    yield self.encode_feature(feature, schema)
-        else:
-            for feature in resultset:
-                yield self.encode_feature(feature, schema)
+                    existing_feature_raw_dict = replacing_dataset.get_raw_feature_dict(
+                        pk_values, data=existing_data
+                    )
+                    # This adapts the existing feature to the new schema
+                    existing_feature = schema.feature_from_raw_dict(
+                        existing_feature_raw_dict
+                    )
+                    if existing_feature == feature:
+                        # Nothing changed? No need to rewrite the feature blob
+                        yield self.encode_pks_to_path(pk_values), existing_data
+                    else:
+                        yield self.encode_feature(feature, schema)
+                return
+        for feature in resultset:
+            yield self.encode_feature(feature, schema)
 
     @property
     def primary_key(self):

--- a/sno/init.py
+++ b/sno/init.py
@@ -228,6 +228,10 @@ def import_table(
         )
         if replace_existing:
             rs = RepositoryStructure(repo)
+            if rs.version < 2:
+                raise InvalidOperation(
+                    f"--replace-existing is not supported for V{rs.version} datasets"
+                )
             try:
                 existing_ds = rs[dest_path]
             except KeyError:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -253,8 +253,10 @@ def test_import_replace_existing_with_compatible_schema_changes(
             )
             assert r.exit_code == 0, r.stderr
 
-            # Now make a view which doesn't include the `survey_reference` column,
-            # and has the columns in a different order
+            # Now replace with a table which
+            # * doesn't include the `survey_reference` column
+            # * has the columns in a different order
+            # * has a new column
             db = geopackage(data / "nz-waca-adjustments.gpkg")
             dbcur = db.cursor()
             dbcur.execute(
@@ -263,10 +265,11 @@ def test_import_replace_existing_with_compatible_schema_changes(
                         "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                         "geom" MULTIPOLYGON,
                         "date_adjusted" DATETIME,
-                        "adjusted_nodes" MEDIUMINT
+                        "adjusted_nodes" MEDIUMINT,
+                        "newcolumn" TEXT
                     );
-                    INSERT INTO nz_waca_adjustments_2 (id, geom, date_adjusted, adjusted_nodes)
-                        SELECT id, geom, date_adjusted, adjusted_nodes FROM nz_waca_adjustments
+                    INSERT INTO nz_waca_adjustments_2 (id, geom, date_adjusted, adjusted_nodes, newcolumn)
+                        SELECT id, geom, date_adjusted, adjusted_nodes, NULL FROM nz_waca_adjustments
                     ;
                     DROP TABLE nz_waca_adjustments;
                     ALTER TABLE nz_waca_adjustments_2 RENAME TO nz_waca_adjustments;

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,7 @@ import pytest
 import pygit2
 
 
+from sno.structure import RepositoryStructure
 from sno.working_copy import WorkingCopy
 from sno.exceptions import (
     INVALID_OPERATION,
@@ -233,6 +234,69 @@ def test_import_replace_existing(
                     ]
                 }
             }
+
+
+def test_import_replace_existing_with_compatible_schema_changes(
+    data_archive, tmp_path, cli_runner, chdir, geopackage,
+):
+    with data_archive("gpkg-polygons") as data:
+        repo_path = tmp_path / 'emptydir'
+        r = cli_runner.invoke(["init", repo_path])
+        assert r.exit_code == 0
+        with chdir(repo_path):
+            r = cli_runner.invoke(
+                [
+                    "import",
+                    data / "nz-waca-adjustments.gpkg",
+                    "nz_waca_adjustments:mytable",
+                ]
+            )
+            assert r.exit_code == 0, r.stderr
+
+            # Now make a view which doesn't include the `survey_reference` column,
+            # and has the columns in a different order
+            db = geopackage(data / "nz-waca-adjustments.gpkg")
+            dbcur = db.cursor()
+            dbcur.execute(
+                """
+                    CREATE TABLE IF NOT EXISTS "nz_waca_adjustments_2" (
+                        "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        "geom" MULTIPOLYGON,
+                        "date_adjusted" DATETIME,
+                        "adjusted_nodes" MEDIUMINT
+                    );
+                    INSERT INTO nz_waca_adjustments_2 (id, geom, date_adjusted, adjusted_nodes)
+                        SELECT id, geom, date_adjusted, adjusted_nodes FROM nz_waca_adjustments
+                    ;
+                    DROP TABLE nz_waca_adjustments;
+                    ALTER TABLE nz_waca_adjustments_2 RENAME TO nz_waca_adjustments;
+                """
+            )
+
+            r = cli_runner.invoke(
+                [
+                    "import",
+                    "--replace-existing",
+                    data / "nz-waca-adjustments.gpkg",
+                    "nz_waca_adjustments:mytable",
+                ]
+            )
+            assert r.exit_code == 0, r.stderr
+            r = cli_runner.invoke(["show", "-o", "json"])
+            assert r.exit_code == 0, r.stderr
+            diff = json.loads(r.stdout)["sno.diff/v1+hexwkb"]["mytable"]
+
+            # The schema changed, but the features didn't.
+            assert diff["meta"]["schema.json"]
+            assert not diff.get("feature")
+
+            repo = pygit2.Repository(str(repo_path))
+            head_rs = RepositoryStructure.lookup(repo, "HEAD")
+            old_rs = RepositoryStructure.lookup(repo, "HEAD^")
+            assert head_rs.tree != old_rs.tree
+            new_feature_tree = head_rs.tree / "mytable/.sno-dataset/feature"
+            old_feature_tree = old_rs.tree / "mytable/.sno-dataset/feature"
+            assert new_feature_tree == old_feature_tree
 
 
 @pytest.mark.parametrize(*V1_OR_V2)


### PR DESCRIPTION
## Description
`sno import --replace-existing`  (#229) currently rewrites all features if
any schema change occurs, because it passes all features directly to
fast-import.

However, Datasets V2 theoretically supports many schema changes without
rewriting features:
 * re-named columns
 * re-ordered columns
 * dropped columns

This commit adds some checks to the importer to re-use existing feature
blobs in those cases.

This will slow down imports if those schema changes are present,
because the importer has to perform additional checks on each feature
to compare them against the corresponding feature in the existing HEAD.

However, it should cause sizable reductions in unnecessary repo
bloat over time.

The importer now deserialises the existing feature from the repo, and
compares it against the new feature. If the results are the same, the
old feature blob is re-used directly, and no new blob is created.

## Related links:

#229 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
