### PR TITLE
Fix build - set-env is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,7 +371,7 @@ jobs:
       - name: "python"
         run: |
           $PY3=(Get-Command python).Definition
-          echo "::set-env name=PY3::$PY3"
+          echo "PY3=$PY3" >> $GITHUB_ENV
 
       - name: "python: pip cache"
         uses: actions/cache@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,7 +371,7 @@ jobs:
       - name: "python"
         run: |
           $PY3=(Get-Command python).Definition
-          echo "PY3=$PY3" >> $GITHUB_ENV
+          echo "PY3=$PY3" >> $Env:GITHUB_ENV
 
       - name: "python: pip cache"
         uses: actions/cache@v1

--- a/makefile.vc
+++ b/makefile.vc
@@ -23,7 +23,7 @@ cleanest: cleaner
 	(cd vendor\ && $(MAKE) /NoLogo /F makefile.vc cleaner)
 
 venv:
-	$(PY3) -m venv $@
+	${env:PY3} -m venv $@
 
 # Dependencies
 

--- a/makefile.vc
+++ b/makefile.vc
@@ -23,7 +23,7 @@ cleanest: cleaner
 	(cd vendor\ && $(MAKE) /NoLogo /F makefile.vc cleaner)
 
 venv:
-	${env:PY3} -m venv $@
+	$(PY3) -m venv $@
 
 # Dependencies
 


### PR DESCRIPTION
## Description

set-env is deprecated but luckily there is a straight-forward replacement.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
https://github.com/guettli/fix-CVE-2020-15228

Unfortunately, the windows build still fails once this change has been made