### PR TITLE
Add a RichTreeBuilder, rewrite diff-apply code to use it.

### DIFF
--- a/sno/apply.py
+++ b/sno/apply.py
@@ -139,7 +139,7 @@ def apply_patch(*, repo, commit, patch_file, allow_empty, **kwargs):
         def extract_key(feature):
             if feature is None:
                 return None
-            return str(feature[pk_name]), feature
+            return feature[pk_name], feature
 
         def parse_delta(change):
             return Delta(

--- a/sno/dataset1.py
+++ b/sno/dataset1.py
@@ -288,6 +288,7 @@ class Dataset1(DatasetStructure):
         geom_cols=None,
         primary_key=None,
         cast_primary_key=True,
+        relative=False,
     ):
         """
         Given a feature, returns the path and the data that *should be written*
@@ -296,7 +297,9 @@ class Dataset1(DatasetStructure):
         if primary_key is None:
             primary_key = self.primary_key
         return (
-            self.encode_1pk_to_path(feature[primary_key], cast_primary_key),
+            self.encode_1pk_to_path(
+                feature[primary_key], cast_primary_key, relative=relative
+            ),
             self.encode_feature_blob(feature, field_cid_map, geom_cols, primary_key),
         )
 

--- a/sno/git_util.py
+++ b/sno/git_util.py
@@ -5,49 +5,6 @@ import pygit2
 
 from .timestamps import tz_offset_to_minutes
 
-EMPTY_TREE_ID = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
-
-
-def replace_subtree(repo, root_tree, subpath, subtree_or_blob):
-    """
-    Given a root tree, creates a new root tree by replacing whatever's
-    at the given path with the given subtree or blob.
-
-    If the given blob is None, that path is deleted.
-    This never conflicts. If the containing dirs don't exist, they are created.
-
-    Returns the new root tree.
-    """
-    if isinstance(subpath, str):
-        subpath = [piece for piece in subpath.split('/') if piece]
-    if not subpath:
-        # replace root_tree with subtree
-        return subtree_or_blob
-    else:
-        [head, *rest] = subpath
-        builder = repo.TreeBuilder(root_tree)
-        remove = False
-        try:
-            old_subtree = root_tree / head
-            remove = True
-        except KeyError:
-            old_subtree = repo.get(EMPTY_TREE_ID)
-        replaced = replace_subtree(repo, old_subtree, rest, subtree_or_blob)
-        if remove:
-            builder.remove(head)
-        if replaced is not None:
-            # insert/replace
-            typ = (
-                pygit2.GIT_FILEMODE_TREE
-                if isinstance(replaced, pygit2.Tree)
-                else pygit2.GIT_FILEMODE_BLOB
-            )
-            if isinstance(replaced, pygit2.Tree):
-                replaced = replaced.oid
-            builder.insert(head, replaced, typ)
-
-        return repo.get(builder.write())
-
 
 _GIT_VAR_OUTPUT_RE = re.compile(
     r"^(?P<name>.*) <(?P<email>[^>]*)> (?P<time>\d+) (?P<offset>[+-]?\d+)$"

--- a/sno/rich_tree_builder.py
+++ b/sno/rich_tree_builder.py
@@ -1,0 +1,133 @@
+import contextlib
+
+import pygit2
+
+EMPTY_TREE_ID = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+
+
+class RichTreeBuilder:
+    """
+    Like a pygit2.TreeBuilder, but more powerful - the client can buffer any number of writes to any paths
+    whereas a pygit2.TreeBuilder only lets you modify one tree at a time.
+    Also a bit like a pygit2.Index, but much more performant since it uses dicts instead of sorted vectors.
+    Conflicts are not detected.
+    """
+
+    def __init__(self, repo, initial_root_tree):
+        """
+        The repo and an initial root tree which will be updated.
+        All paths are specified relative to this tree - the root tree at a particular commit is a good choice.
+        """
+        self.repo = repo
+        self.root_tree = initial_root_tree
+
+        self.root_dict = {}
+        self.cur_path = []
+        self.path_stack = []
+
+    def _resolve_path(self, path):
+        """
+        Resolve the given a path relative to the current path.
+        The given path can be a string like "a/b/c" or a list like ["a", "b", "c"].
+        """
+        if isinstance(path, str):
+            if path.startswith("/"):
+                raise RuntimeError(
+                    "RichTreeBuilder.cd() does not support absolute paths"
+                )
+            path = path.strip("/").split("/")
+        return self.cur_path + path
+
+    @contextlib.contextmanager
+    def cd(self, path):
+        """
+        Change the current directory used to resolve paths by the given relative path.
+        Returns a context manager - when the context manager is closed, the original current directory is restored.
+
+        Example:
+        >>> with rich_tree_builder.cd("a/b/c/.sno-dataset"):
+        >>>    # Make edits inside a/b/c/.sno-dataset:
+        >>>    rich_tree_builder.remove("meta/title")
+        >>> # Context manager closes, current path is reset to the default.
+        """
+        path = self._resolve_path(path)
+        self._pushd()
+        self.cur_path = path
+        try:
+            yield
+        finally:
+            self._popd()
+
+    def _pushd(self):
+        self.path_stack.append(self.cur_path)
+
+    def _popd(self):
+        self.cur_path = self.path_stack.pop()
+
+    def insert(self, path, writeable):
+        """Writes the given data - a tree, a blob, a bytes, or None - at the given relative path."""
+        path = self._resolve_path(path)
+        self._ensure_writeable(writeable)
+
+        cur_dict = self.root_dict
+        for name in path[:-1]:
+            cur_dict = cur_dict.setdefault(name, {})
+            if not isinstance(cur_dict, dict):
+                raise RuntimeError(
+                    f"Expected dict at {path} but found {type(cur_dict)}"
+                )
+
+        cur_dict[path[-1]] = writeable
+
+    def remove(self, path):
+        """Delete the data at the given relative path."""
+        self.insert(path, None)
+
+    def flush(self):
+        """
+        Writes new versions of git trees for all changes that are buffered in memory.
+        Releases the changes in memory for garbage collection.
+        A new version of the root tree is returned - this tree should be committed by the client if these changes are
+        to persist. Alternatively, more changes can be made and flushed before committing.
+        """
+        self.root_tree = copy_and_modify_tree(self.repo, self.root_tree, self.root_dict)
+        self.root_dict = {}
+        return self.root_tree
+
+    def _ensure_writeable(self, writeable):
+        if not isinstance(writeable, (pygit2.Tree, pygit2.Blob, bytes, type(None))):
+            raise ValueError(f"Expected a writeable type but found {type(writeable)}")
+
+
+def copy_and_modify_tree(repo, tree, changes):
+    """
+    Given a tree, and a nested dictionary of changes to be made to that tree, returns a modified copy of that tree.
+    Each dicts keys are path components, and the leaf values must be the desired new value at that path -
+    either pygit2.Tree, a pygi2.Blob, a bytes, or None (None means delete the data at the specified path).
+    Conflicts are not detected.
+    """
+    if not changes:
+        return tree
+    pygit_builder = repo.TreeBuilder(tree)
+    for name, new_value in changes.items():
+        if isinstance(new_value, dict):
+            try:
+                subtree = tree / name
+            except KeyError:
+                subtree = repo.get(EMPTY_TREE_ID)
+            subtree = copy_and_modify_tree(repo, subtree, new_value)
+            pygit_builder.insert(name, subtree.oid, pygit2.GIT_FILEMODE_TREE)
+        elif isinstance(new_value, pygit2.Tree):
+            pygit_builder.insert(name, new_value.oid, pygit2.GIT_FILEMODE_TREE)
+        elif isinstance(new_value, pygit2.Blob):
+            pygit_builder.insert(name, new_value.oid, pygit2.GIT_FILEMODE_BLOB)
+        elif isinstance(new_value, bytes):
+            blob_oid = repo.create_blob(new_value)
+            pygit_builder.insert(name, blob_oid, pygit2.GIT_FILEMODE_BLOB)
+        elif new_value is None:
+            try:
+                pygit_builder.remove(name)
+            except pygit2.GitError:
+                pass  # Conflicts are not detected.
+
+    return repo.get(pygit_builder.write())


### PR DESCRIPTION
## Description

Refactoring change: extracted out a common interface for writing trees, use it for both feature and meta changes.
Tidies up the code.
But more usefully: it will make it easier to write the next change, in which we write to datasets which do not exist at all yet
and have no trees. Then, patches that create or delete datasets will start working.

## Related links:

https://github.com/koordinates/sno/issues/239

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
No change to changelog: will update changelog once linked bug is fixed.
