### PR TITLE
Fix JSON syntax highlighting

### DIFF
--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -5,6 +5,7 @@ import re
 import html5lib
 import pytest
 
+import sno
 from sno.diff_structs import Delta, DeltaDiff
 from sno.geometry import hex_wkb_to_ogr
 from sno.repo import SnoRepo
@@ -1498,6 +1499,17 @@ def test_show_json_format(data_archive_readonly, cli_runner):
         assert r.exit_code == 0, r.stderr
         # output is compact, no indentation
         assert '"sno.diff/v1+hexwkb": {"' in r.stdout
+
+
+def test_show_json_coloured(data_archive_readonly, cli_runner, monkeypatch):
+    always_output_colour = lambda x: True
+    monkeypatch.setattr(sno.output_util, "can_output_colour", always_output_colour)
+
+    with data_archive_readonly("points"):
+        r = cli_runner.invoke(["show", f"-o", "json", "--json-style=pretty", "HEAD"])
+        assert r.exit_code == 0, r.stderr
+        # No asserts about colour codes - that would be system specific. Just a basic check:
+        assert '"sno.diff/v1+hexwkb"' in r.stdout
 
 
 @pytest.mark.parametrize(*V1_OR_V2)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,6 +1,8 @@
 import json
 import pytest
 
+import sno
+
 EXPECTED_GCG_JSON = {
     "column_name": "geom",
     "geometry_type_name": "POINT",
@@ -137,3 +139,23 @@ def test_meta_get_ref(data_archive, cli_runner):
         assert json.loads(r.stdout) == {
             "nz_pa_points_topo_150k": {"title": "NZ Pa Points (Topo, 1:50k)"}
         }
+
+
+def test_meta_get_coloured(data_archive, cli_runner, monkeypatch):
+    always_output_colour = lambda x: True
+    monkeypatch.setattr(sno.output_util, "can_output_colour", always_output_colour)
+
+    with data_archive("points2"):
+        r = cli_runner.invoke(
+            [
+                "meta",
+                "get",
+                "--ref=HEAD^",
+                "nz_pa_points_topo_150k",
+                "-o",
+                "json",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+        # No asserts about colour codes - that would be system specific. Just a basic check:
+        assert "nz_pa_points_topo_150k" in r.stdout


### PR DESCRIPTION
which didn't work with latest version of pygments.

Specifically, pygments.lexers.JsonLexer was changed to not be a RegexLexer and rewritten to be almost stateless. Sno code to copy state from one JSONLexer call to the next for streaming+highlit JSON output was no longer applicable. 

Updated this code to work with the new JsonLexer.
Added unit tests that force syntax highlighting - Sno output in unit tests is otherwise always colour-free.