### PR TITLE
Fix duplicate builds for koordinates-internal PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   posix:
     name: ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +34,20 @@ jobs:
             os: macos-latest
             package-formats: pkg
             services: {}
-    if: "startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' || !contains(github.event.head_commit.message, '[ci only windows]')"
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/7
+    # Skip Linux/macOS builds with `[ci only windows]` unless it's master or a release tag.
+    if: >
+      (
+        github.event_name == 'push'
+        || github.event.pull_request.head.repo.full_name != github.repository
+      ) && (
+        startsWith(github.ref, 'refs/tags/v')
+        || github.ref == 'refs/heads/master'
+        || !contains(github.event.head_commit.message, '[ci only windows]')
+      )
+
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_COMPRESS: "1"
@@ -325,7 +339,19 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-2016
-    if: "startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' || !contains(github.event.head_commit.message, '[ci only posix]')"
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/7
+    # Skip Windows builds with `[ci only posix]` unless it's master or a release tag.
+    if: >
+      (
+        github.event_name == 'push'
+        || github.event.pull_request.head.repo.full_name != github.repository
+      ) && (
+        startsWith(github.ref, 'refs/tags/v')
+        || github.ref == 'refs/heads/master'
+        || !contains(github.event.head_commit.message, '[ci only posix]')
+      )
     steps:
       - name: "msvc setup"
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
## Description

Works around an issue where koordinates-internal PRs and direct pushes _both_ start a build process, causing 6 build envs to run instead of 3.

I replaced the existing `if:` blocks which support  `[ci only windows]`, basically because that seems niche enough to not bother and i didn't want a really overcomplicated `if` statement there

## Related links:

https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/7

## Checklist:

- [ ] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
