### PR TITLE
Allow custom CRS to be edited in Postgis WC

### DIFF
--- a/sno/gpkg_adapter.py
+++ b/sno/gpkg_adapter.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 import re
 
-from osgeo.osr import SpatialReference
-
 from . import crs_util
 from .exceptions import NotYetImplemented
 from .meta_items import META_ITEM_NAMES as V2_META_ITEM_NAMES
@@ -204,7 +202,10 @@ def _gpkg_srs_id(v2_obj):
 def wkt_to_gpkg_spatial_ref_sys(wkt):
     """Given a WKT crs definition, generate a gpkg_spatial_ref_sys meta item."""
     auth_name, auth_code = crs_util.parse_authority(wkt)
-    srs_id = crs_util.get_identifier_int(wkt, (auth_name, auth_code))
+    if auth_code and auth_code.isdigit() and int(auth_code) > 0:
+        srs_id = int(auth_code)
+    else:
+        srs_id = crs_util.get_identifier_int(wkt)
     return [
         {
             "srs_name": crs_util.parse_name(wkt),

--- a/sno/working_copy/gpkg.py
+++ b/sno/working_copy/gpkg.py
@@ -318,7 +318,7 @@ class WorkingCopy_GPKG(WorkingCopy):
 
             sql_insert_dict(dbcur, SQLCommand.INSERT, "gpkg_metadata_reference", params)
 
-    def _wc_meta_items(self, dataset):
+    def meta_items(self, dataset):
         """
         Extract all the metadata of this GPKG and convert to dataset V2 format.
         Note that the extracted schema will not be aligned to any existing schema


### PR DESCRIPTION
![](https://media0.giphy.com/media/nkvJjLPFvnSEw/giphy.gif)

There are two different cases where a CRS might differ in the dataset and the WC, and we want to treat them differently.

In one case, the CRS might be a standard one like EPSG:2193, and it might be in the WC already because it came installed
with Postgis. The dataset might have this same CRS, perhaps imported from some data source, and these two CRS might
differ slightly. In this case, we don't want to mess with the CRS that came with the Postgis working copy, but we also
don't want to commit the Postgis version to the dataset and add a spurious change to the history - what if another
working copy has another version? The CRS could end up switching backwards and forwards depending on which working copy is used. So in this case, we want to ignore the change.

In the other case, the CRS is custom and comes from the dataset. In this case, we are happy to let the user update the
CRS in the working copy and commit the change to the working copy, just as they can in GPKG.

Also improves CRS code generation logic -
generated CRS code shouldn't change if the authority / name is set,
and remains unchanged.


No change to CHANGELOG - still covered by "adding Postgis working copy".
Still TODO: Add documentation about different working copies.