### PR TITLE
Windows: Fix missing PROJ data in builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,6 +475,7 @@ jobs:
           if (Test-Path install.log -PathType leaf) { Get-Content install.log }
           $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" +[System.Environment]::GetEnvironmentVariable("Path", "User")
           & sno --version
+          & tests\scripts\distcheck.ps1
           & tests\scripts\e2e-1.ps1
 
       #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ Existing commands are backward compatible with V1 datasets, however some new fun
  * Commands which are misspelled now suggest the correct spelling [#199](https://github.com/koordinates/sno/issues/199)
  * Bugfix: operations that should immediately fail due to dirty working copy no longer partially succeed. [#181](https://github.com/koordinates/sno/issues/181)
  * Bugfix: some column datatype conversion issues during import and checkout.
- * Linux: Add openssh client dependency into rpm & deb packages [#121](https://github.com/koordinates/sno/issues/121)
+ * Linux: Add openssh client dependency into rpm & deb packages. [#121](https://github.com/koordinates/sno/issues/121)
+ * Windows: Fix missing PROJ data files in packages. [#235](https://github.com/koordinates/sno/issues/235)
 
 ## 0.4.1
 

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -67,9 +67,14 @@ def print_version(ctx):
         *[int(k) for k in re.findall(r"\d\d", str(psycopg2.__libpq_version__))]
     )
 
+    proj_version = "{}.{}.{}".format(
+        osgeo.osr.GetPROJVersionMajor(), osgeo.osr.GetPROJVersionMinor(), osgeo.osr.GetPROJVersionMicro()
+    )
+
     click.echo(
         (
-            f"» GDAL v{osgeo._gdal.__version__}\n"
+            f"» GDAL v{osgeo._gdal.__version__}; "
+            f"PROJ v{proj_version}\n"
             f"» PyGit2 v{pygit2.__version__}; "
             f"Libgit2 v{pygit2.LIBGIT2_VERSION}; "
             f"Git v{git_version}\n"

--- a/tests/scripts/distcheck.ps1
+++ b/tests/scripts/distcheck.ps1
@@ -1,0 +1,25 @@
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'stop'
+
+$SNO_PATH=(Get-Command sno).source
+If ((Get-Item $SNO_PATH).Directory.Name -eq 'Scripts') {
+    # Virtualenv
+    $SNO_PREFIX=(Get-Item (Get-Command sno).source).Directory.Parent.FullName
+    throw (">>> Error: Found Sno in a Virtualenv at $SNO_PREFIX")
+} Else {
+    # Installation
+    $SNO_PREFIX=(Get-Item (Get-Command sno).source).DirectoryName
+}
+Write-Output "Sno is at: ${SNO_PATH} (Prefix: ${SNO_PREFIX})"
+
+# Check PROJ and GDAL data files are installed
+if (! (Test-Path "${SNO_PREFIX}\osgeo\data\proj\proj.db")) {
+    Write-Output ">>> Error: Couldn't find PROJ data files"
+    Exit 1
+}
+if (! (Test-Path "${SNO_PREFIX}\osgeo\data\gdal\gdalvrt.xsd")) {
+    Write-Output ">>> Error: Couldn't find GDAL data files"
+    Exit 1
+}
+
+Write-Output ">>> Success"

--- a/tests/scripts/e2e-1.ps1
+++ b/tests/scripts/e2e-1.ps1
@@ -71,7 +71,7 @@ try {
     }
 
     Exec { sno status }
-    Exec { sno diff }
+    Exec { sno diff --crs=EPSG:3857 }
     Exec { sno commit -m 'my-commit' }
     Exec { sno switch 'master' }
     Exec { sno status }

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -46,7 +46,7 @@ sqlite3 --bail test.gpkg "
   INSERT INTO mylayer (fid, geom) VALUES (999, GeomFromEWKT('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'));
 "
 sno status
-sno diff
+sno diff --crs=EPSG:3857
 sno commit -m my-commit
 sno switch master
 sno status


### PR DESCRIPTION
## Description

* PROJ data files don't appear to be picked up by PyInstaller's osgeo/gdal
hook, so include them explicitly.
* add a distcheck PowerShell script for Windows and run it during CI. Currently checks for GDAL & PROJ data files only. Rough corollary of the existing `distcheck.sh` script.
* report PROJ version via `sno --version`

## Related links:

Similar to #42 but for Windows.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
