### PR TITLE
Makes reset() work for postgis WC, adds some tests.

### DIFF
--- a/sno/db_util.py
+++ b/sno/db_util.py
@@ -1,0 +1,73 @@
+from psycopg2.sql import Identifier, SQL
+
+from . import gpkg
+
+
+# Utilities for dealing with different database drivers.
+
+
+def execute_insert_dict(dbcur, table, record, gpkg_funcs=None, pg_funcs=None):
+    """
+    Insert the given record into the given table.
+    dbcur - Database cursor.
+    table - the name of a table, or fully qualified name in the form f"{schema}.{name}"
+    record - the record to insert, as a dict keyed by column name.
+    gpkg_funcs, pg_funcs - extra functions needed to adapt the types to fit the columns.
+    """
+    if is_postgis(dbcur):
+        # Table can be a fully-qualified name, including the schema.
+        sql = SQL("INSERT INTO {} ({}) VALUES ({});").format(
+            Identifier(*table.split(".")),
+            SQL(",").join([Identifier(k) for k in record]),
+            SQL(",").join(_postgis_placeholders(record, pg_funcs)),
+        )
+    else:
+        sql = f"""
+        INSERT INTO {table}
+            ({','.join([gpkg.ident(k) for k in record])})
+        VALUES
+            ({','.join(_gpkg_placeholders(record, gpkg_funcs))});
+        """
+
+    dbcur.execute(sql, tuple(record.values()))
+    return changes_rowcount(dbcur)
+
+
+def _gpkg_placeholders(record, gpkg_funcs=None):
+    """
+    Returns ['?', '?', '?', ...] - where the nunber of '?' returned is len(record).
+    gpkg_funcs - a dict keyed by index to override some of the placeholders, eg:
+        {1: "GeomFromEWKT(?)"}
+    """
+    result = ["?"] * len(record)
+    if gpkg_funcs:
+        for index, placeholder in gpkg_funcs.items():
+            result[index] = placeholder
+    return result
+
+
+def _postgis_placeholders(record, pg_funcs=None):
+    """
+    Returns ['%s', '%s', '%s', ...] where the number of '%s' returned is len(record).
+    pg_funcs - a dict keyed by index to override some of the placeholders, eg:
+        {1: "SetSRID(%s, 4326)"}
+    """
+
+    result = [SQL("%s")] * len(record)
+    if pg_funcs:
+        for index, placeholder in pg_funcs.items():
+            result[index] = SQL(placeholder)
+    return result
+
+
+def changes_rowcount(dbcur):
+    """Returns the number of rows that the last .execute*() affected."""
+    # PEP 0249 specifies .rowcount, but it not everyone support it:
+    if hasattr(dbcur, "rowcount"):
+        return dbcur.rowcount
+    # Otherwise, this works for GPKG / sqlite:
+    return dbcur.getconnection().changes()
+
+
+def is_postgis(dbcur):
+    return type(dbcur).__module__.startswith("psycopg2")

--- a/sno/working_copy/base.py
+++ b/sno/working_copy/base.py
@@ -1,8 +1,11 @@
+import contextlib
 import itertools
+import logging
 
 import pygit2
 
 from sno.diff_structs import RepoDiff, DatasetDiff, DeltaDiff, Delta
+from sno.exceptions import InvalidOperation, NotYetImplemented
 from sno.filter_util import UNFILTERED
 from sno.repository_version import get_repo_version
 from sno.schema import Schema
@@ -12,8 +15,24 @@ from sno.structure import RepositoryStructure
 SNO_WORKINGCOPY_PATH = "sno.workingcopy.path"
 
 
+L = logging.getLogger("sno.working_copy.base")
+
+
 class WorkingCopyDirty(Exception):
+    """Exception to abort immediately if working copy is dirty."""
+
     pass
+
+
+class Mismatch(ValueError):
+    """Error for if the tree id stored in state table doesn't match the one at HEAD."""
+
+    def __init__(self, working_copy_tree_id, expected_tree_id):
+        self.working_copy_tree_id = working_copy_tree_id
+        self.expected_tree_id = expected_tree_id
+
+    def __str__(self):
+        return f"Working Copy is tree {self.working_copy_tree_id}; expecting {self.expected_tree_id}"
 
 
 class WorkingCopy:
@@ -92,13 +111,17 @@ class WorkingCopy:
         stem = repo.workdir_path.stem
         return f"{stem}.gpkg"
 
