### PR TITLE
apply: Add --allow-missing-old-values option

### DIFF
--- a/sno/dataset2.py
+++ b/sno/dataset2.py
@@ -331,7 +331,9 @@ class Dataset2(RichBaseDataset):
                 else:
                     raise
 
-    def apply_meta_diff(self, meta_diff, tree_builder):
+    def apply_meta_diff(
+        self, meta_diff, tree_builder, *, allow_missing_old_values=False
+    ):
         """Apply a meta diff to this dataset. Checks for conflicts."""
         if not meta_diff:
             return
@@ -374,7 +376,11 @@ class Dataset2(RichBaseDataset):
                         f"{self.path}: Trying to delete nonexistent meta item: {name}"
                     )
                     continue
-                if delta.type == "insert" and name in meta_tree:
+                if (
+                    delta.type == "insert"
+                    and (not allow_missing_old_values)
+                    and name in meta_tree
+                ):
                     has_conflicts = True
                     click.echo(
                         f"{self.path}: Trying to create meta item that already exists: {name}"


### PR DESCRIPTION


## Description

This change makes it easier to generate patches in an external system.

Specifically, #283 has meant some of our internally mirrored repos
have gotten into a state where some meta blobs may or may not exist,
and it's difficult to externally generate a patch without knowing
whether they exist or not.

This change allows our external system to just not supply the "-"
object for each change, and sno will treat the delta as either an insert
or an update as necessary.

For external systems which can be confident in the state of the repo,
this is useful for performance also:

 * patches can be half as large, since old revisions aren't needed
 * patch application can be much faster, since we don't need to fetch
   and decode the old features for every delta.

Even if this flag is specified, any "-" values supplied in the patch
will be checked for conflicts. It only skips checking missing ones.

This is a hidden option since it's not intended for 'normal' use.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
