### PR TITLE
Shard CI test on windows into 10 - green windows ✅

### DIFF
--- a/makefile.vc
+++ b/makefile.vc
@@ -62,14 +62,15 @@ test: $(app) venv\.test.installed
 
 ci-test:
 	set CI=true
-	pytest \
-		--verbose \
-		-p no:sugar \
-		--cov-report term \
-		--cov-report html:test-results\coverage/ \
-		--junit-xml=test-results\junit.xml \
-		--benchmark-enable \
-		-p no:xdist
+	FOR /L %%I IN (0, 1, 9) DO \
+		pytest \
+			--num-shards 10 \
+			--shard-id %I \
+			--verbose \
+			--benchmark-enable \
+			--no-cov \
+			-p no:sugar \
+			-p no:xdist
 
 # Packaging
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -10,5 +10,6 @@ pytest-sugar
 pytest-helpers-namespace
 pytest-benchmark[aspect]
 pytest-profiling
+pytest-shard
 lovely-pytest-docker
 html5lib

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,8 +25,9 @@ pytest-benchmark[aspect]==3.2.3  # via -r requirements/test.in
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-helpers-namespace==2019.1.8  # via -r requirements/test.in
 pytest-profiling==1.7.0   # via -r requirements/test.in
+pytest-shard==0.1.1       # via -r requirements/test.in
 pytest-sugar==0.9.4       # via -r requirements/test.in
-pytest==6.0.2             # via -r requirements/test.in, lovely-pytest-docker, pytest-benchmark, pytest-cov, pytest-helpers-namespace, pytest-profiling, pytest-sugar
+pytest==6.0.2             # via -r requirements/test.in, lovely-pytest-docker, pytest-benchmark, pytest-cov, pytest-helpers-namespace, pytest-profiling, pytest-shard, pytest-sugar
 six==1.15.0               # via -c requirements/../requirements.txt, html5lib, packaging, pytest-profiling
 termcolor==1.1.0          # via pytest-sugar
 toml==0.10.1              # via pytest


### PR DESCRIPTION
## Description

Windows unit tests normally fail before the end, not for any particular reason.
Maybe if the end was 10x closer, they wouldn't fail.
An experiment: this might green the build for us, which would be good, and if it does green the build, it will also give us insight into why the tests are failing.
