### PR TITLE
ci: fix identification of CI runs on/from forks or fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,12 @@ jobs:
       - name: "app: version"
         id: version
         run: |
-          if [[ "${{ github.repository }}" == "koordinates/sno" ]] && [[ "${{ github.ref }}" =~ ^refs/tags/v(.*) ]]; then
+          if [[ '${{ github.repository }}' != 'koordinates/sno' ]] || [[ '${{ github.event.pull_request.head.repo.full_name }}' != '${{ github.repository }}' ]]; then
+            IS_FORK=1
+          else
+            IS_FORK=0
+          fi
+          if (( ! $IS_FORK )) && [[ '${{ github.ref }}' =~ ^refs/tags/v(.*) ]]; then
             VER="${BASH_REMATCH[1]}"
             IS_RELEASE=1
           else
@@ -166,9 +171,11 @@ jobs:
           fi
           echo "App Version: $VER"
           echo "Is Release? $IS_RELEASE"
+          echo "Is Fork PR? $IS_FORK"
           echo "$VER" > sno/VERSION
           echo "::set-output name=value::$VER"
           echo "::set-output name=is_release::$IS_RELEASE"
+          echo "::set-output name=is_fork::$IS_FORK"
 
       - name: "app: install python dependencies"
         run: |
@@ -214,14 +221,14 @@ jobs:
       - name: "🍎 package: setup app signing certificate"
         id: keychain
         uses: apple-actions/import-codesign-certs@v1
-        if: runner.os == 'macOS' && github.repository == 'koordinates/sno'
+        if: "runner.os == 'macOS' && steps.version.outputs.is_fork == 0"
         with:
           p12-file-base64: ${{ secrets.MACOS_APP_CERT }}
           p12-password: ${{ secrets.MACOS_CERT_PW }}
 
       - name: "🍎 package: setup installer signing certificate"
         uses: apple-actions/import-codesign-certs@v1
-        if: runner.os == 'macOS' && steps.version.outputs.is_release == 1
+        if: "runner.os == 'macOS' && steps.version.outputs.is_release == 1"
         with:
           create-keychain: false
           keychain-password: ${{ steps.keychain.outputs.keychain-password }}
@@ -238,7 +245,7 @@ jobs:
         run: |
           make py-tools
 
-          if [ "${{ github.repository }}" == "koordinates/sno" ]; then
+          if (( ! ${{ steps.version.outputs.is_fork }} )); then
             export CODESIGN="${{ secrets.MACOS_CODESIGN_ID }}"
           fi
 
@@ -312,7 +319,7 @@ jobs:
 
       - name: release
         uses: softprops/action-gh-release@v1
-        if: "github.repository == 'koordinates/sno' && steps.version.outputs.is_release == 1"
+        if: "steps.version.outputs.is_release == 1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -387,7 +394,9 @@ jobs:
       - name: "app: version"
         id: version
         run: |
-          If ('${{ github.ref }}'.StartsWith('refs/tags/v')) {
+          $IS_FORK = ( ('${{ github.repository }}' -ne 'koordinates/sno') -or ('${{ github.event.pull_request.head.repo.full_name }}' -ne '${{ github.repository }}') ) ? 1 : 0
+
+          If ( (-not $IS_FORK) -and ('${{ github.ref }}'.StartsWith('refs/tags/v')) ) {
             $VER='${{ github.ref }}'.Substring(11)
             $IS_RELEASE=1
           } Else {
@@ -400,10 +409,12 @@ jobs:
           echo "App Version: $VER"
           echo "Installer Version: $IVER"
           echo "Is Release? $IS_RELEASE"
+          echo "Is Fork PR? $IS_FORK"
           echo "$VER" > .\sno\VERSION
           echo "::set-output name=value::$VER"
           echo "::set-output name=installer::$IVER"
           echo "::set-output name=is_release::$IS_RELEASE"
+          echo "::set-output name=is_fork::$IS_FORK"
 
       - name: "app: install python dependencies"
         run: |
@@ -446,7 +457,7 @@ jobs:
           SIGN_AZURE_CLIENTID: ${{ secrets.WIN_SIGN_AZURE_CLIENTID }}
           SIGN_AZURE_CLIENTSECRET: ${{ secrets.WIN_SIGN_AZURE_CLIENTSECRET }}
         run: |
-          If ( '${{ github.repository }}' -eq 'koordinates/sno' -and ${{ steps.version.outputs.is_release }} -eq 1 ) {
+          If ( ${{ steps.version.outputs.is_release }} -eq 1 ) {
             dotnet tool install --global AzureSignTool --version 2.0.17
 
             $Env:SIGN_AZURE_CERTIFICATE=$Env:WIN_SIGN_AZURE_CERTIFICATE
@@ -484,7 +495,7 @@ jobs:
 
       - name: release
         uses: softprops/action-gh-release@v1
-        if: "github.repository == 'koordinates/sno' && steps.version.outputs.is_release == 1"
+        if: "steps.version.outputs.is_release == 1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
In CI, add to version step outputs as `.is_fork`, and use consistently

ref: https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363/3

## Related links:

https://github.com/koordinates/sno/pull/251 & other PRs from forks
https://github.com/koordinates/sno/pull/244

## Checklist:

- [X] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
