### PR TITLE
Allow `sno switch` to switch to new local branch tracking remote branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `data ls` now accepts an optional ref argument
  * `meta get` now accepts a `--ref=REF` option
  * `clone` now accepts a `--branch` option to clone a specific branch.
+ * `switch BRANCH` now switches to a newly created local branch that tracks `BRANCH`, if `BRANCH` is a remote branch and not a local branch [#259](https://github.com/koordinates/sno/issues/259)
  * Bugfix - don't drop the user-supplied authority from the supplied CRS and generate a new unrelated one. [#278](https://github.com/koordinates/sno/issues/278)
 
 ## 0.5.0

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,0 +1,92 @@
+import pytest
+
+
+from sno.sno_repo import SnoRepo
+from sno.structs import CommitWithReference
+from sno.exceptions import NO_BRANCH, NO_COMMIT
+
+
+@pytest.mark.parametrize(
+    "working_copy",
+    [
+        pytest.param(True, id="with-wc"),
+        pytest.param(False, id="without-wc"),
+    ],
+)
+def test_checkout_branches(data_archive, cli_runner, chdir, tmp_path, working_copy):
+    with data_archive("points") as remote_path:
+
+        r = cli_runner.invoke(["checkout", "-b", "one"])
+        assert r.exit_code == 0, r.stderr
+        r = cli_runner.invoke(["checkout", "HEAD^"])
+        assert r.exit_code == 0, r.stderr
+        r = cli_runner.invoke(["switch", "--create", "two"])
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["checkout", "one", "-b", "three"])
+        assert r.exit_code == 0, r.stderr
+        r = cli_runner.invoke(["switch", "two", "--create", "four"])
+        assert r.exit_code == 0, r.stderr
+
+        repo = SnoRepo(remote_path)
+        one = CommitWithReference.resolve(repo, "one")
+        two = CommitWithReference.resolve(repo, "two")
+        three = CommitWithReference.resolve(repo, "three")
+        four = CommitWithReference.resolve(repo, "four")
+
+        assert one.commit.hex == three.commit.hex
+        assert two.commit.hex == four.commit.hex
+
+        assert one.commit.hex != two.commit.hex
+
+        wc_flag = "--checkout" if working_copy else "--no-checkout"
+        r = cli_runner.invoke(["clone", remote_path, tmp_path, wc_flag])
+        repo = SnoRepo(tmp_path)
+
+        head = CommitWithReference.resolve(repo, "HEAD")
+
+        with chdir(tmp_path):
+
+            r = cli_runner.invoke(["branch"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines() == ["* four"]
+
+            # Commit hex is not a branch name, can't be switched:
+            r = cli_runner.invoke(["switch", head.commit.hex])
+            assert r.exit_code == NO_BRANCH, r.stderr
+            # But can be checked out:
+            r = cli_runner.invoke(["checkout", head.commit.hex])
+            assert r.exit_code == 0, r.stderr
+
+            r = cli_runner.invoke(["checkout", "zero"])
+            assert r.exit_code == NO_COMMIT, r.stderr
+            r = cli_runner.invoke(["switch", "zero"])
+            assert r.exit_code == NO_BRANCH, r.stderr
+
+            r = cli_runner.invoke(["checkout", "one", "--no-guess"])
+            assert r.exit_code == NO_COMMIT, r.stderr
+            r = cli_runner.invoke(["switch", "one", "--no-guess"])
+            assert r.exit_code == NO_BRANCH, r.stderr
+
+            r = cli_runner.invoke(["checkout", "one"])
+            assert r.exit_code == 0, r.stderr
+            assert (
+                r.stdout.splitlines()[0]
+                == "Creating new branch 'one' to track 'origin/one'..."
+            )
+            assert (
+                CommitWithReference.resolve(repo, "HEAD").commit.hex == one.commit.hex
+            )
+            r = cli_runner.invoke(["switch", "two"])
+            assert r.exit_code == 0, r.stderr
+            assert (
+                r.stdout.splitlines()[0]
+                == "Creating new branch 'two' to track 'origin/two'..."
+            )
+            assert (
+                CommitWithReference.resolve(repo, "HEAD").commit.hex == two.commit.hex
+            )
+
+            r = cli_runner.invoke(["branch"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines() == ["  four", "  one", "* two"]


### PR DESCRIPTION
![](https://media2.giphy.com/media/l2YWlt9g2HQBMAb0k/giphy.gif)

## Description

`sno switch x` switches to x if x is a local branch - as before.
`sno switch origin/x` fails as before: you cannot switch to a remote branch
But, `sno switch x` where x is not yet a local branch but is the name of a remote branch, creates a local branch x that tracks `origin/x`. (Just as it does in git)

sno checkout behave similarly, but note that with sno checkout, you CAN `sno checkout origin/x` - this refish is resolved to a particular commit, and that commit is checked out as a "detached HEAD".

## Related links:

Fixes https://github.com/koordinates/sno/issues/259

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