-    class Mismatch(ValueError):
-        def __init__(self, working_copy_tree_id, match_tree_id):
-            self.working_copy_tree_id = working_copy_tree_id
-            self.match_tree_id = match_tree_id
+    def get_db_tree(self, table_name="*"):
+        """Returns the hex tree ID from the state table."""
+        raise NotImplementedError()
 
-        def __str__(self):
-            return f"Working Copy is tree {self.working_copy_tree_id}; expecting {self.match_tree_id}"
+    def assert_db_tree_match(self, tree, *, table_name="*"):
+        wc_tree_id = self.get_db_tree(table_name)
+        expected_tree_id = tree.id.hex if isinstance(tree, pygit2.Tree) else tree
+
+        if wc_tree_id != expected_tree_id:
+            raise Mismatch(wc_tree_id, expected_tree_id)
+        return wc_tree_id
 
     def _chunk(self, iterable, size):
         """Generator. Yield successive chunks from iterable of length <size>."""
@@ -108,6 +131,26 @@ class WorkingCopy:
             if not chunk:
                 return
             yield chunk
+
+    def check_not_dirty(self, help_message=None):
+        """Checks the working copy has no changes in it. Otherwise, raises InvalidOperation"""
+        if not help_message:
+            help_message = "Commit these changes (`sno commit`) or discard these changes (`sno reset`) first."
+        if self.is_dirty():
+            raise InvalidOperation(
+                f"You have uncommitted changes in your working copy.\n{help_message}"
+            )
+
+    def is_dirty(self):
+        """
+        Returns True if there are uncommitted changes in the working copy,
+        or False otherwise.
+        """
+        try:
+            self.diff_to_tree(raise_if_dirty=True)
+            return False
+        except WorkingCopyDirty:
+            return True
 
     def diff_to_tree(self, repo_filter=UNFILTERED, raise_if_dirty=False):
         """
@@ -218,6 +261,21 @@ class WorkingCopy:
         """
         raise NotImplementedError()
 
+    def _execute_dirty_rows_query(self, dbcur, dataset):
+        """
+        Queries the tracking table for the rows belonging to the given dataset, such that the dbcursor's result
+        is the primary keys of all the rows that have been inserted / updated / deleted.
+        """
+        raise NotImplementedError()
+
+    def reset_tracking_table(self, reset_filter=UNFILTERED):
+        """Delete the rows from the tracking table that match the given filter."""
+        raise NotImplementedError()
+
+    def _reset_tracking_table_for_dataset(self, dbcur, dataset):
+        """Delete the rows from the tracking table that match the given dataset."""
+        raise NotImplementedError()
+
     def _db_geom_to_gpkg_geom(self, g):
         """Convert a geometry as returned by the database to a sno geometry.Geometry object."""
         raise NotImplementedError()
@@ -267,3 +325,295 @@ class WorkingCopy:
                 del feature_diff[insert_delta.key]
                 update_delta = delete_delta + insert_delta
                 feature_diff.add_delta(update_delta)
