### PR TITLE
`sno -v import`: Add fast-import stats

### DIFF
--- a/sno/cli.py
+++ b/sno/cli.py
@@ -161,6 +161,7 @@ def cli(ctx, repo_dir, verbose, post_mortem):
         ctx.obj.user_repo_path = repo_dir
 
     # default == WARNING; -v == INFO; -vv == DEBUG
+    ctx.obj.verbosity = verbose
     log_level = logging.WARNING - min(10 * verbose, 20)
     logging.basicConfig(level=log_level)
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -272,6 +272,7 @@ def import_table(
     fast_import_tables(
         repo,
         import_sources,
+        verbosity=ctx.obj.verbosity + 1,
         message=message,
         max_delta_depth=max_delta_depth,
         replace_existing=ReplaceExisting.GIVEN

--- a/sno/upgrade/__init__.py
+++ b/sno/upgrade/__init__.py
@@ -173,7 +173,7 @@ def _upgrade_commit(
         dest_repo,
         source_datasets,
         replace_existing=ReplaceExisting.ALL,
-        quiet=True,
+        verbosity=0,
         header=header,
         # We import every commit onto refs/heads/main, even though not all commits are related - this means
         # the main branch head will jump all over the place. git-fast-import only allows this with --force.


### PR DESCRIPTION
## Description

Nothing changes by default, but I need a way to add extra verbosity
when debugging failed / slow / memory-hungry imports.

This adds the git-fast-import stats to stderr when we run
`sno -v import ...`

I haven't added this to the changelog; I don't think it's warranted - feel free to disagree and I'll add it

### sample output

```
points (main) $ sno -v import ../gpkg-polygons/nz-waca-adjustments.gpkg
Starting git-fast-import...
Importing 228 features from ../gpkg-polygons/nz-waca-adjustments.gpkg:nz_waca_adjustments to nz_waca_adjustments/ ...
Added 228 Features to index in 0.0s
Overall rate: 11665 features/s)
fast-import statistics:
---------------------------------------------------------------------
Alloc'd objects:       5000
Total objects:          622 (         0 duplicates                  )
      blobs  :          234 (         0 duplicates          0 deltas of          0 attempts)
      trees  :          387 (         0 duplicates          0 deltas of          0 attempts)
      commits:            1 (         0 duplicates          0 deltas of          0 attempts)
      tags   :            0 (         0 duplicates          0 deltas of          0 attempts)
Total branches:           1 (         1 loads     )
      marks:           1024 (         0 unique    )
      atoms:            459
Memory total:          2485 KiB
       pools:          2133 KiB
     objects:           351 KiB
---------------------------------------------------------------------
pack_report: getpagesize()            =       4096
pack_report: core.packedGitWindowSize = 1073741824
pack_report: core.packedGitLimit      = 35184372088832
pack_report: pack_used_ctr            =          4
pack_report: pack_mmap_calls          =          2
pack_report: pack_open_windows        =          2 /          2
pack_report: pack_mapped              =     468468 /     468468
---------------------------------------------------------------------

Closed in 0s
```
## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
