### PR TITLE
User from env

### DIFF
--- a/sno/fast_import.py
+++ b/sno/fast_import.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 import click
 import pygit2
 
-from . import core
+from . import git_util
 from .exceptions import SubprocessError, InvalidOperation
 from .import_source import ImportSource
 from .structure import DatasetStructure, RepositoryStructure
@@ -218,10 +218,12 @@ def generate_header(repo, sources, message):
     if message is None:
         message = generate_message(sources)
 
-    user = repo.default_signature
+    author = git_util.author_signature(repo)
+    committer = git_util.committer_signature(repo)
     return (
         f"commit {get_head_branch(repo)}\n"
-        f"committer {user.name} <{user.email}> now\n"
+        f"author {author.name} <{author.email}> now\n"
+        f"committer {committer.name} <{committer.email}> now\n"
         f"data {len(message.encode('utf8'))}\n{message}\n"
     )
 

--- a/sno/git_util.py
+++ b/sno/git_util.py
@@ -1,4 +1,9 @@
+import re
+import subprocess
+
 import pygit2
+
+from .timestamps import tz_offset_to_minutes
 
 EMPTY_TREE_ID = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
@@ -42,3 +47,31 @@ def replace_subtree(repo, root_tree, subpath, subtree_or_blob):
             builder.insert(head, replaced, typ)
 
         return repo.get(builder.write())
+
+
+_GIT_VAR_OUTPUT_RE = re.compile(
+    r"^(?P<name>.*) <(?P<email>[^>]*)> (?P<time>\d+) (?P<offset>[+-]?\d+)$"
+)
+
+
+def _signature(repo, var_name, **overrides):
+    # 'git var' lets us use the environment variables to
+    # control the user info, e.g. GIT_AUTHOR_DATE.
+    # libgit2/pygit2 doesn't handle those env vars at all :(
+    output = subprocess.check_output(
+        ['git', 'var', var_name], cwd=repo.path, encoding='utf8'
+    )
+    m = _GIT_VAR_OUTPUT_RE.match(output)
+    kwargs = m.groupdict()
+    kwargs['time'] = int(kwargs['time'])
+    kwargs['offset'] = tz_offset_to_minutes(kwargs['offset'])
+    kwargs.update(overrides)
+    return pygit2.Signature(**kwargs)
+
+
+def author_signature(repo, **overrides):
+    return _signature(repo, 'GIT_AUTHOR_IDENT', **overrides)
+
+
+def committer_signature(repo, **overrides):
+    return _signature(repo, 'GIT_COMMITTER_IDENT', **overrides)

