### PR TITLE
Tighten up working copy states ready for postgis

### DIFF
--- a/sno/clone.py
+++ b/sno/clone.py
@@ -45,7 +45,6 @@ def get_directory_from_url(url):
 @click.option(
     "--workingcopy-path",
     "wc_path",
-    type=click.Path(dir_okay=False),
     help="Path where the working copy should be created. "
     "This should be a GPKG file eg example.gpkg or a postgres URI including schema eg postgresql://[HOST]/DBNAME/SCHEMA",
 )
@@ -85,7 +84,7 @@ def clone(ctx, bare, do_checkout, wc_path, do_progress, depth, branch, url, dire
 
     if repo_path.exists() and any(repo_path.iterdir()):
         raise InvalidOperation(f'"{repo_path}" isn\'t empty', param_hint="directory")
-    WorkingCopy.check_valid_path(wc_path, repo_path)
+    WorkingCopy.check_valid_creation_path(wc_path, repo_path)
 
     if not repo_path.exists():
         repo_path.mkdir(parents=True)

--- a/sno/sno_repo.py
+++ b/sno/sno_repo.py
@@ -137,6 +137,8 @@ class SnoRepo(pygit2.Repository):
 
         repo_root_path = repo_root_path.resolve()
         cls._ensure_exists_and_empty(repo_root_path)
+        if not bare:
+            WorkingCopy.check_valid_creation_path(wc_path, wc_path)
 
         if bare:
             # Create bare-style repo:
@@ -171,6 +173,8 @@ class SnoRepo(pygit2.Repository):
     ):
         repo_root_path = repo_root_path.resolve()
         cls._ensure_exists_and_empty(repo_root_path)
+        if not bare:
+            WorkingCopy.check_valid_creation_path(wc_path, wc_path)
 
         if bare:
             sno_repo = cls._create_with_git_command(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -792,7 +792,7 @@ def test_import_into_empty_branch(data_archive, cli_runner, chdir, tmp_path):
     repo_path = tmp_path / "data.sno"
     repo_path.mkdir()
 
-    r = cli_runner.invoke(["init", "--no-checkout", repo_path])
+    r = cli_runner.invoke(["init", "--bare", repo_path])
     assert r.exit_code == 0
 
     with data_archive("gpkg-points") as data:


### PR DESCRIPTION
## Description

Various tweaks to how working copy state is sanity-checked -

More nuance: working copies can be
- created (that is, existing) or not
- initialised (= existing plus having the sno-specific tracking + state tables) or not
- has_data or not - if they seem to contain user data already, ignoring the state tables above.

Most places we try to create a working copy, we expect them to be either non-existent, or both created+initialised. If they are created but not initialised, an error will be raised. If they are not created at all, that might still be okay depending on the command.

Some commands will create a working copy automatically if one doesn't exist - eg `checkout`, `init --import`, `clone`. These move the working copy from one valid state - uncreated - to the other - created + initialised - so they will still fail if the working copy is already created but uninitialised.

#### is_created is slightly different for postgres:
Postgres working copies are treated as "uncreated" if the schema exists but doesn't contain anything. This is so you can create an empty postgres schema ahead of time, and then have postgres work exactly the same as GPKG - it starts off "uncreated" and will get created at a sensible time, probably the first time you import data. An empty postgres schema shouldn't trigger an alert "WC already exists but is missing sno tables" like an empty GPKG should, or like a postgres schema that is non-empty but is missing sno tables.

#### create-workingcopy is special:
`sno create-workingcopy` is more lenient about these things so that you can use it to recreate the working copy if it gets broken somehow. It will delete any existing working copy you have at the old configured location, delete any existing working copy you may have at the newly provided location, and then write a new working copy from scratch at the new provided location. However, it takes care not to delete the old schema if it is the same as the new schema, since sno might lack permissions to recreate the schema.

## Related links:

https://github.com/koordinates/sno/issues/293
