### PR TITLE
Open a single db transaction for a single operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.7.0 (UNRELEASED)
 
  * Support for checking out a dataset with a string primary key (or other non-integer primary key) as a GPKG working copy [#307](https://github.com/koordinates/sno/issues/307)
+ * Improved error recovery: Sno commands now write to the working copy within a single transaction, which is rolled back if the command fails. [#281](https://github.com/koordinates/sno/pull/281)
  * Bugfix - `sno meta set` didn't allow updates to `schema.json`
  * Bugfix - Fixed a potential `KeyError` in `Schema._try_align`
  * Bugfix - Fixed a potential `unexpected NoneType` in `WorkingCopy.is_dirty`

--- a/sno/working_copy/base.py
+++ b/sno/working_copy/base.py
@@ -573,21 +573,21 @@ class WorkingCopy:
                 f"Structural changes are affecting:\n{structural_changes_text}"
             )
 
-        # Delete old tables
-        if table_deletes:
-            self.drop_table(
-                target_tree_or_commit, *[base_datasets[d] for d in table_deletes]
-            )
-        # Write new tables
-        if table_inserts:
-            # Note: write_full doesn't work if called from within an existing db session.
-            self.write_full(
-                target_tree_or_commit, *[target_datasets[d] for d in table_inserts]
-            )
-
         with self.session(bulk=1) as db:
             dbcur = db.cursor()
+            # Delete old tables
+            if table_deletes:
+                self.drop_table(
+                    target_tree_or_commit, *[base_datasets[d] for d in table_deletes]
+                )
+            # Write new tables
+            if table_inserts:
+                # Note: write_full doesn't work if called from within an existing db session.
+                self.write_full(
+                    target_tree_or_commit, *[target_datasets[d] for d in table_inserts]
+                )
 
+            # Update tables that can be updated in place.
             for table in table_updates:
                 base_ds = base_datasets[table]
                 target_ds = target_datasets[table]

--- a/sno/working_copy/postgis.py
+++ b/sno/working_copy/postgis.py
@@ -387,8 +387,9 @@ class WorkingCopy_Postgis(WorkingCopy):
                 )
 
     def write_meta(self, dataset):
-        self.write_meta_title(dataset)
-        self.write_meta_crs(dataset)
+        with self.session():
+            self.write_meta_title(dataset)
+            self.write_meta_crs(dataset)
 
     def write_meta_title(self, dataset):
         """Write the dataset title as a comment on the table."""


### PR DESCRIPTION
## Description

Went through all the functions in the working copies and made sure they don't open more than one transaction in a sequence, or call more than one function in a sequence that would result in opening more than one transaction in a sequence.

This can mostly be easily fixed by opening a transaction that is reused, and that contains all the functions called. Any transactions that those functions open will reuse the one ongoing transaction.

A couple of things needed changing - 
- we can't switch database engine mid-transaction to create the spatial index using gdal. Luckily, it seems like reusing the apsw engine works? Is there a downside?
- Rearranged some DELETEs so they didn't need `PRAGMA defer_foreign_keys`
