### PR TITLE
git: disable use of system configuration files

### DIFF
--- a/sno/__init__.py
+++ b/sno/__init__.py
@@ -45,7 +45,8 @@ os.environ["PATH"] = (
 
 # Git
 # https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables
-os.environ["PREFIX"] = prefix
+os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+os.environ["XDG_CONFIG_HOME"] = prefix
 if is_windows:
     os.environ["PATH"] = (
         os.path.join(prefix, "git", "cmd") + os.pathsep + os.environ["PATH"]


### PR DESCRIPTION

## Description

Git config files come in a hierarchy:

* worktree
* repo
* user (`$HOME/.gitconfig`)
* xdg-user (`$XDG_CONFIG_HOME/git/config`)
* system (`$PREFIX/etc/gitconfig`) 

Despite what the docs say, `$PREFIX` is only configurable at build-time, and since on macOS & Windows we're bundling prebuilt Git distributions we can't change it.

This is causing a few oddities wrt authentication and credential-caching on Windows. Libgit2 doesn't (AFAICT) read the user + system configs unless told to, so when we shell out to git we have different behaviour cf the library.

In general I think:
- we want to set our own git system config
- and ideally user config
- and make sure we can override config flags consistently as needed via `-c foo.bar=value` to all Sno commands.

This is a first step, and shouldn't have any particular downsides — we were already attempting to disable the system config by setting `$PREFIX`, but it wasn't working.

## Checklist:

- [ ] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
