### PR TITLE
import: preserve 'numeric' fields if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * Bugfix - `sno meta set` didn't allow updates to `schema.json`
  * Bugfix - Fixed a potential `KeyError` in `Schema._try_align`
  * Bugfix - Fixed a potential `unexpected NoneType` in `WorkingCopy.is_dirty`
+ * Bugfix - imports now preserve fixed-precision numeric types in most situations.
+ * Bugfix - imports now preserve length of text/string fields.
 
 ## 0.6.0
 

--- a/sno/ogr_import_source.py
+++ b/sno/ogr_import_source.py
@@ -494,7 +494,8 @@ class OgrImportSource(ImportSource):
     def _field_to_v2_column_schema(self, fd):
         ogr_type = fd.GetTypeName()
         ogr_width = fd.GetWidth()
-        if self._should_import_as_numeric(ogr_type, ogr_width):
+        ogr_subtype = fd.GetSubType()
+        if (not ogr_subtype) and self._should_import_as_numeric(ogr_type, ogr_width):
             data_type = "numeric"
             # Note 2: Rather confusingly, OGR's concepts of 'width' and 'precision'
             # correspond to 'precision' and 'scale' in most other systems, respectively:
@@ -505,7 +506,6 @@ class OgrImportSource(ImportSource):
                 "scale": fd.GetPrecision(),
             }
         else:
-            ogr_subtype = fd.GetSubType()
             if ogr_subtype == ogr.OFSTNone:
                 data_type_info = self.OGR_TYPE_TO_V2_SCHEMA_TYPE.get(ogr_type)
                 if data_type_info is None:

--- a/sno/schema.py
+++ b/sno/schema.py
@@ -413,6 +413,9 @@ class Schema:
             if approximated_types and approximated_types.get(old_type) == new_type:
                 # new_col's type was the best approximation we could manage of old_col's type.
                 new_col["dataType"] = old_col["dataType"]
+                for k in ("scale", "precision"):
+                    if k in old_col:
+                        new_col[k] = old_col[k]
             else:
                 return False
 

--- a/tests/test_ogr_import_source.py
+++ b/tests/test_ogr_import_source.py
@@ -1,6 +1,9 @@
+import os
 import pytest
 
+from sno import structure
 from sno.ogr_import_source import PostgreSQLImportSource
+from sno.sno_repo import SnoRepo
 
 
 def test_postgres_url_parsing():
@@ -45,3 +48,59 @@ def test_postgres_url_parsing():
         func("postgres:///?host=%2Fvar%2Flib%2Fpostgresql")
         == "PG:host=/var/lib/postgresql"
     )
+
+
+def test_import_various_field_types(tmp_path, postgis_db, cli_runner):
+    # Using postgres here because it has the best type preservation
+    with postgis_db.cursor() as c:
+        c.execute(
+            """
+                DROP TABLE IF EXISTS typoes;
+                CREATE TABLE typoes (
+                    bigant BIGINT PRIMARY KEY,
+                    tumeric20_0 NUMERIC(20,0),
+                    tumeric5_5 NUMERIC(5,5),
+                    flote FLOAT,
+                    dubble DOUBLE PRECISION,
+                    smallant SMALLINT,
+                    tumeric99_0 numeric(99,0),
+                    tumeric4_0 numeric(4,0),
+                    tumeric numeric,
+                    techs varchar,
+                    techs10 varchar(100)
+                );
+                """
+        )
+
+    r = cli_runner.invoke(["init", str(tmp_path)])
+    assert r.exit_code == 0, r.stderr
+    r = cli_runner.invoke(
+        ["-C", str(tmp_path), "import", os.environ["SNO_POSTGRES_URL"], "typoes"],
+    )
+
+    assert r.exit_code == 0, r.stderr
+    repo = SnoRepo(tmp_path)
+    dataset = structure.RepositoryStructure(repo)["typoes"]
+
+    cols = {}
+    for col in dataset.schema.to_column_dicts():
+        col = col.copy()
+        col.pop("id")
+        cols[col.pop("name")] = col
+
+    assert cols == {
+        "bigant": {"dataType": "integer", "primaryKeyIndex": 0, "size": 64},
+        "dubble": {"dataType": "float", "size": 64},
+        "smallant": {"dataType": "integer", "size": 16},
+        "tumeric20_0": {"dataType": "numeric", "precision": 20, "scale": 0},
+        "tumeric4_0": {"dataType": "numeric", "precision": 4, "scale": 0},
+        "tumeric5_5": {"dataType": "numeric", "precision": 5, "scale": 5},
+        "tumeric99_0": {"dataType": "numeric", "precision": 99, "scale": 0},
+        "techs": {"dataType": "text"},
+        "techs10": {"dataType": "text", "length": 100},
+        # these two are regrettable but currently unavoidable;
+        # ogr treats both floats and unqualified numerics as Real(0.0),
+        # so they're indistinguishable from doubles.
+        "tumeric": {"dataType": "float", "size": 64},
+        "flote": {"dataType": "float", "size": 64},
+    }


### PR DESCRIPTION

## Description

OGR doesn't support fixed-precision numeric fields very well,
and turns them into either Integer or Real (floating point).

It does preserve the precision and scale,
so in some cases we can use those to heuristically restore the original
'NUMERIC(x,y)' type.

However there are a few edge cases and pitfalls here, noted in comments.
Perfect preservation of all types isn't possible.
A longer term fix would be to remove OGR's involvement in the import
process; it doesn't excel at preserving exact types.

### todo

- [x] add tests

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
