### PR TITLE
No merge renames

### DIFF
--- a/sno/merge.py
+++ b/sno/merge.py
@@ -94,7 +94,7 @@ def do_merge(repo, ff, ff_only, dry_run, commit, commit_message, quiet=False):
         return merge_jdict
 
     tree3 = commit_with_ref3.map(lambda c: c.tree)
-    index = repo.merge_trees(**tree3.as_dict())
+    index = repo.merge_trees(**tree3.as_dict(), flags={"find_renames": False})
 
     if index.conflicts:
         merge_index = MergeIndex.from_pygit2_index(index)


### PR DESCRIPTION
## Description

Two commits - 
first commit upgrades pygit2 to 1.3.0 to have this functionality.
second commit turns off `find_renames` during a merge. Find renames is not useful to us all during a merge for a couple of reasons - 

- the sno code for distinguishing and dealing with all the different types of rename conflicts - eg rename/add, rename/delete, rename/edit rename/rename - has never been written
- it is currently not possible to write this code since pygit2 doesn't properly expose rename conflicts - a rename/rename conflict shows up in the conflicts list, but spread into three pieces, and there is no way to reassemble it.

To make things as sensible as possible given the constraints above, the best thing to do for now is turn off rename detection. That way, a rename/rename conflict is not a conflict it all - it is a delete/delete "conflict" (ie, not a conflict) and then two unrelated adds that also don't conflict. This may not be exactly what the user wanted, but it is better than creating broken partial-conflicts that we can't even reassemble into real conflicts.

Most real world conflicts (ie, not renames which are rare) will continue to work as before.

## Related links:

https://github.com/koordinates/sno/issues/79