### PR TITLE
Always open pygit2.Repository as bare

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ jsonschema==3.2.0         # via -r requirements/requirements.in
 msgpack==0.6.2            # via -r requirements/requirements.in
 #psycopg2==2.8.5           # via -r requirements/requirements.in
 pycparser==2.20           # via cffi
-#pygit2==1.1.0             # via -r requirements/requirements.in
+#pygit2==1.3.0             # via -r requirements/requirements.in
 pygments==2.7.2           # via -r requirements/requirements.in
 pyrsistent==0.17.3        # via jsonschema
 rtree==0.9.4              # via -r requirements/requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -7,7 +7,7 @@ jsonschema
 
 # these are only here for dependencies
 psycopg2==2.8.5
-pygit2==1.1.0
+pygit2==1.3.0
 #apsw==3.31.1.post1  # X.Y.Z.post1 maps to X.Y.Z-r1 release version
 
 # workaround weird import error with pyinstaller

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -104,12 +104,7 @@ def do_merge(repo, ff, ff_only, dry_run, commit, commit_message, quiet=False):
         return merge_jdict
 
     tree3 = commit_with_ref3.map(lambda c: c.tree)
-
-    with repo.no_locked_index_file():
-        # For no real reason, repo.merge_trees requires access to the index,
-        # and unfortunately, it doesn't respect GIT_INDEX_FILE env variable.
-        # TODO - find a solution that doesn't requrite modifying the file system.
-        index = repo.merge_trees(**tree3.as_dict())
+    index = repo.merge_trees(**tree3.as_dict())
 
     if index.conflicts:
         merge_index = MergeIndex.from_pygit2_index(index)

--- a/sno/sno_repo.py
+++ b/sno/sno_repo.py
@@ -84,12 +84,17 @@ class SnoRepo(pygit2.Repository):
     Helps set up sno specific config, and adds support for pathlib Paths.
     """
 
-    def __init__(self, root_path):
-        if isinstance(root_path, Path):
-            root_path = str(root_path.resolve())
+    def __init__(self, path):
+        path = Path(path).resolve()
+        if (path / ".sno").exists():
+            path = path / ".sno"
 
         try:
-            super().__init__(root_path)
+            super().__init__(
+                str(path),
+                # Instructs pygit2 not to look at the working copy or the index.
+                pygit2.GIT_REPOSITORY_OPEN_BARE | pygit2.GIT_REPOSITORY_OPEN_FROM_ENV,
+            )
         except pygit2.GitError:
             raise NotFound("Not an existing sno repository", exit_code=NO_REPOSITORY)
 

--- a/vendor/libgit2/Makefile
+++ b/vendor/libgit2/Makefile
@@ -1,6 +1,6 @@
-LIBGIT2_REF ?= v0.99.0
+LIBGIT2_REF ?= v1.1.0
 LIBGIT2_REPO ?= libgit2/libgit2
-LIBGIT2_ARCHIVE := libgit2-0.99.0.tar.gz
+LIBGIT2_ARCHIVE := libgit2-1.1.0.tar.gz
 
 CFLAGS += -g
 CXXFLAGS += -g

--- a/vendor/makefile.vc
+++ b/vendor/makefile.vc
@@ -1,9 +1,9 @@
 PATH=$(MAKEDIR)\env\Scripts;$(PATH);C:\Program Files\7-zip;
 
 GIT_VER=2.25.1
-LIBGIT_REF=v0.99.0
-PYGIT2_REF=ccf4df153c68d4af7d3d0f4f4f9104afc6f38d43
-PYGIT2_VER=1.1.0
+LIBGIT_REF=v1.1.0
+PYGIT2_REF=da410961f0a426cdecbd36548c2b36dc13c674c2
+PYGIT2_VER=1.3.0
 SQLITE_VER=3.31.1  # and APSW (-r1/.post1)
 
 # ==================================================================

--- a/vendor/pygit2/Makefile
+++ b/vendor/pygit2/Makefile
@@ -1,5 +1,5 @@
-# v1.1.0+
-PYGIT2_REF ?= ccf4df153c68d4af7d3d0f4f4f9104afc6f38d43
+# v1.3.0+
+PYGIT2_REF ?= da410961f0a426cdecbd36548c2b36dc13c674c2
 PYGIT2_REPO ?= libgit2/pygit2
 PYGIT2_ARCHIVE := pygit2-$(PYGIT2_REF).tar.gz
 


### PR DESCRIPTION
![](https://media2.giphy.com/media/ykUYsNYRvrprq/giphy.gif)

## Description

From pygit / libgit's point of view, we don't have a working copy, and the index file is unreadable. (This is by design: it stops the `git` command line tool from messing up the repo). Previously, repositories were "bare" for the same reason, but now they aren't: it was a bit odd to have git-bare sno-bare repos, with no working copy at all, and git-bare sno-non-bare repos, with a sno working copy (eg a GPKG).
 So now the repo's config is appropriately bare or non-bare, but it means pygit / libgit sometimes has trouble reading the repository if it does some operation that might involve the index, even if only peripherally - like merge_trees, which doesn't really need the index, but opens it anyway to see if there are merge directives in there.

We stopped this previously by temporarily deleting the index, but this is a better fix: we always open a pygit2.Repository as bare, ignoring the config.

## Related links:

https://github.com/koordinates/sno/issues/297