+
+    def update_state_table_tree(self, tree):
+        """Write the given tree to the state table."""
+        tree_id = tree.id.hex if isinstance(tree, pygit2.Tree) else tree
+        L.info(f"Tree sha: {tree_id}")
+        with self.session() as db:
+            dbcur = db.cursor()
+            changes = self._update_state_table_tree_impl(dbcur, tree_id)
+        assert changes == 1, f"{self.STATE_TABLE} update: expected 1Δ, got {changes}"
+
+    def _update_state_table_tree_impl(self, dbcur, tree_id):
+        """
+        Write the given tree ID to the state table.
+        tree_id - str, the hex SHA of the tree at HEAD.
+        """
+        raise NotImplementedError()
+
+    def reset(
+        self,
+        target_tree_or_commit,
+        *,
+        force=False,
+        paths=None,
+        track_changes_as_dirty=False,
+    ):
+        """
+        Resets the working copy to the given target-tree (or the tree pointed to by the given target-commit).
+
+        If there are uncommitted changes, raises InvalidOperation, unless force=True is given
+        (in which case the changes are discarded)
+
+        If track_changes_as_dirty=False (the default) the tree ID in the sno-state table gets set to the
+        new tree ID and the tracking table is left empty. If it is True, the old tree ID is kept and the
+        tracking table is used to record all the changes, so that they can be committed later.
+        """
+        if not force:
+            self.check_not_dirty()
+
+        L = logging.getLogger(f"{self.__class__.__qualname__}.reset")
+        commit = None
+        if isinstance(target_tree_or_commit, pygit2.Commit):
+            commit = target_tree_or_commit
+            target_tree = commit.tree
+        else:
+            commit = None
+            target_tree = target_tree_or_commit
+        target_tree_id = target_tree.id.hex
+
+        # base_tree is the tree the working copy is based on.
+        # If the working copy exactly matches base_tree, it is clean and has an empty tracking table.
+        base_tree_id = self.get_db_tree()
+        base_tree = self.repo[base_tree_id]
+        repo_tree_id = self.repo.head.peel(pygit2.Tree).hex
+
+        L.debug(
+            "reset(): WorkingCopy base_tree:%s, Repo HEAD has tree:%s. Resetting working copy to tree: %s",
+            base_tree_id,
+            repo_tree_id,
+            target_tree_id,
+        )
+        L.debug(
+            f"reset(): commit={commit.id if commit else 'none'} track_changes_as_dirty={track_changes_as_dirty}",
+        )
+
+        repo_structure = RepositoryStructure(self.repo)
+        base_datasets = {
+            ds.table_name: ds
+            for ds in self._filter_by_paths(repo_structure.iter_at(base_tree), paths)
+        }
+        if base_tree == target_tree:
+            target_datasets = base_datasets
+        else:
+            target_datasets = {
+                ds.table_name: ds
+                for ds in self._filter_by_paths(
+                    repo_structure.iter_at(target_tree), paths
+                )
+            }
+
+        table_inserts = target_datasets.keys() - base_datasets.keys()
+        table_deletes = base_datasets.keys() - target_datasets.keys()
+        table_updates = base_datasets.keys() & target_datasets.keys()
+        table_updates_unsupported = set()
+
+        for table in table_updates:
+            base_ds = base_datasets[table]
+            ds_version = base_ds.VERSION
+
+            # Do we support changing the WC metadata to back to base_ds metadata?
+            rev_wc_meta_diff = self.diff_db_to_tree_meta(base_ds)
+            update_supported = self._is_meta_update_supported(
+                ds_version, rev_wc_meta_diff
+            )
+
+            # And, do we support then changing it from base_ds metadata to target_ds metadata?
+            target_ds = target_datasets[table]
+            if target_ds != base_ds:
+                rev_rev_meta_diff = base_ds.diff_meta(target_ds)
+                update_supported = update_supported and self._is_meta_update_supported(
+                    ds_version, rev_rev_meta_diff
+                )
+
+            if not update_supported:
+                table_updates_unsupported.add(table)
+
+        for table in table_updates_unsupported:
+            table_updates.remove(table)
+            table_inserts.add(table)
+            table_deletes.add(table)
+
+        L.debug(
+            "reset(): table_inserts: %s, table_deletes: %s, table_updates %s",
+            table_inserts,
+            table_deletes,
+            table_updates,
+        )
+
+        structural_changes = table_inserts | table_deletes
+        if track_changes_as_dirty and structural_changes:
+            # We don't yet support tracking changes as dirty if we delete, create, or rewrite an entire table.
+            structural_changes_text = "\n".join(structural_changes)
+            raise NotYetImplemented(
+                "Sorry, this operation is not possible when there are structural changes."
+                f"Structural changes are affecting:\n{structural_changes_text}"
+            )
+
+        # Delete old tables
+        if table_deletes:
+            self.drop_table(
+                target_tree_or_commit, *[base_datasets[d] for d in table_deletes]
+            )
+        # Write new tables
+        if table_inserts:
+            # Note: write_full doesn't work if called from within an existing db session.
+            self.write_full(
+                target_tree_or_commit, *[target_datasets[d] for d in table_inserts]
+            )
+
+        with self.session(bulk=1) as db:
+            dbcur = db.cursor()
+
+            for table in table_updates:
+                base_ds = base_datasets[table]
+                target_ds = target_datasets[table]
+                self._update_table(
+                    base_ds,
+                    target_ds,
+                    dbcur,
+                    commit,
+                    track_changes_as_dirty=track_changes_as_dirty,
+                )
+
+            if not track_changes_as_dirty:
+                # update the tree id
+                self._update_state_table_tree_impl(dbcur, target_tree_id)
+
+    def _filter_by_paths(self, datasets, paths):
+        """Filters the datasets so that only those matching the paths are returned."""
+        if paths:
+            return [ds for ds in datasets if ds.path.startswith(paths)]
+        else:
+            return datasets
+
+    def _update_table(
+        self, base_ds, target_ds, dbcur, commit=None, track_changes_as_dirty=False
+    ):
+        """
+        Update the given table in working copy from its current state to target_ds.
+        The table must exist in the working copy in the source and continue to exist in the destination,
+        and not have any unsupported meta changes - see _is_meta_update_supported.
+        base_ds - the dataset that this working copy table is currently based on.
+        target_ds - the target desired state for this working copy table.
+        dbcur - database cursor.
+        commit - the commit that contains target_ds, if any.
+        track_changes_if_dirty - whether to track changes made from base_ds -> target_ds as WC edits.
+        """
+
+        self._apply_meta_diff(base_ds, ~self.diff_db_to_tree_meta(base_ds), dbcur)
+        # WC now has base_ds structure and so we can write base_ds features to WC.
+        self._reset_dirty_rows(base_ds, dbcur)
+
+        if target_ds != base_ds:
+            self._apply_meta_diff(base_ds, base_ds.diff_meta(target_ds), dbcur)
+            # WC now has target_ds structure and so we can write target_ds features to WC.
+            self._apply_feature_diff(base_ds, target_ds, dbcur, track_changes_as_dirty)
+
+    def _apply_feature_diff(
+        self, base_ds, target_ds, dbcur, track_changes_as_dirty=False
+    ):
+        """
+        Change the features of this working copy from their current state, base_ds - to the desired state, target_ds.
+        base_ds - dataset containing the features that match the WC table currently.
+        target_ds - dataset containing the desired features of the WC table.
+        dbcur - database cursor.
+        track_changes_as_dirty - whether to track these changes as working-copy edits in the tracking table.
+        """
+        feature_diff_index = base_ds.feature_tree.diff_to_tree(target_ds.feature_tree)
+        if not feature_diff_index:
+            return
+
+        L.debug("Applying feature diff: about %s changes", len(feature_diff_index))
+
+        delete_pks = []
+        insert_and_update_pks = []
+
+        for d in feature_diff_index.deltas:
+            if d.old_file and d.old_file.path.startswith(base_ds.META_PATH):
+                continue
+            if d.new_file and d.new_file.path.startswith(base_ds.META_PATH):
+                continue
+
+            if d.status == pygit2.GIT_DELTA_DELETED:
+                delete_pks.append(base_ds.decode_path_to_1pk(d.old_file.path))
+            elif d.status in (pygit2.GIT_DELTA_ADDED, pygit2.GIT_DELTA_MODIFIED):
+                insert_and_update_pks.append(
+                    target_ds.decode_path_to_1pk(d.new_file.path)
+                )
+            else:
+                # RENAMED, COPIED, IGNORED, TYPECHANGE, UNMODIFIED, UNREADABLE, UNTRACKED
+                raise NotImplementedError(f"Delta status: {d.status_char()}")
+
+        if not track_changes_as_dirty:
+            # We don't want to track these changes as working copy edits - they will be part of the new WC base.
+            ctx = self._suspend_triggers(dbcur, base_ds)
+        else:
+            # We want to track these changes as working copy edits so they can be committed later.
+            ctx = contextlib.nullcontext()
+
+        with ctx:
+            self.delete_features(dbcur, base_ds, delete_pks)
+            self.write_features(dbcur, target_ds, insert_and_update_pks)
+
+    def _is_meta_update_supported(self, dataset_version, meta_diff):
+        """
+        Returns True if the given meta-diff is supported *without* dropping and rewriting the table.
+        (Any meta change is supported - even in datasets v1 - if we drop and rewrite the table,
+        but of course it is less efficient).
+        meta_diff - DeltaDiff object containing the meta changes.
+        """
+
+        # By default, no meta updates are supported (without dropping and rewriting).
+        # Subclasses can override to support various types of meta updates.
+        return not meta_diff
+
+    def _apply_meta_diff(self, dataset, meta_diff, dbcur):
+        """
+        Change the metadata of this working copy according to the given meta diff.
+        Not all changes are possible or supported - see _is_meta_update_supported.
+        dataset - which table to update.
+        meta_diff - a DeltaDiff object containing meta-item deltas for this dataset.
+        dbcur - database cursor.
+        """
+        L.debug("Meta diff: %s changes", len(meta_diff))
+        table_name = dataset.table_name
+        for key in meta_diff:
+            func_key = key.replace("/", "_").replace(".", "_")
+            func = getattr(self, f"_apply_meta_{func_key}")
+            delta = meta_diff[key]
+            func(table_name, delta.old_value, delta.new_value, dbcur)
+
+    def _reset_dirty_rows(self, base_ds, dbcur):
+        """
+        Reset the dirty rows recorded in the tracking table to match the originals from the dataset.
+        base_ds - the dataset this WC table is based on.
+        dbcur - database cursor.
+        """
+        track_count = self._execute_dirty_rows_query(dbcur, base_ds)
+        dirty_pk_list = [r[0] for r in dbcur]
+        if not dirty_pk_list:
+            return
+
+        # We're resetting the dirty rows so we don't track these changes in the tracking table.
+        with self._suspend_triggers(dbcur, base_ds):
+            # todo: suspend/remove spatial index
+            L.debug("Cleaning up dirty rows...")
+
+            count = self.delete_features(dbcur, base_ds, dirty_pk_list)
+            L.debug(
+                "_reset_dirty_rows(): removed %s features, tracking Δ count=%s",
+                count,
+                track_count,
+            )
+            count = self.write_features(
+                dbcur, base_ds, dirty_pk_list, ignore_missing=True
+            )
+            L.debug(
+                "_reset_dirty_rows(): wrote %s features, tracking Δ count=%s",
+                count,
+                track_count,
+            )
+
+            self._reset_tracking_table_for_dataset(dbcur, base_ds)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -88,7 +88,7 @@ def test_diff_points(
                 "+                                     geom = POINT(...)",
                 "+                                  t50_fid = 9999999",
                 "+                               name_ascii = Te Motu-a-kore",
-                "+                               macronated = 0",
+                "+                               macronated = N",
                 "+                                     name = Te Motu-a-kore",
             ]
         elif output_format == "geojson":
