### PR TITLE
Always return features as dicts

### DIFF
--- a/sno/fsck.py
+++ b/sno/fsck.py
@@ -161,18 +161,14 @@ def fsck(ctx, reset_datasets, fsck_args):
             if not has_err:
                 click.echo("Checking features...")
                 feature_err_count = 0
-                for feature in dataset.features():
-
-                    # TODO - reintroduce this check by writing Feature objects, instead of using dicts everywhere.
-                    """
+                for feature, blob in dataset.features_plus_blobs():
                     h_verify = os.path.basename(dataset.encode_1pk_to_path(feature[pk]))
-                    if pk_hash != h_verify:
+                    if blob.name != h_verify:
                         has_err = True
                         click.secho(
-                            f"✘ Hash mismatch for feature '{feature[pk]}': repo says {pk_hash} but should be {h_verify}",
+                            f"✘ Hash mismatch for feature '{feature[pk]}': repo says {blob.name} but should be {h_verify}",
                             fg="red",
                         )
-                    """
 
                     dbcur.execute(
                         f"SELECT * FROM {gpkg.ident(table)} WHERE {gpkg.ident(pk)}=?;",

--- a/sno/rich_base_dataset.py
+++ b/sno/rich_base_dataset.py
@@ -32,6 +32,10 @@ class RichBaseDataset(BaseDataset):
 
     RTREE_INDEX_EXTENSIONS = ("sno-idxd", "sno-idxi")
 
+    def features_plus_blobs(self):
+        for blob in self.feature_blobs():
+            yield self.get_feature(path=blob.name, data=blob.data), blob
+
     def build_spatial_index(self, path):
         """
         Internal proof-of-concept method for building a spatial index across the repository.
@@ -47,10 +51,11 @@ class RichBaseDataset(BaseDataset):
             t0 = time.monotonic()
 
             c = 0
-            for (pk, geom) in self.feature_tuples(
-                [self.primary_key, self.geom_column_name]
-            ):
+            for feature in self.features():
                 c += 1
+                pk = feature[self.primary_key]
+                geom = feature[self.geom_column_name]
+
                 if geom is None:
                     continue
 

--- a/sno/schema.py
+++ b/sno/schema.py
@@ -263,16 +263,12 @@ class Schema:
         cols = ",\n".join(repr(c) for c in self.columns)
         return f"Schema([{cols}])"
 
-    def feature_from_raw_dict(self, raw_dict, keys=True):
+    def feature_from_raw_dict(self, raw_dict):
         """
         Takes a "raw" feature dict - values keyed by column ID.
-        Returns a dict of values keyed by column name (if keys=True)
-        or a tuple of value in schema order (if keys=False).
+        Returns a dict of values keyed by column name.
         """
-        if keys:
-            return {c.name: raw_dict.get(c.id, None) for c in self.columns}
-        else:
-            return tuple([raw_dict.get(c.id, None) for c in self.columns])
+        return {c.name: raw_dict.get(c.id, None) for c in self.columns}
 
     def feature_to_raw_dict(self, feature):
         """

--- a/sno/working_copy/gpkg.py
+++ b/sno/working_copy/gpkg.py
@@ -639,9 +639,10 @@ class WorkingCopy_GPKG(WorkingCopy):
 
                 CHUNK_SIZE = 10000
                 total_features = dataset.feature_count
-                for rows in self._chunk(dataset.feature_tuples(col_names), CHUNK_SIZE):
-                    dbcur.executemany(sql_insert_features, rows)
-                    feat_progress += len(rows)
+                for row_dicts in self._chunk(dataset.features(), CHUNK_SIZE):
+                    row_tuples = (row_dict.values() for row_dict in row_dicts)
+                    dbcur.executemany(sql_insert_features, row_tuples)
+                    feat_progress += len(row_dicts)
 
                     t0a = time.monotonic()
                     L.info(
@@ -693,13 +694,12 @@ class WorkingCopy_GPKG(WorkingCopy):
 
         feat_count = 0
         CHUNK_SIZE = 10000
-        for rows in self._chunk(
-            dataset.get_feature_tuples(
-                pk_iter, col_names, ignore_missing=ignore_missing
-            ),
+        for row_dicts in self._chunk(
+            dataset.get_features(pk_iter, ignore_missing=ignore_missing),
             CHUNK_SIZE,
         ):
-            dbcur.executemany(sql_write_feature, rows)
+            row_tuples = (row_dict.values() for row_dict in row_dicts)
+            dbcur.executemany(sql_write_feature, row_tuples)
             feat_count += changes_rowcount(dbcur)
 
         return feat_count

--- a/sno/working_copy/postgis.py
+++ b/sno/working_copy/postgis.py
@@ -568,9 +568,9 @@ class WorkingCopy_Postgis(WorkingCopy):
                 t0p = t0
 
                 CHUNK_SIZE = 10000
-                for rows in self._chunk(dataset.feature_tuples(col_names), CHUNK_SIZE):
-
-                    dbcur.executemany(sql_insert_features, rows)
+                for row_dicts in self._chunk(dataset.features(), CHUNK_SIZE):
+                    row_tuples = (tuple(row_dict.values()) for row_dict in row_dicts)
+                    dbcur.executemany(sql_insert_features, row_tuples)
                     feat_count += changes_rowcount(dbcur)
 
                     nc = feat_count / CHUNK_SIZE
@@ -629,13 +629,12 @@ class WorkingCopy_Postgis(WorkingCopy):
 
         feat_count = 0
         CHUNK_SIZE = 10000
-        for rows in self._chunk(
-            dataset.get_feature_tuples(
-                pk_iter, col_names, ignore_missing=ignore_missing
-            ),
+        for row_dicts in self._chunk(
+            dataset.get_features(pk_iter, ignore_missing=ignore_missing),
             CHUNK_SIZE,
         ):
-            dbcur.executemany(sql_write_feature, (tuple(r) for r in rows))
+            row_tuples = (tuple(row_dict.values()) for row_dict in row_dicts)
+            dbcur.executemany(sql_write_feature, row_tuples)
             feat_count += changes_rowcount(dbcur)
 
         return feat_count


### PR DESCRIPTION
## Description

Drop support for returning features from datasets as tuples - always return them as dicts.
There were three possible reasons for getting features as tuples as opposed to dicts -
a) as an optimisation, tuples are slightly quicker if you don't need the keys
b) the get_feature_tuple code let you specify which columns you wanted in which order, which might be useful...
c) a + b together - generating a tuple could be even quicker if you don't even need all the values

However, they were relatively few calls to get_feature_tuple, relatively few places where we only need some subset of a row, and datasets V2 had limited support for these optimisations anyway - if you specified that you only wanted certain columns in a certain order, it would just generate the dict and then convert that to a tuple for you - nothing the client couldn't do themselves, and not something they do very often. In any case unpacking a feature from the git object is what takes the most time currently, and the entire feature is unpacked regardless - whether it is put into a dict or a tuple afterwards doesn't really change the overall speed.

As a result of this change, dataset1 and 2 have more in common than before, so some of the code is able to be moved into base_dataset.py

I did some profiling and it doesn't appear to have changed anything - some tests were up 5% quicker, the some were up to 5% slower, so it looks like mostly noise:
https://docs.google.com/spreadsheets/d/174DhZ4N3cS3pfjleHlPjmtxmk5HZDrmVIflAIcIKSvk/edit#gid=922066028

This is done to make the code simpler ready for alphanumeric PKs - I began work on alphanumeric PKs but ran into a problem where get_feature_tuple not doing what I wanted, so decided to make this change I've had planned for a while