### PR TITLE
import: No empty commits without --allow-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.6.0 (UNRELEASED)
 
- * `apply` no longer creates empty commits unless you specify `--allow-empty` [#243](https://github.com/koordinates/sno/issues/243)
+ * `apply` and `import` no longer create empty commits unless you specify `--allow-empty` [#243](https://github.com/koordinates/sno/issues/243), [#245](https://github.com/koordinates/sno/issues/245)
 
 ## 0.5.0
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -83,7 +83,8 @@ def temporary_branch(repo):
 @click.pass_context
 @click.argument("source")
 @click.argument(
-    "tables", nargs=-1,
+    "tables",
+    nargs=-1,
 )
 @click.option(
     "--all-tables",
@@ -141,7 +142,10 @@ def temporary_branch(repo):
     help="List available import formats, and then exit",
 )
 @click.option(
-    "--output-format", "-o", type=click.Choice(["text", "json"]), default="text",
+    "--output-format",
+    "-o",
+    type=click.Choice(["text", "json"]),
+    default="text",
 )
 @click.option(
     "--primary-key",
@@ -151,6 +155,16 @@ def temporary_branch(repo):
     "--replace-existing",
     is_flag=True,
     help="Replace existing dataset(s) of the same name.",
+)
+@click.option(
+    "--allow-empty",
+    is_flag=True,
+    default=False,
+    help=(
+        "Usually recording a commit that has the exact same tree as its sole "
+        "parent commit is a mistake, and the command prevents you from making "
+        "such a commit. This option bypasses the safety"
+    ),
 )
 @click.option(
     "--max-delta-depth",
@@ -170,6 +184,7 @@ def import_table(
     tables,
     table_info,
     replace_existing,
+    allow_empty,
     max_delta_depth,
 ):
     """
@@ -261,6 +276,7 @@ def import_table(
             replace_existing=ReplaceExisting.GIVEN
             if replace_existing
             else ReplaceExisting.DONT_REPLACE,
+            allow_empty=allow_empty,
         )
 
     rs = RepositoryStructure(repo)
@@ -314,7 +330,14 @@ def import_table(
     help="--depth option to git-fast-import (advanced users only)",
 )
 def init(
-    ctx, message, directory, repo_version, import_from, bare, wc_path, max_delta_depth,
+    ctx,
+    message,
+    directory,
+    repo_version,
+    import_from,
+    bare,
+    wc_path,
+    max_delta_depth,
 ):
     """
     Initialise a new repository and optionally import data.
@@ -347,7 +370,10 @@ def init(
 
     if import_from:
         fast_import_tables(
-            repo, sources, message=message, max_delta_depth=max_delta_depth,
+            repo,
+            sources,
+            message=message,
+            max_delta_depth=max_delta_depth,
         )
         head_commit = repo.head.peel(pygit2.Commit)
         checkout.reset_wc_if_needed(repo, head_commit)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -89,7 +89,10 @@ def test_import_table_with_prompt(data_archive_readonly, tmp_path, cli_runner, c
         assert r.exit_code == 0
         with chdir(repo_path):
             r = cli_runner.invoke(
-                ["import", data / "census2016_sdhca_ot_short.gpkg",],
+                [
+                    "import",
+                    data / "census2016_sdhca_ot_short.gpkg",
+                ],
                 input="census2016_sdhca_ot_ced_short\n",
             )
             # Table was specified interactively via prompt
@@ -178,7 +181,11 @@ def test_import_table_with_prompt_with_no_input(
 
 
 def test_import_replace_existing(
-    data_archive, tmp_path, cli_runner, chdir, geopackage,
+    data_archive,
+    tmp_path,
+    cli_runner,
+    chdir,
+    geopackage,
 ):
     with data_archive("gpkg-polygons") as data:
         repo_path = tmp_path / 'emptydir'
@@ -237,8 +244,45 @@ def test_import_replace_existing(
             }
 
 
+def test_import_replace_existing_with_no_changes(
+    data_archive,
+    tmp_path,
+    cli_runner,
+    chdir,
+    geopackage,
+):
+    with data_archive("gpkg-polygons") as data:
+        repo_path = tmp_path / 'emptydir'
+        r = cli_runner.invoke(["init", repo_path])
+        assert r.exit_code == 0
+        with chdir(repo_path):
+            r = cli_runner.invoke(
+                [
+                    "import",
+                    data / "nz-waca-adjustments.gpkg",
+                    "nz_waca_adjustments:mytable",
+                ]
+            )
+            assert r.exit_code == 0, r.stderr
+
+            # now import the same thing over the top (no changes)
+            r = cli_runner.invoke(
+                [
+                    "import",
+                    "--replace-existing",
+                    data / "nz-waca-adjustments.gpkg",
+                    "nz_waca_adjustments:mytable",
+                ]
+            )
+            assert r.exit_code == 44, r.stderr
+
+
 def test_import_replace_existing_with_compatible_schema_changes(
-    data_archive, tmp_path, cli_runner, chdir, geopackage,
+    data_archive,
+    tmp_path,
+    cli_runner,
+    chdir,
+    geopackage,
 ):
     with data_archive("gpkg-polygons") as data:
         repo_path = tmp_path / 'emptydir'
@@ -304,7 +348,11 @@ def test_import_replace_existing_with_compatible_schema_changes(
 
 
 def test_import_replace_existing_with_column_renames(
-    data_archive, tmp_path, cli_runner, chdir, geopackage,
+    data_archive,
+    tmp_path,
+    cli_runner,
+    chdir,
+    geopackage,
 ):
     with data_archive("gpkg-polygons") as data:
         repo_path = tmp_path / 'emptydir'
@@ -594,7 +642,11 @@ def test_init_import(
 
 
 def test_init_import_commit_headers(
-    data_archive, tmp_path, cli_runner, chdir, geopackage,
+    data_archive,
+    tmp_path,
+    cli_runner,
+    chdir,
+    geopackage,
 ):
     with data_archive("gpkg-points") as data:
         repo_path = tmp_path / "data.sno"


### PR DESCRIPTION

## Description
This adds the --allow-empty option, which has the same meaning as
in `commit` and `apply`.

This behaviour mostly only affects `--replace-existing`,
since `import` will never produce an empty commit if you're not
replacing anything.

Because import uses fast-import, this was a little tricky. fast-import will happily do empty commits and there's no easy way to stop it from doing so. 

So instead, I made fast-import use a temporary branch to do its importing on. Then afterwards I checked whether the commit was empty before updating the original branch ref to the new commit.


## Related links:

#243 did the same thing for `apply`

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
