### PR TITLE
clone: Add `--filter` flag; pass it to git clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ### Other changes
 
  * Support for detecting features which have changed slightly during a re-import from a data source without a primary key, and reimporting them with the same primary key as last time so they show as edits as opposed to inserts. [#212](https://github.com/koordinates/sno/issues/212)
- * `init` now accepts a `--initial-branch` option
  * Bugfix - fixed issues roundtripping certain type metadata in the PostGIS working copy: specifically geometry types with 3 or more dimensions (Z/M values) and numeric types with scale.
  * Internal dependency change - Sno no longer depends on [apsw](https://pypi.org/project/apsw/), instead it depends on [SQLAlchemy](https://www.sqlalchemy.org/).
+ * `init` now accepts a `--initial-branch` option
+ * `clone` now accepts a `--filter` option (advanced users only)
 
 ## 0.7.1
 

--- a/sno/clone.py
+++ b/sno/clone.py
@@ -62,6 +62,15 @@ def get_directory_from_url(url):
     help="Create a shallow clone with a history truncated to the specified number of commits.",
 )
 @click.option(
+    "--filter",
+    "filterspec",
+    help=(
+        "(Advanced users only.) Use a partial clone (don't fetch all objects). The supplied <filter-spec> "
+        "is used for the partial clone filter. For example, --filter=blob:none will filter out all blobs. "
+    ),
+    metavar="<filter-spec>",
+)
+@click.option(
     "-b",
     "--branch",
     metavar="NAME",
@@ -78,7 +87,18 @@ def get_directory_from_url(url):
     type=click.Path(exists=False, file_okay=False, writable=True),
     required=False,
 )
-def clone(ctx, bare, do_checkout, wc_path, do_progress, depth, branch, url, directory):
+def clone(
+    ctx,
+    bare,
+    do_checkout,
+    wc_path,
+    do_progress,
+    depth,
+    filterspec,
+    branch,
+    url,
+    directory,
+):
     """ Clone a repository into a new directory """
 
     repo_path = Path(directory or get_directory_from_url(url)).resolve()
@@ -95,6 +115,12 @@ def clone(ctx, bare, do_checkout, wc_path, do_progress, depth, branch, url, dire
         args.append(f"--depth={depth}")
     if branch is not None:
         args.append(f"--branch={branch}")
+    if filterspec is not None:
+        # git itself does reasonable validation of this, so we don't bother here
+        # e.g. "fatal: invalid filter-spec 'hello'"
+        # for the various forms it can take, see
+        # https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---filterltfilter-specgt
+        args.append(f"--filter={filterspec}")
 
     repo = SnoRepo.clone_repository(url, repo_path, args, wc_path, bare)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,9 @@ def git_user_config(monkeypatch_session, tmp_path_factory, request):
             f"\tautoDetach = false\n"
             f"[init]\n"
             f"\tdefaultBranch = main\n"
+            # used by test_clone_filter
+            f"[uploadPack]\n"
+            f"\tallowFilter = true\n"
         )
 
     L.debug("Temporary HOME for git config: %s", home)

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -119,6 +119,38 @@ def test_clone(
             assert not wc.exists()
 
 
+def test_clone_filter(
+    data_archive,
+    tmp_path,
+    cli_runner,
+    chdir,
+):
+    with data_archive("points") as remote_path:
+        with chdir(tmp_path):
+            args = [
+                "clone",
+                "--filter=blob:none",
+                f"file://{remote_path}",
+                "--bare",
+            ]
+            r = cli_runner.invoke(args)
+            assert r.exit_code == 0, r.stderr
+
+            repo_path = tmp_path / "points"
+            assert repo_path.is_dir()
+
+            # it's kind of hard to tell if `--filter` succeeded tbh.
+            # this is one way though. If --filter wasn't present, this config
+            # var would be an empty string.
+            assert (
+                subprocess.check_output(
+                    ["git", "-C", str(repo_path), "config", "remote.origin.promisor"],
+                    encoding="utf-8",
+                ).strip()
+                == "true"
+            )
+
+
 def test_fetch(
     data_archive_readonly,
     data_working_copy,


### PR DESCRIPTION
## Description

For advanced uses of sno, partial clones are useful as an optimisation. This adds a `--filter` flag which is passed directly to `git clone` and has the same behaviour.

e.g. `sno clone --filter=blob:tree:5` filters out all feature blobs, greatly speeding up the clone. If you only need the `meta` blobs for the dataset, this might be a sensible thing to do.

## Related links:

https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---filterltfilter-specgt

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
