### PR TITLE
Add optional ref arg to `sno data ls`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `apply` and `import` no longer create empty commits unless you specify `--allow-empty` [#243](https://github.com/koordinates/sno/issues/243), [#245](https://github.com/koordinates/sno/issues/245)
  * Patches that create or delete datasets are now supported in Datasets V2 [#239](https://github.com/koordinates/sno/issues/239)
  * `apply`, `commit` and `merge` commands now optimise repositories after committing, to avoid poor repo performance. [#250](https://github.com/koordinates/sno/issues/250)
+ * `data ls` now accepts an optional ref argument
 
 ## 0.5.0
 

--- a/sno/data.py
+++ b/sno/data.py
@@ -27,14 +27,15 @@ def data(ctx, **kwargs):
     type=click.Choice(["text", "json"]),
     default="text",
 )
+@click.argument("refish", required=False, default="HEAD")
 @click.pass_context
-def data_ls(ctx, output_format):
+def data_ls(ctx, output_format, refish):
     """List all of the datasets in the sno repository"""
     repo = ctx.obj.get_repo(allowed_states=RepoState.ALL_STATES)
     if repo.is_empty:
         ds_paths = []
     else:
-        rs = RepositoryStructure.lookup(repo, "HEAD")
+        rs = RepositoryStructure.lookup(repo, refish)
         ds_paths = [ds.path for ds in rs]
 
     if output_format == "text":

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -44,3 +44,12 @@ def test_data_ls_empty(repo_version, output_format, tmp_path, cli_runner, chdir)
         else:
             output = json.loads(r.stdout)
             assert output == {"sno.data.ls/v1": []}
+
+
+def test_data_ls_with_ref(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points2"):
+        r = cli_runner.invoke(["data", "ls", "-o", "json", "HEAD^"])
+        assert r.exit_code == 0, r
+
+        output = json.loads(r.stdout)
+        assert output == {"sno.data.ls/v1": ["nz_pa_points_topo_150k"]}


### PR DESCRIPTION


## Description

```
Usage: sno data ls [OPTIONS] [REFISH]
```

It's useful to be able to see what datasets exist at different refs.

This change is backward compatible.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)? **(yes, albeit minimal because we don't have test repos with multiple datasets and it seems too much work to set one up for testing such a tiny/safe feature)**
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
