### PR TITLE
Better support for custom CRS

### DIFF
--- a/sno/crs_util.py
+++ b/sno/crs_util.py
@@ -1,14 +1,34 @@
 from osgeo.osr import SpatialReference
 
 
-def get_identifier(crs):
+def get_identifier_str(crs):
     """
-    Given a CRS, generate a unique idenfier for it. Eg: "EPSG:2193"
+    Given a CRS, generate a stable, unique identifier for it of type 'str'. Eg: "EPSG:2193"
     """
     if isinstance(crs, str):
         crs = SpatialReference(crs)
-    if isinstance(crs, SpatialReference):
-        auth_name = crs.GetAuthorityName(None)
-        auth_code = crs.GetAuthorityCode(None)
+    if not isinstance(crs, SpatialReference):
+        raise RuntimeError(f"Unrecognised CRS: {crs}")
+    auth_name = crs.GetAuthorityName(None)
+    auth_code = crs.GetAuthorityCode(None)
+    if auth_name and auth_code:
         return f"{auth_name}:{auth_code}"
-    raise RuntimeError(f"Unrecognised CRS: {crs}")
+    code = auth_name or auth_code
+    if code and code.strip() not in ("0", "EPSG"):
+        return code
+    return f"CUSTOM:{get_identifier_int(crs)}"
+
+
+def get_identifier_int(crs):
+    """
+    Given a CRS, generate a stable, unique identifer for it of type 'int'. Eg: 2193
+    """
+    if isinstance(crs, str):
+        crs = SpatialReference(crs)
+    if not isinstance(crs, SpatialReference):
+        raise RuntimeError(f"Unrecognised CRS: {crs}")
+    auth_code = crs.GetAuthorityCode(None)
+    if auth_code and auth_code.isdigit() and int(auth_code) > 0:
+        return int(auth_code)
+    # Stable code that fits easily in an int32 and won't collide with EPSG codes.
+    return (hash(crs.ExportToWkt()) & 0xFFFFFFF) + 1000000

--- a/sno/gpkg_adapter.py
+++ b/sno/gpkg_adapter.py
@@ -114,7 +114,7 @@ def all_v2_crs_definitions(gpkg_obj):
         definition = gsrs["definition"]
         if not definition or definition == "undefined":
             continue
-        yield crs_util.get_identifier(definition), definition
+        yield crs_util.get_identifier_str(definition), definition
 
 
 def get_table_name(gpkg_obj):
@@ -203,11 +203,9 @@ def _gpkg_srs_id(v2_obj):
 
 def wkt_to_gpkg_spatial_ref_sys(wkt):
     """Given a WKT crs definition, generate a gpkg_spatial_ref_sys meta item."""
-    # TODO: Better support for custom WKT. https://github.com/koordinates/sno/issues/148
     spatial_ref = SpatialReference(wkt)
-    spatial_ref.AutoIdentifyEPSG()
     organization = spatial_ref.GetAuthorityName(None) or "NONE"
-    srs_id = spatial_ref.GetAuthorityCode(None) or 0
+    srs_id = crs_util.get_identifier_int(spatial_ref)
     return [
         {
             "srs_name": spatial_ref.GetName(),
@@ -221,7 +219,7 @@ def wkt_to_gpkg_spatial_ref_sys(wkt):
 
 
 def wkt_to_v2_name(wkt):
-    identifier = crs_util.get_identifier(wkt)
+    identifier = crs_util.get_identifier_str(wkt)
     return f"crs/{identifier}.wkt"
 
 
@@ -355,7 +353,7 @@ def _gkpg_geometry_columns_to_v2_type(ggc, gsrs):
 
     crs_identifier = None
     if gsrs and gsrs[0]["definition"]:
-        crs_identifier = crs_util.get_identifier(gsrs[0]["definition"])
+        crs_identifier = crs_util.get_identifier_str(gsrs[0]["definition"])
 
     extra_type_info = {
         "geometryType": f"{geometry_type} {z}{m}".strip(),

--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -400,15 +400,7 @@ class WorkingCopyGPKG(WorkingCopy):
         Calling Schema.align_* is required to find how the columns matches the existing schema.
         """
         with self.session() as db:
-            gpkg_meta_items = dict(gpkg.get_meta_items(db, dataset.table_name))
-
-        class GpkgTableMetaItems:
-            def __init__(self, name, gpkg_meta_items):
-                self.name = name
-                self.gpkg_meta_items = gpkg_meta_items
-
-            def get_gpkg_meta_item(self, path):
-                return gpkg_meta_items[path]
+            gpkg_meta_items_obj = gpkg.get_gpkg_meta_items_obj(db, dataset.table_name)
 
         gpkg_name = os.path.basename(self.path)
 
@@ -418,9 +410,7 @@ class WorkingCopyGPKG(WorkingCopy):
         # for two unrelated columns.
         id_salt = f"{gpkg_name} {dataset.table_name} {self.get_db_tree()}"
 
-        yield from gpkg_adapter.all_v2_meta_items(
-            GpkgTableMetaItems(dataset.table_name, gpkg_meta_items), id_salt=id_salt
-        )
+        yield from gpkg_adapter.all_v2_meta_items(gpkg_meta_items_obj, id_salt=id_salt)
 
     def delete_meta(self, dataset):
         table_name = dataset.table_name

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -568,6 +568,25 @@ def test_init_import(
         else:
             assert not xml_metadata
 
+        srs_definition = (
+            db.cursor()
+            .execute(
+                f"""
+            SELECT srs.definition
+            FROM gpkg_spatial_ref_sys srs JOIN gpkg_geometry_columns geom
+            ON srs.srs_id = geom.srs_id
+            WHERE geom.table_name = '{table}'
+            """
+            )
+            .fetchone()
+        )
+        if table == "nz_pa_points_topo_150k":
+            assert srs_definition[0].startswith('GEOGCS["WGS 84",DATUM["WGS_1984"')
+        elif table == "nz_waca_adjustments":
+            assert srs_definition[0].startswith(
+                'GEOGCS["NZGD2000",DATUM["New_Zealand_Geodetic_Datum_2000"'
+            )
+
         H.verify_gpkg_extent(db, table)
         with chdir(repo_path):
             # check that we can view the commit we created


### PR DESCRIPTION
![](https://media0.giphy.com/media/dtjfmbZhDM4m3YrVpI/giphy.gif)

## Description

Fix a few loose ends to do with CRS import / working copy generation, so that custom CRS can imported and roundtripped properly.

- don't call SpatialReference.AutoIdentifyEPSG() - this can change the CRS definition.
- in fact, don't roundtrip through SpatialReference(wkt).ExportToWkt() at all, if it can be helped - this can change the CRS definition too.

To avoid this second one, we now pull the CRS definition straight from GPKG for a GPKGImportSource, not through OGR.

## Related links:

Fixes https://github.com/koordinates/sno/issues/148

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
