### PR TITLE
make py-requirements: importlib-metadata, pygments, rtree, typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,17 +9,18 @@ cached-property==1.5.2    # via pygit2
 certifi==2020.12.5        # via -r requirements/requirements.in
 cffi==1.14.4              # via pygit2
 click==7.1.2              # via -r requirements/requirements.in
-importlib-metadata==3.1.1  # via jsonschema
+importlib-metadata==3.4.0  # via jsonschema
 jsonschema==3.2.0         # via -r requirements/requirements.in
 msgpack==0.6.2            # via -r requirements/requirements.in
 #psycopg2==2.8.5           # via -r requirements/requirements.in
 pycparser==2.20           # via cffi
 #pygit2==1.3.0             # via -r requirements/requirements.in
-pygments==2.7.3           # via -r requirements/requirements.in
+pygments==2.7.4           # via -r requirements/requirements.in
 pyrsistent==0.17.3        # via jsonschema
-rtree==0.9.4              # via -r requirements/requirements.in
+rtree==0.9.7              # via -r requirements/requirements.in
 six==1.15.0               # via jsonschema
+typing-extensions==3.7.4.3  # via importlib-metadata
 zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==49.1.3        # via -r requirements/requirements.in, jsonschema, rtree
+setuptools==49.1.3        # via -r requirements/requirements.in, jsonschema

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,33 +5,34 @@
 #    make py-requirements
 #
 apipkg==1.5               # via execnet
-appnope==0.1.2            # via -r requirements/dev.in
+appnope==0.1.2            # via -r requirements/dev.in, ipython
 attrs==20.3.0             # via -c requirements/../requirements.txt, -c requirements/test.txt, pytest
 backcall==0.2.0           # via ipython
 colorama==0.4.4           # via -c requirements/test.txt, -r requirements/dev.in
 decorator==4.4.2          # via ipython
 execnet==1.7.1            # via pytest-xdist
-importlib-metadata==3.1.1  # via -c requirements/../requirements.txt, -c requirements/test.txt, pluggy, pytest
+importlib-metadata==3.4.0  # via -c requirements/../requirements.txt, -c requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -c requirements/test.txt, pytest
 ipdb==0.13.4              # via -r requirements/dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.19.0           # via -r requirements/dev.in, ipdb
-jedi==0.17.2              # via ipython
-packaging==20.7           # via -c requirements/test.txt, pytest
-parso==0.7.1              # via jedi
+jedi==0.18.0              # via ipython
+packaging==20.8           # via -c requirements/test.txt, pytest
+parso==0.8.1              # via jedi
 pexpect==4.8.0            # via -r requirements/dev.in, ipython
 pickleshare==0.7.5        # via ipython
 pluggy==0.13.1            # via -c requirements/test.txt, pytest
-prompt-toolkit==3.0.8     # via ipython
-ptyprocess==0.6.0         # via pexpect
-py==1.9.0                 # via -c requirements/test.txt, pytest, pytest-forked
-pygments==2.7.3           # via -c requirements/../requirements.txt, ipython
+prompt-toolkit==3.0.10    # via ipython
+ptyprocess==0.7.0         # via pexpect
+py==1.10.0                # via -c requirements/test.txt, pytest, pytest-forked
+pygments==2.7.4           # via -c requirements/../requirements.txt, ipython
 pyparsing==2.4.7          # via -c requirements/test.txt, packaging
 pytest-forked==1.3.0      # via pytest-xdist
 pytest-xdist==2.2.0       # via -r requirements/dev.in
 pytest==6.2.1             # via -c requirements/test.txt, pytest-forked, pytest-xdist
 toml==0.10.2              # via -c requirements/test.txt, pytest
 traitlets==5.0.5          # via ipython
+typing-extensions==3.7.4.3  # via -c requirements/../requirements.txt, -c requirements/test.txt, importlib-metadata
 wcwidth==0.2.5            # via prompt-toolkit
 zipp==3.4.0               # via -c requirements/../requirements.txt, -c requirements/test.txt, importlib-metadata
 

--- a/requirements/licenses.ini
+++ b/requirements/licenses.ini
@@ -7,6 +7,7 @@ authorized_licenses:
     gnu library or lesser general public license (lgpl)
     mit
     mozilla public license 2.0 (mpl 2.0)
+    PSF
 
 unauthorized_licenses:
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,17 +8,17 @@ aspectlib==1.5.2          # via pytest-benchmark
 atomicwrites==1.4.0       # via -r requirements/test.in
 attrs==20.3.0             # via -c requirements/../requirements.txt, pytest
 colorama==0.4.4           # via -r requirements/test.in
-coverage==5.3             # via pytest-cov
+coverage==5.3.1           # via pytest-cov
 fields==5.0.0             # via aspectlib
 gprof2dot==2019.11.30     # via pytest-profiling
 html5lib==1.1             # via -r requirements/test.in
-importlib-metadata==3.1.1  # via -c requirements/../requirements.txt, pluggy, pytest
+importlib-metadata==3.4.0  # via -c requirements/../requirements.txt, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 lovely-pytest-docker==0.2.0  # via -r requirements/test.in
-packaging==20.7           # via pytest, pytest-sugar
+packaging==20.8           # via pytest, pytest-sugar
 pluggy==0.13.1            # via pytest
 py-cpuinfo==7.0.0         # via pytest-benchmark
-py==1.9.0                 # via pytest
+py==1.10.0                # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-benchmark[aspect]==3.2.3  # via -r requirements/test.in
 pytest-cov==2.10.1        # via -r requirements/test.in
@@ -30,5 +30,6 @@ pytest==6.2.1             # via -r requirements/test.in, lovely-pytest-docker, p
 six==1.15.0               # via -c requirements/../requirements.txt, html5lib, pytest-profiling
 termcolor==1.1.0          # via pytest-sugar
 toml==0.10.2              # via pytest
+typing-extensions==3.7.4.3  # via -c requirements/../requirements.txt, importlib-metadata
 webencodings==0.5.1       # via html5lib
 zipp==3.4.0               # via -c requirements/../requirements.txt, importlib-metadata


### PR DESCRIPTION
Also involves adding PSF - Python Software Foundation - to the list of allowed licenses.

"The Python Software Foundation License (PSFL) is a BSD-style, permissive free software license which is compatible with the GNU General Public License (GPL). Its primary use is for distribution of the Python project software. Unlike the GPL the Python license is not a copyleft license, and allows modified versions to be distributed without source code. The PSFL is listed as approved on both FSF's approved licenses list, and OSI's approved licenses list." - Wikipedia

License text: https://spdx.org/licenses/PSF-2.0.html
