### PR TITLE
Fix for "unsupported mandatory extension: '.sno'"

### DIFF
--- a/sno/merge.py
+++ b/sno/merge.py
@@ -104,7 +104,12 @@ def do_merge(repo, ff, ff_only, dry_run, commit, commit_message, quiet=False):
         return merge_jdict
 
     tree3 = commit_with_ref3.map(lambda c: c.tree)
-    index = repo.merge_trees(**tree3.as_dict())
+
+    with repo.no_locked_index_file():
+        # For no real reason, repo.merge_trees requires access to the index,
+        # and unfortunately, it doesn't respect GIT_INDEX_FILE env variable.
+        # TODO - find a solution that doesn't requrite modifying the file system.
+        index = repo.merge_trees(**tree3.as_dict())
 
     if index.conflicts:
         merge_index = MergeIndex.from_pygit2_index(index)

--- a/sno/sno_repo.py
+++ b/sno/sno_repo.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import struct
 import subprocess
@@ -287,3 +288,14 @@ class SnoRepo(pygit2.Repository):
             raise InvalidOperation(f'"{dir_path}" isn\'t empty')
         elif not dir_path.exists():
             dir_path.mkdir(parents=True)
+
+    @contextlib.contextmanager
+    def no_locked_index_file(self):
+        try:
+            (self.gitdir_path / SnoRepoFiles.INDEX).unlink()
+        except FileNotFoundError:
+            pass  # Use missing_ok once we have python 3.8
+        try:
+            yield
+        finally:
+            self.lock_git_index()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,7 +314,7 @@ def data_imported(cli_runner, data_archive, chdir, request, tmp_path_factory):
     def _data_imported(archive, source_gpkg, table, repo_version=DEFAULT_REPO_VERSION):
         nonlocal incr
 
-        params = [archive, source_gpkg, table, repo_version]
+        params = [archive, source_gpkg, table, str(repo_version)]
         cache_key = f"data_imported~{'~'.join(params)}"
 
         repo_path = Path(request.config.cache.makedir(cache_key)) / "data.sno"
@@ -843,7 +843,7 @@ def create_conflicts(
 ):
     @contextlib.contextmanager
     def ctx(data, repo_version=1):
-        archive = f"{data.ARCHIVE}2" if repo_version == 2 else data.ARCHIVE
+        archive = f"{data.ARCHIVE}2" if int(repo_version) == 2 else data.ARCHIVE
         with data_working_copy(archive) as (repo_path, wc):
             repo = SnoRepo(repo_path)
             sample_pks = data.SAMPLE_PKS

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -30,7 +30,7 @@ def _count_tracking_table_changes(db, working_copy, layer):
     return change_count
 
 
