### PR TITLE
apply: Reject empty commits without --allow-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.6.0 (UNRELEASED)
+
+ * `apply` no longer creates empty commits unless you specify `--allow-empty` [#243](https://github.com/koordinates/sno/issues/243)
+
 ## 0.5.0
 
 sno v0.5 introduces a new repo layout, which is the default, dubbed 'Datasets V2'

--- a/sno/apply.py
+++ b/sno/apply.py
@@ -1,14 +1,10 @@
-import copy
 import json
 from datetime import datetime
 
 import click
 
-import pygit2
-
 from .git_util import author_signature
 from .exceptions import (
-    NO_CHANGES,
     NO_TABLE,
     NO_WORKING_COPY,
     NotFound,
@@ -158,8 +154,6 @@ def apply_patch(*, repo, commit, patch_file, allow_empty, **kwargs):
             repo_diff.recursive_set([ds_path, "feature"], feature_diff)
 
     if commit:
-        if not repo_diff and not allow_empty:
-            raise NotFound("No changes to commit", exit_code=NO_CHANGES)
         try:
             metadata = patch['sno.patch/v1']
         except KeyError:

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -12,6 +12,7 @@ from .exceptions import (
     InvalidOperation,
     NotFound,
     NotYetImplemented,
+    NO_CHANGES,
     NO_COMMIT,
     PATCH_DOES_NOT_APPLY,
 )
@@ -224,6 +225,8 @@ class RepositoryStructure:
         responsibility of the caller.
         """
         new_tree_oid = self.create_tree_from_diff(wcdiff)
+        if (not allow_empty) and new_tree_oid == self.tree.oid:
+            raise NotFound("No changes to commit", exit_code=NO_CHANGES)
         L.info("Committing...")
         # this will also update the ref (branch) to point to the current commit
         new_commit = self.repo.create_commit(

--- a/tests/data/patches/points-empty-2.snopatch
+++ b/tests/data/patches/points-empty-2.snopatch
@@ -1,0 +1,33 @@
+{
+  "sno.diff/v1+hexwkb": {
+    "nz_pa_points_topo_150k": {
+      "feature": [
+        {
+          "+": {
+            "fid": 1095,
+            "geom": "0101000000DD1A926B95F16540D5B4783B715642C0",
+            "t50_fid": 2427339,
+            "name_ascii": "Harataunga (Rakairoa)\n",
+            "macronated": "Y",
+            "name": "Harataunga (R\u0101kairoa)\n"
+          },
+          "-": {
+            "fid": 1095,
+            "geom": "0101000000DD1A926B95F16540D5B4783B715642C0",
+            "t50_fid": 2427339,
+            "name_ascii": "Harataunga (Rakairoa)\n",
+            "macronated": "Y",
+            "name": "Harataunga (R\u0101kairoa)\n"
+          }
+        }
+      ]
+    }
+  },
+  "sno.patch/v1": {
+    "authorEmail": "robert@example.com",
+    "authorName": "Robert Coup",
+    "authorTime": "2019-06-20T14:28:33Z",
+    "authorTimeOffset": "+01:00",
+    "message": "Improve naming on Coromandel East coast"
+  }
+}

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -25,6 +25,15 @@ def test_apply_empty_patch(data_archive_readonly, cli_runner):
         assert 'No changes to commit' in r.stderr
 
 
+def test_apply_nonempty_patch_which_makes_no_changes(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points2"):
+        # Despite appearances, this patch is empty because it makes a change
+        # which has no actual effect.
+        r = cli_runner.invoke(["apply", patches / 'points-empty-2.snopatch'])
+        assert r.exit_code == 44, r
+        assert 'No changes to commit' in r.stderr
+
+
 def test_apply_with_wrong_dataset_name(data_archive, cli_runner):
     patch_data = json.dumps(
         {


### PR DESCRIPTION


## Description

Patches can be non-empty and still result in an empty commit.
In that case `apply` was just creating an empty commit.
This fixes it to only create an empty commit with the `--allow-empty`
option; otherwise it exits with code 44.

## Related links:

none

## Checklist:

- [ ] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
