### PR TITLE
Add a proper sno reset command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.8.0 (UNRELEASED)
 
-### End of support for Datasets V1
+### Breaking changes
 
  * Backwards compatibility with Datasets V1 ends at Sno 0.8.0 - all Sno commands except `sno upgrade` will no longer work in a V1 repository. Since Datasets V2 has been the default since Sno 0.5.0, most users will be unaffected. Remaining V1 repositories can be upgraded to V2 using `sno upgrade EXISTING_REPO NEW_REPO`, and the ability to upgrade from V1 to V2 continues to be supported indefinitely. [#342](https://github.com/koordinates/sno/pull/342)
+ * `reset` now behaves more like `git reset` - specifically, `sno reset COMMIT` stays on the same branch but sets the branch tip to be `COMMIT`. [#60](https://github.com/koordinates/sno/issues/60)
 
 ### Other changes
 

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -169,9 +169,10 @@ def cli(ctx, repo_dir, verbose, post_mortem):
 cli.add_command(apply.apply)
 cli.add_command(branch.branch)
 cli.add_command(checkout.checkout)
+cli.add_command(checkout.create_workingcopy)
+cli.add_command(checkout.reset)
 cli.add_command(checkout.restore)
 cli.add_command(checkout.switch)
-cli.add_command(checkout.create_workingcopy)
 cli.add_command(clone.clone)
 cli.add_command(conflicts.conflicts)
 cli.add_command(commit.commit)
@@ -191,16 +192,6 @@ cli.add_command(status.status)
 cli.add_command(query.query)
 cli.add_command(upgrade.upgrade)
 cli.add_command(upgrade.upgrade_to_tidy)
-
-
-# aliases/shortcuts
-
-
-@cli.command()
-@click.pass_context
-def reset(ctx):
-    """ Discard changes made in the working copy (ie. reset to HEAD """
-    ctx.invoke(checkout.checkout, discard_changes=True, refish="HEAD")
 
 
 # straight process-replace commands

--- a/tests/test_working_copy_gpkg.py
+++ b/tests/test_working_copy_gpkg.py
@@ -877,34 +877,6 @@ def test_delete_branch(data_working_copy, cli_runner):
         assert r.exit_code == 0, r
 
 
-def test_reset(data_working_copy, cli_runner, geopackage, edit_polygons):
-    with data_working_copy("polygons") as (repo_path, wc):
-        db = geopackage(wc)
-        with db:
-            cur = db.cursor()
-            edit_polygons(cur)
-
-        r = cli_runner.invoke(["status", "--output-format=json"])
-        assert r.exit_code == 0, r
-        changes = json.loads(r.stdout)["sno.status/v1"]["workingCopy"]["changes"]
-        assert changes == {
-            "nz_waca_adjustments": {
-                "feature": {"inserts": 1, "updates": 2, "deletes": 5}
-            }
-        }
-        r = cli_runner.invoke(["diff", "--exit-code"])
-        assert r.exit_code == 1, r
-
-        r = cli_runner.invoke(["reset"])
-
-        r = cli_runner.invoke(["status", "--output-format=json"])
-        assert r.exit_code == 0, r
-        changes = json.loads(r.stdout)["sno.status/v1"]["workingCopy"]["changes"]
-        assert changes is None
-        r = cli_runner.invoke(["diff", "--exit-code"])
-        assert r.exit_code == 0, r
-
-
 def test_approximated_types():
     assert gpkg_adapter.APPROXIMATED_TYPES == compute_approximated_types(
         gpkg_adapter.V2_TYPE_TO_GPKG_TYPE, gpkg_adapter.GPKG_TYPE_TO_V2_TYPE


### PR DESCRIPTION
![](https://media4.giphy.com/media/hDSy8w6rGHeTe/giphy.gif)

sno reset COMMIT -> stays on the same branch but sets the branch tip to be COMMIT.

Removes existing sno reset alias which did the same thing as a no-args sno restore.

## Related links:

https://github.com/koordinates/sno/issues/60

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