-V1_OR_V2 = ("repo_version", ["1", "2"])
+V1_OR_V2 = ("repo_version", [1, 2])
 
 
 @pytest.mark.parametrize(
@@ -60,7 +60,7 @@ def test_commit(
     edit_table,
 ):
     """ commit outstanding changes from the working copy """
-    versioned_archive = archive + "2" if repo_version == "2" else archive
+    versioned_archive = archive + "2" if repo_version == 2 else archive
 
     with data_working_copy(versioned_archive) as (repo_dir, wc_path):
         # empty

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -7,7 +7,7 @@ from sno.structs import CommitWithReference
 H = pytest.helpers.helpers()
 
 
-V1_OR_V2 = ("repo_version", ["1", "2"])
+V1_OR_V2 = ("repo_version", [1, 2])
 
 
 @pytest.mark.parametrize(*V1_OR_V2)
@@ -21,12 +21,13 @@ def test_merge_index_roundtrip(repo_version, create_conflicts, cli_runner):
         ancestor_id = repo.merge_base(ours.id, theirs.id)
         assert ancestor_id.hex == ancestor.id.hex
 
-        index = repo.merge_trees(ancestor.tree, ours.tree, theirs.tree)
+        with repo.no_locked_index_file():
+            index = repo.merge_trees(ancestor.tree, ours.tree, theirs.tree)
         assert index.conflicts
 
         # Create a MergeIndex object, and roundtrip it into a tree and back.
         orig = MergeIndex.from_pygit2_index(index)
-        assert len(orig.entries) == 242
+        assert len(orig.entries) == 236 if repo_version == 2 else 242
         assert len(orig.conflicts) == 4
         assert len(orig.resolves) == 0
         assert len(orig.unresolved_conflicts) == 4
@@ -45,7 +46,7 @@ def test_merge_index_roundtrip(repo_version, create_conflicts, cli_runner):
         key, conflict = items[1]
         r1.add_resolve(key, [])
         assert r1 != orig
-        assert len(r1.entries) == 242
+        assert len(r1.entries) == 236 if repo_version == 2 else 242
         assert len(r1.conflicts) == 4
         assert len(r1.resolves) == 2
         assert len(r1.unresolved_conflicts) == 2

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -28,7 +28,7 @@ def test_data_ls(archive_name, output_format, data_archive_readonly, cli_runner)
 
 
 @pytest.mark.parametrize("output_format", ("text", "json"))
-@pytest.mark.parametrize("repo_version", ["1", "2"])
+@pytest.mark.parametrize("repo_version", [1, 2])
 def test_data_ls_empty(repo_version, output_format, tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "emptydir"
     r = cli_runner.invoke(["init", repo_path, "--repo-version", repo_version])

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -15,7 +15,7 @@ H = pytest.helpers.helpers()
 
 DIFF_OUTPUT_FORMATS = ["text", "geojson", "json", "quiet", "html"]
 SHOW_OUTPUT_FORMATS = ["text", "json"]
-V1_OR_V2 = ("repo_version", ["1", "2"])
+V1_OR_V2 = ("repo_version", [1, 2])
 
 
 def _check_html_output(s):
@@ -36,7 +36,7 @@ def test_diff_points(
     repo_version, output_format, data_working_copy, geopackage, cli_runner
 ):
     """ diff the working copy against HEAD """
-    data_archive = "points2" if repo_version == "2" else "points"
+    data_archive = "points2" if repo_version == 2 else "points"
     with data_working_copy(data_archive) as (repo, wc):
         # empty
         r = cli_runner.invoke(
@@ -269,7 +269,7 @@ def test_diff_reprojection(
     repo_version, output_format, data_working_copy, geopackage, cli_runner
 ):
     """ diff the working copy against HEAD """
-    data_archive = "points2" if repo_version == "2" else "points"
+    data_archive = "points2" if repo_version == 2 else "points"
     with data_working_copy(data_archive) as (repo, wc):
         # make some changes
         db = geopackage(wc)
@@ -334,7 +334,7 @@ def test_diff_polygons(
     repo_version, output_format, data_working_copy, geopackage, cli_runner
 ):
     """ diff the working copy against HEAD """
-    data_archive = "polygons2" if repo_version == "2" else "polygons"
+    data_archive = "polygons2" if repo_version == 2 else "polygons"
     with data_working_copy(data_archive) as (repo, wc):
         # empty
         r = cli_runner.invoke(
@@ -671,7 +671,7 @@ def test_diff_table(
     repo_version, output_format, data_working_copy, geopackage, cli_runner
 ):
     """ diff the working copy against HEAD """
-    data_archive = "table2" if repo_version == "2" else "table"
+    data_archive = "table2" if repo_version == 2 else "table"
     with data_working_copy(data_archive) as (repo, wc):
         # empty
         r = cli_runner.invoke(
@@ -1349,7 +1349,7 @@ def test_show_points_HEAD(
     """
     Show a patch; ref defaults to HEAD
     """
-    data_archive = "points2" if repo_version == "2" else "points"
+    data_archive = "points2" if repo_version == 2 else "points"
     with data_archive_readonly(data_archive):
         r = cli_runner.invoke(["show", f"--output-format={output_format}", "HEAD"])
         assert r.exit_code == 0, r.stderr
@@ -1419,7 +1419,7 @@ def test_show_points_HEAD(
 
 @pytest.mark.parametrize(*V1_OR_V2)
 def test_diff_filtered(repo_version, data_archive_readonly, cli_runner):
-    data_archive = "points2" if repo_version == "2" else "points"
+    data_archive = "points2" if repo_version == 2 else "points"
     with data_archive_readonly(data_archive):
         r = cli_runner.invoke(["diff", "HEAD^...", "nz_pa_points_topo_150k:1182"])
         assert r.exit_code == 0, r.stderr
@@ -1506,7 +1506,7 @@ def test_create_patch(repo_version, data_archive_readonly, cli_runner):
     """
     Show a patch; ref defaults to HEAD
     """
-    data_archive = "points2" if repo_version == "2" else "points"
+    data_archive = "points2" if repo_version == 2 else "points"
     with data_archive_readonly(data_archive):
         r = cli_runner.invoke(["create-patch"])
         assert r.exit_code == 2, r.stderr
@@ -1542,7 +1542,7 @@ def test_show_shallow_clone(data_archive_readonly, cli_runner, tmp_path, chdir):
 def test_diff_streaming(repo_version, data_archive_readonly):
     # Test that a diff can be created without reading every feature,
     # and that the features in that diff can be read one by one.
-    data_archive = "points2" if repo_version == "2" else "points"
+    data_archive = "points2" if repo_version == 2 else "points"
     with data_archive_readonly(data_archive) as repo_path:
         repo = SnoRepo(repo_path)
         old = RepositoryStructure.lookup(repo, "HEAD^")[H.POINTS.LAYER]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -42,7 +42,7 @@ GPKG_IMPORTS = (
         pytest.param("gpkg-stringpk", "stringpk.gpkg", "stringpk", id="stringpk"),
     ],
 )
-V1_OR_V2 = ("repo_version", ["1", "2"])
+V1_OR_V2 = ("repo_version", [1, 2])
 
 
 @pytest.mark.slow
@@ -547,7 +547,7 @@ def test_init_import(
     repo_version,
 ):
     """ Import the GeoPackage (eg. `kx-foo-layer.gpkg`) into a Sno repository. """
-    state_table = "gpkg_sno_state" if repo_version == "2" else ".sno-meta"
+    state_table = "gpkg_sno_state" if repo_version == 2 else ".sno-meta"
     with data_archive(archive) as data:
         # list tables
         repo_path = tmp_path / "data.sno"

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -19,7 +19,7 @@ from sno.sno_repo import SnoRepo
 
 H = pytest.helpers.helpers()
 
-V1_OR_V2 = ("repo_version", ["1", "2"])
+V1_OR_V2 = ("repo_version", [1, 2])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -48,7 +48,7 @@ GPKG_IMPORTS = (
     ],
 )
 
-V1_OR_V2 = ("repo_version", ["1", "2"])
+V1_OR_V2 = ("repo_version", [1, 2])
 
 
 def test_dataset_versions():
@@ -726,9 +726,9 @@ def test_feature_find_decode_performance(
 
         # TODO: try to avoid two sets of code for two dataset versions -
         # either by making their interfaces more similar, or by deleting v1
-        if repo_version == "1":
+        if repo_version == 1:
             benchmark(dataset.repo_feature_to_dict, feature_path, feature_data)
-        elif repo_version == "2":
+        elif repo_version == 2:
             benchmark(dataset.get_feature, path=feature_path, data=feature_data)
     else:
         raise NotImplementedError(f"Unknown profile: {profile}")
@@ -857,14 +857,14 @@ def test_write_feature_performance(
 
                 index = pygit2.Index()
 
-                if repo_version == "1":
+                if repo_version == 1:
                     kwargs = {
                         "geom_cols": source.geom_cols,
                         "field_cid_map": dataset.get_field_cid_map(source),
                         "primary_key": source.primary_key,
                         "cast_primary_key": False,
                     }
-                elif repo_version == "2":
+                elif repo_version == 2:
                     kwargs = {"schema": source.schema}
 
                 def _write_feature():

--- a/tests/test_working_copy_gpkg.py
+++ b/tests/test_working_copy_gpkg.py
@@ -27,7 +27,7 @@ H = pytest.helpers.helpers()
         pytest.param("table", H.TABLE.LAYER, H.TABLE.HEAD_SHA, id="table"),
     ],
 )
-@pytest.mark.parametrize("version", ["1", "2"])
+@pytest.mark.parametrize("version", [1, 2])
 def test_checkout_workingcopy(
     version, archive, table, commit_sha, data_archive, tmp_path, cli_runner, geopackage
 ):

--- a/tests/test_working_copy_postgis.py
+++ b/tests/test_working_copy_postgis.py
@@ -20,7 +20,7 @@ H = pytest.helpers.helpers()
         pytest.param("table", H.TABLE.LAYER, H.TABLE.HEAD_SHA, id="table"),
     ],
 )
-@pytest.mark.parametrize("version", ["1", "2"])
+@pytest.mark.parametrize("version", [1, 2])
 def test_checkout_workingcopy(
     version, archive, table, commit_sha, data_archive, cli_runner, new_postgis_db_schema
 ):


### PR DESCRIPTION
## Description

pygit2.Repository.merge_trees for some reason requires access to the git index file - even though it doesn't use it. The file can be missing, this works perfectly.
We don't need the file: we only have a customised index there because it convinces git that it doesn't understand the working-copy part of the repository, so it doesn't try to mess with it.
Just to make it work, the call to merge_trees is now wrapped with a context manager that deletes the index file and then recreates it once the call is finished.

This solution is not ideal since it changes the file-system - multiple simultaneously running sno's could conflict with each other (not that this is a recommended way to use sno anyway), or a crashing sno could leave it in a bad way. Ideally, we would do something more like we do to run `git gc` - we set an environment variable that tells git to use a different index file.

Tests here were broken due to setting repo_version to "1" or "2" but testing if it equals 1 or 2 - the v2 test was never actually run. click.Choice flags only work with strings, which is annoying, and is why repo_version values are sometimes "1" and "2" instead of 1 and 2. This changes all the tests to use integers, which is less surprising, and makes the fixtures more robust to receiving either strings or ints.