### PR TITLE
Add a `--ref REF` option to `sno meta get` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * Patches that create or delete datasets are now supported in Datasets V2 [#239](https://github.com/koordinates/sno/issues/239)
  * `apply`, `commit` and `merge` commands now optimise repositories after committing, to avoid poor repo performance. [#250](https://github.com/koordinates/sno/issues/250)
  * `data ls` now accepts an optional ref argument
+ * `meta get` now accepts a `--ref=REF` option
 
 ## 0.5.0
 

--- a/sno/meta.py
+++ b/sno/meta.py
@@ -47,16 +47,17 @@ def meta(ctx, **kwargs):
     default="pretty",
     help="How to format the JSON output. Only used with -o json",
 )
+@click.option("--ref", default="HEAD")
 @click.argument("dataset", required=False)
 @click.argument("keys", required=False, nargs=-1)
 @click.pass_context
-def meta_get(ctx, output_format, json_style, dataset, keys):
+def meta_get(ctx, output_format, json_style, ref, dataset, keys):
     """
     Prints the value of meta keys.
 
     Optionally, output can be filtered to a dataset and a particular key.
     """
-    rs = RepositoryStructure(ctx.obj.repo)
+    rs = RepositoryStructure.lookup(ctx.obj.repo, ref)
 
     if dataset:
         try:

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -109,3 +109,31 @@ def test_meta_set(data_archive, cli_runner):
         meta = output["sno.diff/v1+hexwkb"]["nz_pa_points_topo_150k"]["meta"]
         assert meta["title"] == {"-": "NZ Pa Points (Topo, 1:50k)", "+": "newtitle"}
         assert meta["description"]["+"] == "newdescription"
+
+
+def test_meta_get_ref(data_archive, cli_runner):
+    with data_archive("points2"):
+        r = cli_runner.invoke(
+            [
+                "meta",
+                "set",
+                "nz_pa_points_topo_150k",
+                "title=newtitle",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+        r = cli_runner.invoke(
+            [
+                "meta",
+                "get",
+                "--ref=HEAD^",
+                "nz_pa_points_topo_150k",
+                "title",
+                "-o",
+                "json",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+        assert json.loads(r.stdout) == {
+            "nz_pa_points_topo_150k": {"title": "NZ Pa Points (Topo, 1:50k)"}
+        }


### PR DESCRIPTION


## Description

Makes it possible to look at something other than HEAD with `sno meta get`

This is slightly different style to some other commands - generally in git land and so far in sno land refs are an argument rather than an option.

However, making it an argument here would be quite ambiguous because all the other arguments are optional too. It also seems like a fairly niche thing for humans to use (usually you'd just want to look at HEAD) so I just made it an option instead.

## Related links:

none
## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
