### PR TITLE
Add a `sno clone --branch` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `apply`, `commit` and `merge` commands now optimise repositories after committing, to avoid poor repo performance. [#250](https://github.com/koordinates/sno/issues/250)
  * `data ls` now accepts an optional ref argument
  * `meta get` now accepts a `--ref=REF` option
+ * `clone` now accepts a `--branch` option to clone a specific branch.
 
 ## 0.5.0
 

--- a/sno/clone.py
+++ b/sno/clone.py
@@ -54,13 +54,24 @@ def get_directory_from_url(url):
     type=click.INT,
     help="Create a shallow clone with a history truncated to the specified number of commits.",
 )
+@click.option(
+    "-b",
+    "--branch",
+    metavar="NAME",
+    help=(
+        "Instead of pointing the newly created HEAD to the branch pointed to by the cloned repository's "
+        "HEAD, point to NAME branch instead. In a non-bare repository, this is the branch that will be "
+        "checked out.  --branch can also take tags and detaches the HEAD at that commit in the resulting "
+        "repository. "
+    ),
+)
 @click.argument("url", nargs=1)
 @click.argument(
     "directory",
     type=click.Path(exists=False, file_okay=False, writable=True),
     required=False,
 )
-def clone(ctx, bare, wc_path, do_progress, depth, url, directory):
+def clone(ctx, bare, wc_path, do_progress, depth, branch, url, directory):
     """ Clone a repository into a new directory """
 
     repo_path = Path(directory or get_directory_from_url(url)).resolve()
@@ -73,6 +84,8 @@ def clone(ctx, bare, wc_path, do_progress, depth, url, directory):
     args = ["--progress" if do_progress else "--quiet"]
     if depth is not None:
         args.append(f"--depth={depth}")
+    if branch is not None:
+        args.append(f"--branch={branch}")
 
     repo = SnoRepo.clone_repository(url, repo_path, args, wc_path, bare)
 


### PR DESCRIPTION
## Description

Also accepts tags, but I copied the name from the corresponding `git`
option. Doesn't accept arbitrary refs (commit hashes, etc)

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
