### PR TITLE
init: Change default branch to 'main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ### Breaking changes
 
  * Backwards compatibility with Datasets V1 ends at Sno 0.8.0 - all Sno commands except `sno upgrade` will no longer work in a V1 repository. Since Datasets V2 has been the default since Sno 0.5.0, most users will be unaffected. Remaining V1 repositories can be upgraded to V2 using `sno upgrade EXISTING_REPO NEW_REPO`, and the ability to upgrade from V1 to V2 continues to be supported indefinitely. [#342](https://github.com/koordinates/sno/pull/342)
+ * `sno init` now sets the head branch to `main` by default, instead of `master`. To override this, add `--initial-branch=master`
  * `reset` now behaves more like `git reset` - specifically, `sno reset COMMIT` stays on the same branch but sets the branch tip to be `COMMIT`. [#60](https://github.com/koordinates/sno/issues/60)
 
 ### Other changes

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -29,7 +29,11 @@ from . import (
     query,
     upgrade,
 )
-from .cli_util import call_and_exit_flag, add_help_subcommand
+from .cli_util import (
+    call_and_exit_flag,
+    add_help_subcommand,
+    startup_load_git_init_config,
+)
 from .context import Context
 from .exec import execvp
 
@@ -280,6 +284,7 @@ def reflog(ctx, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def config(ctx, args):
     """ Get and set repository or global options """
+    startup_load_git_init_config()
     params = ["git", "config"]
     if ctx.obj.user_repo_path:
         params[1:1] = ["-C", ctx.obj.user_repo_path]

--- a/sno/clone.py
+++ b/sno/clone.py
@@ -6,6 +6,7 @@ from urllib.parse import urlsplit
 import click
 
 from . import checkout
+from .cli_util import startup_load_git_init_config
 from .exceptions import InvalidOperation
 from .repo import SnoRepo
 from .working_copy.base import WorkingCopy
@@ -100,7 +101,7 @@ def clone(
     directory,
 ):
     """ Clone a repository into a new directory """
-
+    startup_load_git_init_config()
     repo_path = Path(directory or get_directory_from_url(url)).resolve()
 
     if repo_path.exists() and any(repo_path.iterdir()):

--- a/sno/init.py
+++ b/sno/init.py
@@ -8,7 +8,13 @@ from osgeo import gdal
 from sno import is_windows
 from . import checkout
 from .core import check_git_user
-from .cli_util import call_and_exit_flag, MutexOption, StringFromFile, JsonFromFile
+from .cli_util import (
+    call_and_exit_flag,
+    startup_load_git_init_config,
+    MutexOption,
+    StringFromFile,
+    JsonFromFile,
+)
 from .exceptions import InvalidOperation
 from .import_source import ImportSource
 from .ogr_import_source import OgrImportSource, FORMAT_TO_OGR_MAP
@@ -356,7 +362,7 @@ def init(
     Initialise a new repository and optionally import data.
     DIRECTORY must be empty. Defaults to the current directory.
     """
-
+    startup_load_git_init_config()
     if directory is None:
         directory = os.curdir
     repo_path = Path(directory).resolve()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
+import os
 import re
 
+import pygit2
 import pytest
 
 from sno import cli
@@ -23,3 +25,31 @@ def test_cli_help():
         if name == "help":
             continue
         assert cmd.help, f"`{name}` command has no help text"
+
+
+@pytest.fixture
+def empty_gitconfig(monkeypatch, tmpdir):
+    old = os.environ["HOME"]
+    (tmpdir / ".gitconfig").write_text("", encoding="utf8")
+    monkeypatch.setenv("HOME", str(tmpdir))
+    pygit2.option(
+        pygit2.GIT_OPT_SET_SEARCH_PATH, pygit2.GIT_CONFIG_LEVEL_GLOBAL, str(tmpdir)
+    )
+    yield
+    pygit2.option(
+        pygit2.GIT_OPT_SET_SEARCH_PATH, pygit2.GIT_CONFIG_LEVEL_GLOBAL, str(old)
+    )
+
+
+def test_config(empty_gitconfig, cli_runner):
+    # don't load the ~/.gitconfig file from conftest.py
+    # (because it sets init.defaultBranch and we're trying to test what
+    # happens without that set)
+    # note: merely changing os.environ['HOME'] doesn't help here;
+    # once libgit has seen one HOME it never notices if we change it.
+
+    # The default init.defaultBranch in git is still 'master' as of 2.30.0
+    # but we override it to 'main'. Let's check that works properly
+    r = cli_runner.invoke(["config", "init.defaultBranch"])
+    assert r.exit_code == 0, r.stderr
+    assert r.stdout == "main\n"


### PR DESCRIPTION

## Description

'main' is likely to be the default in the git project shortly,
and makes sense to incorporate the same change in sno as soon as
possible to avoid further disruption as usage increases.

Because sno relies on git's config mechanism and we want to use
the existing `init.defaultBranch` config variable,
this change to the default value of that variable relies on overriding
it iff it hasn't been set.

Only 'init', 'clone' and 'config' commands actually use that variable,
so this change only parses the config and overrides that value at
startup in those three commands, to avoid slowing down startup for
other commands.



## Related links:


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
