### PR TITLE
Don't rely on SpatialReference for parsing authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `data ls` now accepts an optional ref argument
  * `meta get` now accepts a `--ref=REF` option
  * `clone` now accepts a `--branch` option to clone a specific branch.
+ * Bugfix - don't drop the user-supplied authority from the supplied CRS and generate a new unrelated one. [#278](https://github.com/koordinates/sno/issues/278)
 
 ## 0.5.0
 

--- a/sno/crs_util.py
+++ b/sno/crs_util.py
@@ -1,3 +1,5 @@
+import re
+
 from osgeo.osr import SpatialReference
 
 from .cli_util import StringFromFile
@@ -19,37 +21,105 @@ class CoordinateReferenceString(StringFromFile):
             )
 
 
-def get_identifier_str(crs):
+class _WktPatterns:
+    """Regular expressions for recognizing WKT name and authority."""
+
+    WHITESPACE = r"\s*"
+    OPEN_BRACKET = r"[%s]" % re.escape("[(")
+    CLOSE_BRACKET = r"[%s]" % re.escape("])")
+
+    WKT_STR = r'"((?:""|[^"])*)"'
+
+    ROOT_NAME_PATTERN = re.compile(
+        WHITESPACE.join(["^", "[A-Z]*", OPEN_BRACKET, WKT_STR]), re.IGNORECASE
+    )
+
+    ROOT_AUTHORITY_PATTERN = re.compile(
+        WHITESPACE.join(
+            [
+                "AUTHORITY",
+                OPEN_BRACKET,
+                WKT_STR,
+                ",",
+                WKT_STR,
+                CLOSE_BRACKET,
+                CLOSE_BRACKET,
+                "$",
+            ]
+        ),
+        re.IGNORECASE,
+    )
+
+
+def parse_name(crs):
+    if isinstance(crs, str):
+        m = _WktPatterns.ROOT_NAME_PATTERN.search(crs)
+        if m:
+            return m.group(1)
+        else:
+            spatial_ref = SpatialReference(crs)
+    elif isinstance(crs, SpatialReference):
+        spatial_ref = crs
+    else:
+        raise RuntimeError(f"Unrecognised CRS: {crs}")
+    return spatial_ref.GetName()
+
+
+def parse_authority(crs):
+    if isinstance(crs, str):
+        m = _WktPatterns.ROOT_AUTHORITY_PATTERN.search(crs)
+        if m:
+            return m.group(1), m.group(2)
+        spatial_ref = SpatialReference(crs)
+    elif isinstance(crs, SpatialReference):
+        spatial_ref = crs
+    else:
+        raise RuntimeError(f"Unrecognised CRS: {crs}")
+
+    # Use osgeo only as a fallback if the regex failed -
+    # We avoid using it since it is opinionated and sometimes chooses not to return the information it parsed -
+    # if it doesn't think the authority matches the CRS, it might just ignore it.
+    return spatial_ref.GetAuthorityName(None), spatial_ref.GetAuthorityCode(None)
+
+
+def get_identifier_str(crs, authority=None):
     """
     Given a CRS, generate a stable, unique identifier for it of type 'str'. Eg: "EPSG:2193"
     """
-    if isinstance(crs, str):
-        crs = SpatialReference(crs)
-    if not isinstance(crs, SpatialReference):
-        raise RuntimeError(f"Unrecognised CRS: {crs}")
-    auth_name = crs.GetAuthorityName(None)
-    auth_code = crs.GetAuthorityCode(None)
+    if authority is not None:
+        auth_name, auth_code = authority
+    else:
+        auth_name, auth_code = parse_authority(crs)
+
     if auth_name and auth_code:
         return f"{auth_name}:{auth_code}"
     code = auth_name or auth_code
     if code and code.strip() not in ("0", "EPSG"):
         return code
-    return f"CUSTOM:{get_identifier_int(crs)}"
+    return f"CUSTOM:{get_identifier_int(crs, (auth_name, auth_code))}"
 
 
-def get_identifier_int(crs):
+def get_identifier_int(crs, authority=None):
     """
     Given a CRS, generate a stable, unique identifer for it of type 'int'. Eg: 2193
     """
-    if isinstance(crs, str):
-        crs = SpatialReference(crs)
-    if not isinstance(crs, SpatialReference):
-        raise RuntimeError(f"Unrecognised CRS: {crs}")
-    auth_code = crs.GetAuthorityCode(None)
+    if authority is not None:
+        auth_name, auth_code = authority
+    else:
+        auth_name, auth_code = parse_authority(crs)
+
     if auth_code and auth_code.isdigit() and int(auth_code) > 0:
         return int(auth_code)
