### PR TITLE
Further improvements to numeric type handling

### DIFF
--- a/tests/test_ogr_import_source.py
+++ b/tests/test_ogr_import_source.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 
+from osgeo import gdal
+
 from sno import structure
 from sno.ogr_import_source import PostgreSQLImportSource
 from sno.sno_repo import SnoRepo
@@ -50,6 +52,15 @@ def test_postgres_url_parsing():
     )
 
 
+def _dataset_col_types(dataset):
+    cols = {}
+    for col in dataset.schema.to_column_dicts():
+        col = col.copy()
+        col.pop("id")
+        cols[col.pop("name")] = col
+    return cols
+
+
 def test_import_various_field_types(tmp_path, postgis_db, cli_runner):
     # Using postgres here because it has the best type preservation
     with postgis_db.cursor() as c:
@@ -57,12 +68,14 @@ def test_import_various_field_types(tmp_path, postgis_db, cli_runner):
             """
                 DROP TABLE IF EXISTS typoes;
                 CREATE TABLE typoes (
-                    bigant BIGINT PRIMARY KEY,
+                    bigant_pk BIGINT PRIMARY KEY,
+                    bigant BIGINT,
+                    smallant SMALLINT,
+                    regularant INTEGER,
                     tumeric20_0 NUMERIC(20,0),
                     tumeric5_5 NUMERIC(5,5),
                     flote FLOAT,
                     dubble DOUBLE PRECISION,
-                    smallant SMALLINT,
                     tumeric99_0 numeric(99,0),
                     tumeric4_0 numeric(4,0),
                     tumeric numeric,
@@ -72,26 +85,30 @@ def test_import_various_field_types(tmp_path, postgis_db, cli_runner):
                 """
         )
 
-    r = cli_runner.invoke(["init", str(tmp_path)])
+    r = cli_runner.invoke(["init", str(tmp_path / "repo1")])
     assert r.exit_code == 0, r.stderr
     r = cli_runner.invoke(
-        ["-C", str(tmp_path), "import", os.environ["SNO_POSTGRES_URL"], "typoes"],
+        [
+            "-C",
+            str(tmp_path / "repo1"),
+            "import",
+            os.environ["SNO_POSTGRES_URL"],
+            "typoes",
+        ],
     )
 
     assert r.exit_code == 0, r.stderr
-    repo = SnoRepo(tmp_path)
+    repo = SnoRepo(tmp_path / "repo1")
     dataset = structure.RepositoryStructure(repo)["typoes"]
 
-    cols = {}
-    for col in dataset.schema.to_column_dicts():
-        col = col.copy()
-        col.pop("id")
-        cols[col.pop("name")] = col
+    cols = _dataset_col_types(dataset)
 
     assert cols == {
-        "bigant": {"dataType": "integer", "primaryKeyIndex": 0, "size": 64},
+        "bigant_pk": {"dataType": "integer", "primaryKeyIndex": 0, "size": 64},
+        "bigant": {"dataType": "integer", "size": 64},
         "dubble": {"dataType": "float", "size": 64},
         "smallant": {"dataType": "integer", "size": 16},
+        "regularant": {"dataType": "integer", "size": 32},
         "tumeric20_0": {"dataType": "numeric", "precision": 20, "scale": 0},
         "tumeric4_0": {"dataType": "numeric", "precision": 4, "scale": 0},
         "tumeric5_5": {"dataType": "numeric", "precision": 5, "scale": 5},
@@ -103,4 +120,48 @@ def test_import_various_field_types(tmp_path, postgis_db, cli_runner):
         # so they're indistinguishable from doubles.
         "tumeric": {"dataType": "float", "size": 64},
         "flote": {"dataType": "float", "size": 64},
+    }
+
+    # Now generate a DBF file, and try again from there.
+    ogr_conn_str = PostgreSQLImportSource.postgres_url_to_ogr_conn_str(
+        os.environ["SNO_POSTGRES_URL"]
+    )
+    gdal.VectorTranslate(
+        str(tmp_path / "typoes.dbf"),
+        ogr_conn_str,
+        format="ESRI Shapefile",
+        layers=["typoes"],
+    )
+
+    r = cli_runner.invoke(["init", str(tmp_path / "repo2")])
+    assert r.exit_code == 0, r.stderr
+    r = cli_runner.invoke(
+        [
+            "-C",
+            str(tmp_path / "repo2"),
+            "import",
+            str(tmp_path / "typoes.dbf"),
+            "typoes",
+        ],
+    )
+
+    assert r.exit_code == 0, r.stderr
+    repo = SnoRepo(tmp_path / "repo2")
+    dataset = structure.RepositoryStructure(repo)["typoes"]
+
+    cols = _dataset_col_types(dataset)
+    assert cols == {
+        "FID": {"dataType": "integer", "primaryKeyIndex": 0, "size": 64},
+        "bigant": {"dataType": "integer", "size": 64},
+        "regularant": {"dataType": "integer", "size": 32},
+        "smallant": {"dataType": "integer", "size": 32},
+        "dubble": {"dataType": "float", "size": 64},
+        "flote": {"dataType": "float", "size": 64},
+        "techs": {"dataType": "text", "length": 80},
+        "techs10": {"dataType": "text", "length": 100},
+        "tumeric": {"dataType": "float", "size": 64},
+        "tumeric20_": {"dataType": "numeric", "precision": 20, "scale": 0},
+        "tumeric4_0": {"dataType": "numeric", "precision": 4, "scale": 0},
+        "tumeric5_5": {"dataType": "numeric", "precision": 5, "scale": 5},
+        "tumeric99_": {"dataType": "numeric", "precision": 99, "scale": 0},
     }


### PR DESCRIPTION
## Description
This adds tests for handling of types that have been translated
by OGR to  shapefile.

This fixes a few niche behaviours:

* numerics from databases are treated as numerics, and integers/floats are treated as integers/floats
* from _shapefile_ specifically:
  * `Real(24.15)` is now treated as a double instead of numeric 
  * `Integer(5.0)` is now treated as a smallint instead of numeric


## Related links:

this is in response to https://github.com/koordinates/sno/pull/320#discussion_r534172256

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?