--- a/sno/timestamps.py
+++ b/sno/timestamps.py
@@ -66,9 +66,9 @@ def tz_offset_to_minutes(tz_offset_string):
     Takes a timestamp offset string ('+HHMM') and converts it to
     an integer number of minutes (for pygit2.Signature.offset)
     """
-    as_int = int(tz_offset_string)
+    as_int = int(tz_offset_string.replace(':', ''))
     hours, minutes = divmod(abs(as_int), 100)
     total_minutes = 60 * hours + minutes
     if as_int < 0:
-        total_minutes *= -1
+        total_minutes = -total_minutes
     return total_minutes

--- a/sno/timestamps.py
+++ b/sno/timestamps.py
@@ -49,3 +49,26 @@ def commit_time_to_text(iso8601z, iso8601_tz):
     dt = iso8601_utc_to_datetime(iso8601z)
     tz = timezone(iso8601_tz_to_timedelta(iso8601_tz))
     return dt.astimezone(tz).strftime("%c %z")
+
+
+def minutes_to_tz_offset(tz_offset_minutes):
+    """
+    Takes a pygit2 tz offset (integer number of minutes)
+    and converts it to a timestamp offset string ('+HHMM')
+    """
+    hours, minutes = divmod(abs(tz_offset_minutes), 60)
+    sign = "+" if tz_offset_minutes >= 0 else "-"
+    return f"{sign}{hours:02}{minutes:02}"
+
+
+def tz_offset_to_minutes(tz_offset_string):
+    """
+    Takes a timestamp offset string ('+HHMM') and converts it to
+    an integer number of minutes (for pygit2.Signature.offset)
+    """
+    as_int = int(tz_offset_string)
+    hours, minutes = divmod(abs(as_int), 100)
+    total_minutes = 60 * hours + minutes
+    if as_int < 0:
+        total_minutes *= -1
+    return total_minutes

--- a/sno/upgrade/__init__.py
+++ b/sno/upgrade/__init__.py
@@ -11,6 +11,7 @@ from sno import checkout, context
 from sno.exceptions import InvalidOperation
 from sno.fast_import import fast_import_tables, ReplaceExisting
 from sno.repository_version import get_repo_version, write_repo_version_config
+from sno.timestamps import minutes_to_tz_offset
 
 
 @click.command()
@@ -114,12 +115,6 @@ def upgrade(ctx, source, dest):
     click.secho("\nUpgrade complete", fg="green", bold=True)
 
 
-def _raw_time(timestamp, tz_offset_minutes):
-    hours, minutes = divmod(abs(tz_offset_minutes), 60)
-    sign = "+" if tz_offset_minutes >= 0 else "-"
-    return f"{timestamp} {sign}{hours:02}{minutes:02}"
-
-
 def _upgrade_commit(
     i, source_repo, source_commit, source_version, dest_parents, dest_repo, commit_map,
 ):
@@ -129,8 +124,8 @@ def _upgrade_commit(
     feature_count = sum(s.feature_count for s in sources)
 
     s = source_commit
-    author_time = _raw_time(s.author.time, s.author.offset)
-    commit_time = _raw_time(s.commit_time, s.commit_time_offset)
+    author_time = f'{s.author.time} {minutes_to_tz_offset(s.author.offset)}'
+    commit_time = f'{s.commit_time} {minutes_to_tz_offset(s.commit_time_offset)}'
     header = (
         # We import every commit onto refs/heads/master and fix the branch heads later.
         "commit refs/heads/master\n"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,8 @@
 import json
+import shutil
+
 import pytest
 import pygit2
-
 
 from sno.structure import RepositoryStructure
 from sno.working_copy import WorkingCopy
@@ -749,7 +750,7 @@ def test_init_import_alt_names(data_archive, tmp_path, cli_runner, chdir, geopac
 
 @pytest.mark.slow
 def test_init_import_home_resolve(
-    data_archive, tmp_path, cli_runner, chdir, monkeypatch
+    data_archive, tmp_path, cli_runner, chdir, monkeypatch, git_user_config
 ):
     """ Import from a ~-specified gpkg path """
     repo_path = tmp_path / "data.sno"
@@ -761,6 +762,11 @@ def test_init_import_home_resolve(
     with data_archive("gpkg-points") as source_path:
         with chdir(repo_path):
             monkeypatch.setenv("HOME", str(source_path))
+
+            # make sure we have a .gitconfig file in HOME,
+            # otherwise sno can't find the user information for the commit
+            orig_home = git_user_config[2]
+            shutil.copy2(orig_home / ".gitconfig", source_path)
 
             r = cli_runner.invoke(
                 [


### PR DESCRIPTION
## Description

sno currently ignores environment variables when selecting an author and committer for a commit, in all the places I found where we make commits:

* `apply`
* `commit`
* `import`
* `meta set`

It'd be useful for scripts calling sno to be able to use `GIT_AUTHOR_EMAIL` etc.

Unfortunately libgit2 & pygit2 don't seem to have any builtin support for this. I did find this PR on libgit2 which will add a way to get this information, but it looks like it'll require the caller to use it explicitly, and even after that is merged it would need to find it's way into pygit2 so we could use it: libgit2/libgit2#4409

Since the precedence of the many ways of setting user info is quite complex, I didn't really want to implement it myself and risk getting it subtly different to the git implementation. After some experimentation we found the `git var` command which takes care of returning the right information given the repository and global config as well as the various environment variables. Just parsing the output of that command gives us everything we need.

## Related links:

libgit2/libgit2#4409

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
