### PR TITLE
Postgis: Support for resets involving meta changes

### DIFF
--- a/sno/working_copy/postgis_adapter.py
+++ b/sno/working_copy/postgis_adapter.py
@@ -53,7 +53,7 @@ def v2_schema_to_postgis_spec(schema, v2_obj):
     'fid INTEGER, geom GEOMETRY(POINT,2136), desc VARCHAR(128), PRIMARY KEY(fid)'
     """
     result = [
-        SQL("{} {}").format(Identifier(col.name), SQL(_v2_type_to_pg_type(col, v2_obj)))
+        SQL("{} {}").format(Identifier(col.name), SQL(v2_type_to_pg_type(col, v2_obj)))
         for col in schema
     ]
 
@@ -64,7 +64,7 @@ def v2_schema_to_postgis_spec(schema, v2_obj):
     return SQL(", ").join(result)
 
 
-def _v2_type_to_pg_type(column_schema, v2_obj):
+def v2_type_to_pg_type(column_schema, v2_obj):
     """Convert a v2 schema type to a postgis type."""
 
     v2_type = column_schema.data_type


### PR DESCRIPTION
![](https://media4.giphy.com/media/2fMaOoI1vYA57Ct1cI/giphy.gif)

## Description

Support for `sno checkout` between two commits where any of the following could have changed:
- dataset schemas
- CRS definitions
- other metadata not supported by Postgis (eg title, description).

This PR handles inserting CRS definitions if they are missing (but it never updates or deletes existing ones).

This PR has some optimisations so that schema changes don't always cause the entire table to be recreated.
These changes are done using single SQL commands:

ALTER TABLE x DROP COLUMN;
ALTER TABLE x RENAME COLUMN y TO z;
ALTER TABLE x ALTER COLUMN y TYPE z;

But, if columns have been inserted or reordered, the entire table will be rewritten. There is no Postgres command for reordering columns, and if a column has been inserted, we may need to populate it from the dataset anyway - so there is no single SQL command that will take care of everything, and any attempt to optimise may or may not be any quicker.

## Related links:

https://github.com/koordinates/sno/issues/267