### PR TITLE
Tests: Enable parallelism in non-windows builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,7 @@ ci-test:
 		--cov-report term \
 		--cov-report html:test-results/coverage/ \
 		--junit-xml=test-results/junit.xml \
-		--benchmark-enable \
-		-p no:xdist
+		--benchmark-enable
 
 # Cleanup
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 import os
+import platform
 import random
 import re
 import shutil
@@ -35,10 +36,10 @@ L = logging.getLogger("sno.tests")
 
 
 def pytest_addoption(parser):
-    if "CI" in os.environ:
+    if "CI" in os.environ and platform.system() == "Windows":
         # pytest.ini sets --numprocesses=auto
         # for parallelism in local dev.
-        # But in CI we disable xdist because it causes a crash in windows builds.
+        # But in CI on Windows we disable xdist because it causes a crash in builds.
         # (simply doing --numprocesses=0 is insufficient; the plugin needs to be
         # disabled completely)
         # However, there's no way to *remove* an option that's in pytest.ini's addopts.


### PR DESCRIPTION
## Description

This saves 3-4 minutes in CI for linux and macos builds.

We use xdist in dev because it makes tests much faster. There's some issue using it in CI in windows, so we turned it off in CI.

But, that's overkill - it works fine in other environments, so this PR turns it back on in macos/linux to save a few minutes.

Since linux is generally the slowest environment this should cut down overall build time too.

## Related links:
.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