+
+    if isinstance(crs, str):
+        wkt = crs.strip()
+    elif isinstance(crs, SpatialReference):
+        wkt = crs.ExportToPrettyWkt()
+    else:
+        raise RuntimeError(f"Unrecognised CRS: {crs}")
+
     # Stable code that fits easily in an int32 and won't collide with EPSG codes.
-    return (uint32hash(crs.ExportToWkt()) & 0xFFFFFFF) + 1000000
+    return (uint32hash(wkt) & 0xFFFFFFF) + 1000000
 
 
 def get_identifier_int_from_dataset(dataset, crs_name=None):

--- a/sno/gpkg_adapter.py
+++ b/sno/gpkg_adapter.py
@@ -203,14 +203,13 @@ def _gpkg_srs_id(v2_obj):
 
 def wkt_to_gpkg_spatial_ref_sys(wkt):
     """Given a WKT crs definition, generate a gpkg_spatial_ref_sys meta item."""
-    spatial_ref = SpatialReference(wkt)
-    organization = spatial_ref.GetAuthorityName(None) or "NONE"
-    srs_id = crs_util.get_identifier_int(spatial_ref)
+    auth_name, auth_code = crs_util.parse_authority(wkt)
+    srs_id = crs_util.get_identifier_int(wkt, (auth_name, auth_code))
     return [
         {
-            "srs_name": spatial_ref.GetName(),
+            "srs_name": crs_util.parse_name(wkt),
             "definition": wkt,
-            "organization": organization,
+            "organization": auth_name or "NONE",
             "srs_id": srs_id,
             "organization_coordsys_id": srs_id,
             "description": None,

--- a/tests/test_crs_util.py
+++ b/tests/test_crs_util.py
@@ -1,0 +1,32 @@
+from osgeo.osr import SpatialReference
+
+from sno import crs_util
+
+# This is EPSG:4326 but with explicit axes in the order EAST, NORTH.
+# It exists in the wild and it doesn't work well with SpatialReference.
+# We just want to parse it without losing parts of it.
+TEST_WKT = """
+GEOGCS["WGS 84",
+    DATUM["WGS_1984",
+        SPHEROID["WGS 84", 6378137, 298.257223563,
+            AUTHORITY["EPSG", "7030"]],
+        AUTHORITY["EPSG", "6326"]],
+    PRIMEM["Greenwich", 0,
+        AUTHORITY["EPSG", "8901"]],
+    UNIT["degree", 0.0174532925199433,
+        AUTHORITY["EPSG", "9122"]],
+    AXIS["Longitude", EAST],
+    AXIS["Latitude", NORTH],
+    AUTHORITY["EPSG", "4326"]]
+"""
+
+
+def test_parse():
+    assert crs_util.parse_name(TEST_WKT) == "WGS 84"
+    assert crs_util.parse_authority(TEST_WKT) == ("EPSG", "4326")
+
+    # Strangely this doesn't entirely work using osgeo:
+    spatial_ref = SpatialReference(TEST_WKT)
+    assert spatial_ref.GetName() == "WGS 84"
+    assert spatial_ref.GetAuthorityName(None) is None
+    assert spatial_ref.GetAuthorityCode(None) is None


### PR DESCRIPTION
## Description

The osgeo.osr SpatialReference class is very fiddly to use well for simple tasks. For instance, the user supplies some WKT. We want to parse the authority from it and store it at a path based on its authority. SpatialReference can do this - but whether it successfully returns the authority it parsed, or None, or an error, depends on many things:

- is osgeo configured so that it can find the proj4 database 
- does osgeo think the WKT matches the definition from the database with that authority
- are the axes defined in the same order as the definition in the database
- how is the SpatialReference initialised - eg SpatialReference(wkt) or SpatialReference.SetFromUserInput(wkt)
- how is SetAxisMappingStrategy configured (maybe?)

This is a bit too much to worry about when we just want to be told what authority is written inside the WKT, and it makes testing difficult. Finding all these conditions took me some time and I am still not sure what the perfect configuration for everything is, or if there are tradeoffs. So, I have switched to extracting using regexes - also more efficient.

## Related links:

https://github.com/koordinates/sno/issues/278

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