@@ -177,7 +177,7 @@ def test_diff_points(
                         "id": "I::9999",
                         "properties": {
                             "fid": 9999,
-                            "macronated": "0",
+                            "macronated": "N",
                             "name": "Te Motu-a-kore",
                             "name_ascii": "Te Motu-a-kore",
                             "t50_fid": 9999999,
@@ -249,7 +249,7 @@ def test_diff_points(
                                 "+": {
                                     "fid": 9999,
                                     "geom": "010100000000000000000000000000000000000000",
-                                    "macronated": "0",
+                                    "macronated": "N",
                                     "name": "Te Motu-a-kore",
                                     "name_ascii": "Te Motu-a-kore",
                                     "t50_fid": 9999999,

--- a/tests/test_working_copy_gpkg.py
+++ b/tests/test_working_copy_gpkg.py
@@ -323,7 +323,7 @@ def test_working_copy_reset(
     """
     Check that we reset any working-copy changes correctly before doing any new checkout
 
-    We can do this via `sno reset` or `sno checkout --force HEAD`
+    We can do this via `sno reset` or `sno checkout --discard-changes HEAD`
     """
     raise pytest.skip()  # apsw.SQLError: SQLError: Safety level may not be changed inside a transaction
     if layer == H.POINTS.LAYER:

--- a/tests/test_working_copy_postgis.py
+++ b/tests/test_working_copy_postgis.py
@@ -1,8 +1,8 @@
-import os
 import pytest
 
-from sno.sno_repo import SnoRepo
+import pygit2
 
+from sno.sno_repo import SnoRepo
 from sno.working_copy import WorkingCopy
 
 
@@ -21,32 +21,124 @@ H = pytest.helpers.helpers()
 )
 @pytest.mark.parametrize("version", ["1", "2"])
 def test_checkout_workingcopy(
-    version, archive, table, commit_sha, data_archive, cli_runner, postgis_db
+    version, archive, table, commit_sha, data_archive, cli_runner, new_postgis_db_schema
 ):
-    """ Checkout a working copy to edit """
-    postgres_url = os.environ["SNO_POSTGRES_URL"]
-
+    """ Checkout a working copy """
+    if version == "2":
+        archive += "2"
     with data_archive(archive) as repo_path:
+        repo = SnoRepo(repo_path)
         H.clear_working_copy()
 
+        with new_postgis_db_schema() as (postgres_url, postgres_schema):
+            repo.config["sno.workingcopy.path"] = postgres_url
+            r = cli_runner.invoke(["checkout"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines() == [
+                f"Creating working copy at {postgres_url} ..."
+            ]
+
+            r = cli_runner.invoke(["status"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines() == [
+                "On branch master",
+                "",
+                "Nothing to commit, working copy clean",
+            ]
+
+            wc = WorkingCopy.get(repo)
+            assert wc.is_created()
+
+            head_tree_id = repo.head.peel(pygit2.Tree).id.hex
+            assert wc.assert_db_tree_match(head_tree_id)
+
+
+@pytest.mark.parametrize(
+    "archive,table,commit_sha",
+    [
+        pytest.param("points", H.POINTS.LAYER, H.POINTS.HEAD_SHA, id="points"),
+        pytest.param(
+            "polygons", H.POLYGONS.LAYER, H.POLYGONS.HEAD_SHA, id="polygons-pk"
+        ),
+        pytest.param("table", H.TABLE.LAYER, H.TABLE.HEAD_SHA, id="table"),
+    ],
+)
+def test_commit_edits(
+    archive,
+    table,
+    commit_sha,
+    data_archive,
+    cli_runner,
+    new_postgis_db_schema,
+    edit_points,
+    edit_polygons,
+    edit_table,
+):
+    """ Checkout a working copy and make some edits """
+    with data_archive(f"{archive}2") as repo_path:
         repo = SnoRepo(repo_path)
-        repo.config["sno.workingcopy.path"] = postgres_url
-        r = cli_runner.invoke(["checkout"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [f"Creating working copy at {postgres_url} ..."]
+        H.clear_working_copy()
 
-        r = cli_runner.invoke(["status"])
-        assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [
-            "On branch master",
-            "",
-            "Nothing to commit, working copy clean",
-        ]
+        with new_postgis_db_schema() as (postgres_url, postgres_schema):
+            repo.config["sno.workingcopy.path"] = postgres_url
+            r = cli_runner.invoke(["checkout"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines() == [
+                f"Creating working copy at {postgres_url} ..."
+            ]
 
-        # FIXME -
-        # Make some edits to show that diffs actually work.
-        # Modify data editing fixtures eg insert(), edit() to work on postgres too.
+            r = cli_runner.invoke(["status"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines() == [
+                "On branch master",
+                "",
+                "Nothing to commit, working copy clean",
+            ]
 
-        wc = WorkingCopy.get(repo)
-        assert wc.is_created()
-        wc.delete()
+            wc = WorkingCopy.get(repo)
+            assert wc.is_created()
+
+            table_prefix = postgres_schema + "."
+            with wc.session() as db:
+                dbcur = db.cursor()
+                if archive == "points":
+                    edit_points(dbcur, table_prefix)
+                elif archive == "polygons":
+                    edit_polygons(dbcur, table_prefix)
+                elif archive == "table":
+                    edit_table(dbcur, table_prefix)
+
+            r = cli_runner.invoke(["status"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines() == [
+                "On branch master",
+                "",
+                "Changes in working copy:",
+                '  (use "sno commit" to commit)',
+                '  (use "sno reset" to discard changes)',
+                "",
+                f"  {table}:",
+                "    feature:",
+                "      1 inserts",
+                "      2 updates",
+                "      5 deletes",
+            ]
+            orig_head = repo.head.peel(pygit2.Commit).hex
+
+            r = cli_runner.invoke(["commit", "-m", "test_commit"])
+            assert r.exit_code == 0, r.stderr
+
+            r = cli_runner.invoke(["status"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines() == [
+                "On branch master",
+                "",
+                "Nothing to commit, working copy clean",
+            ]
+
+            new_head = repo.head.peel(pygit2.Commit).hex
+            assert new_head != orig_head
+
+            r = cli_runner.invoke(["checkout", "HEAD^"])
+
+            assert repo.head.peel(pygit2.Commit).hex == orig_head


### PR DESCRIPTION
![](https://media3.giphy.com/media/sChf4Eo55W8x2/giphy.gif)

## Description

Making reset work mostly means moving WC.reset functionality from gpkg.py into base.py, where it is shared by all working copies. A little bit of code that is database specific must be extracted out.

Also - started using register_type to make sure types coming out of the postgis database end up in the right format in python. These conversions were previously done manually for geometries, but now we also need to do it for timestamps. Since there could be arbitrarily many timestamps (or geometries, for that matter) in a single row, the code is tidier if we just use register_type to do it automatically.

Also - added tests, and made some test fixtures - edit_points, edit_polygons, edit_table - work for postgis as well as for gpkg.

## Related links:

https://github.com/koordinates/sno/issues/267
