### PR TITLE
show: Add commit hash to json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * Internal dependency change - Sno no longer depends on [apsw](https://pypi.org/project/apsw/), instead it depends on [SQLAlchemy](https://www.sqlalchemy.org/).
  * `init` now accepts a `--initial-branch` option
  * `clone` now accepts a `--filter` option (advanced users only)
+ * `show -o json` now includes the commit hash in the output
 
 ## 0.7.1
 

--- a/sno/show.py
+++ b/sno/show.py
@@ -178,6 +178,7 @@ def show_output_json(*, target, output_path, json_style, **kwargs):
             "authorEmail": author.email,
             "authorTime": datetime_to_iso8601_utc(author_time),
             "authorTimeOffset": timedelta_to_iso8601_tz(author_time_offset),
+            "commit": commit.oid.hex,
             "message": commit.message,
         }
         dump_json_output(data, *args, **kwargs)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1409,6 +1409,7 @@ def test_show_points_HEAD(output_format, data_archive_readonly, cli_runner):
                 "authorName": "Robert Coup",
                 "authorTime": "2019-06-20T14:28:33Z",
                 "authorTimeOffset": "+01:00",
+                "commit": "0c64d8211c072a08d5fc6e6fe898cbb59fc83d16",
                 "message": "Improve naming on Coromandel East coast",
             }
 
@@ -1479,6 +1480,7 @@ def test_show_polygons_initial(output_format, data_archive_readonly, cli_runner)
                 "authorName": "Robert Coup",
                 "authorTime": "2019-07-22T11:05:39Z",
                 "authorTimeOffset": "+01:00",
+                "commit": "a149557b7cec7a35c07a9bc404a5d53f6c5ad154",
                 "message": "Import from nz-waca-adjustments.gpkg",
             }
 


### PR DESCRIPTION
## Description

`sno show` has the commit hash in it, but for some reason `sno show -o json` doesn't, and if you need it you need to get it from a `sno log -o json -1` separately.

This adds it to `sno show -o json` output

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
