### PR TITLE
Roll-forward "Upgrade pygit2 to 1.3.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ jsonschema==3.2.0         # via -r requirements/requirements.in
 msgpack==0.6.2            # via -r requirements/requirements.in
 #psycopg2==2.8.5           # via -r requirements/requirements.in
 pycparser==2.20           # via cffi
-#pygit2==1.1.0             # via -r requirements/requirements.in
+#pygit2==1.3.0             # via -r requirements/requirements.in
 pygments==2.7.2           # via -r requirements/requirements.in
 pyrsistent==0.17.3        # via jsonschema
 rtree==0.9.4              # via -r requirements/requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -7,7 +7,7 @@ jsonschema
 
 # these are only here for dependencies
 psycopg2==2.8.5
-pygit2==1.1.0
+pygit2==1.3.0
 #apsw==3.31.1.post1  # X.Y.Z.post1 maps to X.Y.Z-r1 release version
 
 # workaround weird import error with pyinstaller

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -370,3 +370,6 @@ print-lib-deps-Darwin:
 print-lib-deps-Linux:
 	@echo -e "\nExamining library dependencies..."
 	find env/lib/  && find . -name "*.so" -print -exec ldd {} \;
+
+
+# Force cache-miss and rebuild at 2020-12-01 10:00

--- a/vendor/libgit2/Makefile
+++ b/vendor/libgit2/Makefile
@@ -1,6 +1,6 @@
-LIBGIT2_REF ?= v0.99.0
+LIBGIT2_REF ?= v1.1.0
 LIBGIT2_REPO ?= libgit2/libgit2
-LIBGIT2_ARCHIVE := libgit2-0.99.0.tar.gz
+LIBGIT2_ARCHIVE := libgit2-1.1.0.tar.gz
 
 CFLAGS += -g
 CXXFLAGS += -g

--- a/vendor/makefile.vc
+++ b/vendor/makefile.vc
@@ -1,9 +1,9 @@
 PATH=$(MAKEDIR)\env\Scripts;$(PATH);C:\Program Files\7-zip;
 
 GIT_VER=2.25.1
-LIBGIT_REF=v0.99.0
-PYGIT2_REF=ccf4df153c68d4af7d3d0f4f4f9104afc6f38d43
-PYGIT2_VER=1.1.0
+LIBGIT_REF=v1.1.0
+PYGIT2_REF=da410961f0a426cdecbd36548c2b36dc13c674c2
+PYGIT2_VER=1.3.0
 SQLITE_VER=3.31.1  # and APSW (-r1/.post1)
 
 # ==================================================================

--- a/vendor/pygit2/Makefile
+++ b/vendor/pygit2/Makefile
@@ -1,5 +1,5 @@
-# v1.1.0+
-PYGIT2_REF ?= ccf4df153c68d4af7d3d0f4f4f9104afc6f38d43
+# v1.3.0+
+PYGIT2_REF ?= da410961f0a426cdecbd36548c2b36dc13c674c2
 PYGIT2_REPO ?= libgit2/pygit2
 PYGIT2_ARCHIVE := pygit2-$(PYGIT2_REF).tar.gz
 


### PR DESCRIPTION
Already approved as part of #298

Caused build failures at that time, shortly afterwards - we seem to be having issues with the vendor build-cache.
This time around, trying to make sure the cache cannot be used.

## Description
Upgrade pygit from 1.1.0 to 1.3.0+ so that we can use open-as-bare functionality.

## Related links:
Required for #297 - which is closed as fixed, but got rolled back.
