### PR TITLE
Roll-forward "Always open pygit2.Repository as bare"

### DIFF
--- a/sno/merge.py
+++ b/sno/merge.py
@@ -104,12 +104,7 @@ def do_merge(repo, ff, ff_only, dry_run, commit, commit_message, quiet=False):
         return merge_jdict
 
     tree3 = commit_with_ref3.map(lambda c: c.tree)
-
-    with repo.no_locked_index_file():
-        # For no real reason, repo.merge_trees requires access to the index,
-        # and unfortunately, it doesn't respect GIT_INDEX_FILE env variable.
-        # TODO - find a solution that doesn't requrite modifying the file system.
-        index = repo.merge_trees(**tree3.as_dict())
+    index = repo.merge_trees(**tree3.as_dict())
 
     if index.conflicts:
         merge_index = MergeIndex.from_pygit2_index(index)

--- a/sno/sno_repo.py
+++ b/sno/sno_repo.py
@@ -100,12 +100,17 @@ class SnoRepo(pygit2.Repository):
     Note: this is not enforced, especially since all legacy "bare-style" sno repos violate this assumption.
     """
 
-    def __init__(self, root_path, *, validate=True):
-        if isinstance(root_path, Path):
-            root_path = str(root_path.resolve())
+    def __init__(self, path, *, validate=True):
+        path = Path(path).resolve()
+        if (path / ".sno").exists():
+            path = path / ".sno"
 
         try:
-            super().__init__(root_path)
+            super().__init__(
+                str(path),
+                # Instructs pygit2 not to look at the working copy or the index.
+                pygit2.GIT_REPOSITORY_OPEN_BARE | pygit2.GIT_REPOSITORY_OPEN_FROM_ENV,
+            )
         except pygit2.GitError:
             raise NotFound("Not an existing sno repository", exit_code=NO_REPOSITORY)
 

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -372,4 +372,4 @@ print-lib-deps-Linux:
 	find env/lib/  && find . -name "*.so" -print -exec ldd {} \;
 
 
-# Force cache-miss and rebuild at 2020-12-01 10:00
+# Force cache-miss and rebuild at 2020-12-01 13:00


### PR DESCRIPTION
Already reviewed and submitted as #298, but we had problems with the vendor build-cache.
Trying again but forcing a cache miss by modifying vendor/Makefile

## Description
From pygit / libgit's point of view, we don't have a working copy, and the index file is unreadable. (This is by design: it stops the git command line tool from messing up the repo). Previously, repositories were "bare" for the same reason, but now they aren't: it was a bit odd to have git-bare sno-bare repos, with no working copy at all, and git-bare sno-non-bare repos, with a sno working copy (eg a GPKG).
So now the repo's config is appropriately bare or non-bare, but it means pygit / libgit sometimes has trouble reading the repository if it does some operation that might involve the index, even if only peripherally - like merge_trees, which doesn't really need the index, but opens it anyway to see if there are merge directives in there.

We stopped this previously by temporarily deleting the index, but this is a better fix: we always open a pygit2.Repository as bare, ignoring the config.

## Related links:
Fixes #297
