### PR TITLE
Optimise repository after committing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
  * `apply` and `import` no longer create empty commits unless you specify `--allow-empty` [#243](https://github.com/koordinates/sno/issues/243), [#245](https://github.com/koordinates/sno/issues/245)
  * Patches that create or delete datasets are now supported in Datasets V2 [#239](https://github.com/koordinates/sno/issues/239)
+ * `apply`, `commit` and `merge` commands now optimise repositories after committing, to avoid poor repo performance. [#250](https://github.com/koordinates/sno/issues/250)
 
 ## 0.5.0
 

--- a/sno/apply.py
+++ b/sno/apply.py
@@ -14,6 +14,7 @@ from .exceptions import (
 )
 from .diff_structs import RepoDiff, DeltaDiff, Delta
 from .geometry import hex_wkb_to_gpkg_geom
+from .git_util import gc
 from .schema import Schema
 from .structure import RepositoryStructure
 from .timestamps import iso8601_utc_to_datetime, iso8601_tz_to_timedelta
@@ -224,3 +225,4 @@ def apply(ctx, **kwargs):
     Applies and commits the given JSON patch (as created by `sno show -o json`)
     """
     apply_patch(repo=ctx.obj.repo, **kwargs)
+    gc(ctx.obj.repo, "--auto", use_subprocess=False)

--- a/sno/commit.py
+++ b/sno/commit.py
@@ -15,6 +15,7 @@ from .exceptions import (
     NO_WORKING_COPY,
 )
 from .filter_util import build_feature_filter
+from .git_util import gc
 from .output_util import dump_json_output
 from .repo_files import (
     COMMIT_EDITMSG,
@@ -118,6 +119,8 @@ def commit(ctx, message, allow_empty, output_format, filters):
         dump_json_output(jdict, sys.stdout)
     else:
         click.echo(commit_json_to_text(jdict))
+
+    gc(repo, "--auto", use_subprocess=False)
 
 
 def get_commit_message(repo, diff, draft_message="", quiet=False):

--- a/sno/git_util.py
+++ b/sno/git_util.py
@@ -3,6 +3,7 @@ import subprocess
 
 import pygit2
 
+from .exec import execvp
 from .timestamps import tz_offset_to_minutes
 
 
@@ -68,3 +69,14 @@ def author_signature(repo, **overrides):
 
 def committer_signature(repo, **overrides):
     return _signature(repo, "GIT_COMMITTER_IDENT", **overrides)
+
+
+def gc(repo, *args, use_subprocess=True):
+    """
+    Runs git-gc on the repository
+    """
+    args = ["git", "-C", repo.path, "gc", *args]
+    if use_subprocess:
+        subprocess.run(args)
+    else:
+        execvp("git", args)

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -11,6 +11,7 @@ from .conflicts import (
 )
 from .diff import get_repo_diff
 from .exceptions import InvalidOperation
+from .git_util import gc
 from .merge_util import AncestorOursTheirs, MergeIndex, MergeContext
 from .output_util import dump_json_output
 from .repo_files import (
@@ -245,6 +246,7 @@ def complete_merging_state(ctx):
 
     # TODO - support json output
     click.echo(merge_status_to_text(merge_jdict, fresh=True))
+    gc(repo, "--auto", use_subprocess=False)
 
 
 def merge_context_to_text(jdict):
@@ -407,3 +409,5 @@ def merge(ctx, ff, ff_only, dry_run, message, output_format, commit):
         dump_json_output({"sno.merge/v1": jdict}, sys.stdout)
     else:
         click.echo(merge_status_to_text(jdict, fresh=True))
+    if not no_op and not conflicts:
+        gc(repo, "--auto", use_subprocess=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,15 @@ def git_user_config(monkeypatch_session, tmp_path_factory, request):
     USER_EMAIL = "sno-tester@example.com"
 
     with open(home / ".gitconfig", "w") as f:
-        f.write(f"[user]\n\tname = {USER_NAME}\n\temail = {USER_EMAIL}\n")
+        f.write(
+            f"[user]\n"
+            f"\tname = {USER_NAME}\n"
+            f"\temail = {USER_EMAIL}\n"
+            # make `gc` syncronous in testing.
+            # otherwise it has race conditions with test teardown.
+            f"[gc]\n"
+            f"\tautoDetach = false"
+        )
 
     L.debug("Temporary HOME for git config: %s", home)
 


### PR DESCRIPTION
## Description

There's no way for pygit2 to create objects directly in pack files. Doing commits of large changes ends up with a lot of loose objects, which eventually slows down the performance of the repo.

This runs `git gc --auto` at the end of every commit, apply, and merge command to try and avoid the slowdown.

## Related links:

This is a workaround for #247 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
