### PR TITLE
Make pyodbc work for windows and mac builds 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,14 @@ jobs:
                   --health-retries 5
                 ports:
                   - 5432:5432
+              sqlserver:
+                image: mcr.microsoft.com/mssql/server
+                options: >-
+                  -e ACCEPT_EULA=Y
+                  -e SA_PASSWORD=PassWord1
+                ports:
+                  - 1433:1433
+
           - name: macOS
             id: Darwin
             os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         platform:
           - name: Linux
             id: Linux
-            os: ubuntu-20.04
+            os: ubuntu-latest
             package-formats: deb rpm
             services:
               postgis:
@@ -282,8 +282,6 @@ jobs:
         id: package-Linux
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -q -y unixodbc-dev
           make -C platforms deb rpm
           ls -la platforms/linux/dist/*.rpm platforms/linux/dist/*.deb
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         platform:
           - name: Linux
             id: Linux
-            os: ubuntu-latest
+            os: ubuntu-20.04
             package-formats: deb rpm
             services:
               postgis:
@@ -282,6 +282,8 @@ jobs:
         id: package-Linux
         if: runner.os == 'Linux'
         run: |
+          sudo apt-get update
+          sudo apt-get install -q -y unixodbc-dev
           make -C platforms deb rpm
           ls -la platforms/linux/dist/*.rpm platforms/linux/dist/*.deb
 

--- a/Makefile
+++ b/Makefile
@@ -177,14 +177,15 @@ install: | $(sno-app-any)
 test: $(py-install-test)
 	pytest -v --cov-report term --cov-report html:coverage
 
-ifeq ($(PLATFORM),Linux)
-# (github actions only supports docker containers on linux)
-ci-test:
-	export SNO_POSTGRES_URL ?= postgresql://docker:docker@localhost:5432/gis
-	export SNO_SQLSERVER_URL ?= mssql://sa:PassWord1@localhost:1433/master
-endif
 
 .PHONY: ci-test
+
+ifeq ($(PLATFORM),Linux)
+# (github actions only supports docker containers on linux)
+ci-test: export SNO_POSTGRES_URL ?= postgresql://docker:docker@localhost:5432/gis
+ci-test: export SNO_SQLSERVER_URL ?= mssql://sa:PassWord1@localhost:1433/master
+endif
+
 ci-test:
 	CI=true pytest \
 		-vv \

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,9 @@ test: $(py-install-test)
 
 ifeq ($(PLATFORM),Linux)
 # (github actions only supports docker containers on linux)
-ci-test: export SNO_POSTGRES_URL ?= postgresql://docker:docker@localhost:5432/gis
+ci-test:
+	export SNO_POSTGRES_URL ?= postgresql://docker:docker@localhost:5432/gis
+	export SNO_SQLSERVER_URL ?= mssql://sa:PassWord1@localhost:1433/master
 endif
 
 .PHONY: ci-test

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pycparser==2.20
     # via -r requirements/requirements.in
 pygments==2.8.1
     # via -r requirements/requirements.in
-pyodbc==4.0.30
+pyodbc==4.0.30 ; platform_system != "Linux"
     # via -r requirements/requirements.in
 pyrsistent==0.17.3
     # via jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,11 @@ cached-property==1.5.2
     # via pygit2
 certifi==2020.12.5
     # via -r requirements/requirements.in
-cffi==1.14.4
+cffi==1.14.5
     # via pygit2
 click==7.1.2
     # via -r requirements/requirements.in
-importlib-metadata==3.4.0
+importlib-metadata==3.7.2
     # via jsonschema
 jsonschema==3.2.0
     # via -r requirements/requirements.in
@@ -26,7 +26,9 @@ pycparser==2.20
     # via cffi
 #pygit2==1.3.0
     # via -r requirements/requirements.in
-pygments==2.7.4
+pygments==2.8.1
+    # via -r requirements/requirements.in
+pyodbc==4.0.30
     # via -r requirements/requirements.in
 pyrsistent==0.17.3
     # via jsonschema
@@ -34,11 +36,11 @@ rtree==0.9.7
     # via -r requirements/requirements.in
 six==1.15.0
     # via jsonschema
-sqlalchemy==1.3.22
+sqlalchemy==1.3.23
     # via -r requirements/requirements.in
 typing-extensions==3.7.4.3
     # via importlib-metadata
-zipp==3.4.0
+zipp==3.4.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,9 @@
 apipkg==1.5
     # via execnet
 appnope==0.1.2
-    # via -r requirements/dev.in
+    # via
+    #   -r requirements/dev.in
+    #   ipython
 attrs==20.3.0
     # via
     #   -c requirements/../requirements.txt
@@ -21,9 +23,9 @@ colorama==0.4.4
     #   -r requirements/dev.in
 decorator==4.4.2
     # via ipython
-execnet==1.7.1
+execnet==1.8.0
     # via pytest-xdist
-importlib-metadata==3.4.0
+importlib-metadata==3.7.2
     # via
     #   -c requirements/../requirements.txt
     #   -c requirements/test.txt
@@ -43,7 +45,7 @@ ipython==7.21.0
     #   ipdb
 jedi==0.18.0
     # via ipython
-packaging==20.8
+packaging==20.9
     # via
     #   -c requirements/test.txt
     #   pytest
@@ -59,7 +61,7 @@ pluggy==0.13.1
     # via
     #   -c requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.14
+prompt-toolkit==3.0.16
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -68,7 +70,7 @@ py==1.10.0
     #   -c requirements/test.txt
     #   pytest
     #   pytest-forked
-pygments==2.7.4
+pygments==2.8.1
     # via
     #   -c requirements/../requirements.txt
     #   ipython
@@ -99,7 +101,7 @@ typing-extensions==3.7.4.3
     #   importlib-metadata
 wcwidth==0.2.5
     # via prompt-toolkit
-zipp==3.4.0
+zipp==3.4.1
     # via
     #   -c requirements/../requirements.txt
     #   -c requirements/test.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@ Click~=7.0
 jsonschema
 msgpack~=0.6.1
 Pygments
-pyodbc
+pyodbc ; platform_system!="Linux"
 Rtree~=0.9.4
 sqlalchemy
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,15 +14,15 @@ attrs==20.3.0
     #   pytest
 colorama==0.4.4
     # via -r requirements/test.in
-coverage==5.3.1
+coverage==5.5
     # via pytest-cov
 fields==5.0.0
     # via aspectlib
-gprof2dot==2019.11.30
+gprof2dot==2021.2.21
     # via pytest-profiling
 html5lib==1.1
     # via -r requirements/test.in
-importlib-metadata==3.4.0
+importlib-metadata==3.7.2
     # via
     #   -c requirements/../requirements.txt
     #   pluggy
@@ -31,7 +31,7 @@ iniconfig==1.1.1
     # via pytest
 lovely-pytest-docker==0.2.0
     # via -r requirements/test.in
-packaging==20.8
+packaging==20.9
     # via
     #   pytest
     #   pytest-sugar
@@ -80,7 +80,7 @@ typing-extensions==3.7.4.3
     #   importlib-metadata
 webencodings==0.5.1
     # via html5lib
-zipp==3.4.0
+zipp==3.4.1
     # via
     #   -c requirements/../requirements.txt
     #   importlib-metadata

--- a/tests/test_working_copy_sqlserver.py
+++ b/tests/test_working_copy_sqlserver.py
@@ -3,6 +3,7 @@ import pytest
 import pygit2
 from sqlalchemy.exc import IntegrityError
 
+from sno import is_linux
 from sno.repo import SnoRepo
 from sno.working_copy import sqlserver_adapter
 from test_working_copy import compute_approximated_types
@@ -11,6 +12,7 @@ from test_working_copy import compute_approximated_types
 H = pytest.helpers.helpers()
 
 
+@pytest.mark.xfail(is_linux, reason="pyodbc is not yet included in linux build")
 @pytest.mark.parametrize(
     "existing_schema",
     [
@@ -66,6 +68,7 @@ def test_checkout_workingcopy(
             assert wc.assert_db_tree_match(head_tree_id)
 
 
+@pytest.mark.xfail(is_linux, reason="pyodbc is not yet included in linux build")
 @pytest.mark.parametrize(
     "existing_schema",
     [
@@ -111,6 +114,7 @@ def test_init_import(
             assert wc.path == sqlserver_url
 
 
+@pytest.mark.xfail(is_linux, reason="pyodbc is not yet included in linux build")
 @pytest.mark.parametrize(
     "archive,table,commit_sha",
     [
@@ -194,6 +198,7 @@ def test_commit_edits(
             assert repo.head.peel(pygit2.Commit).hex == orig_head
 
 
+@pytest.mark.xfail(is_linux, reason="pyodbc is not yet included in linux build")
 def test_edit_schema(data_archive, cli_runner, new_sqlserver_db_schema):
     with data_archive("polygons") as repo_path:
         repo = SnoRepo(repo_path)
@@ -299,6 +304,7 @@ def test_approximated_types():
     )
 
 
+@pytest.mark.xfail(is_linux, reason="pyodbc is not yet included in linux build")
 def test_types_roundtrip(data_archive, cli_runner, new_sqlserver_db_schema):
     with data_archive("types") as repo_path:
         repo = SnoRepo(repo_path)
@@ -314,6 +320,7 @@ def test_types_roundtrip(data_archive, cli_runner, new_sqlserver_db_schema):
             assert r.exit_code == 0, r.stdout
 
 
+@pytest.mark.xfail(is_linux, reason="pyodbc is not yet included in linux build")
 def test_geometry_constraints(
     data_archive,
     cli_runner,


### PR DESCRIPTION
![](https://media3.giphy.com/media/l4pThMAKS4BOtz8d2/giphy.gif)

## Description

We don't yet have a working way of including pyodbc for linux builds (only for unix, if I understand correctly).
This PR makes pyodbc a dependency for windows and mac, but not for linux. Any tests that require pyodbc - that is, all the SQL Server tests - are marked as xfail, but only on linux.

Note that also - the only environment where these tests are even being attempted as part of the CI tests is also linux, as of this PR. That's because the linux environment is spinning up the SQL Server docker image, and the other environments don't. However, it's not being used yet, since these tests are xfailing, since we don't have pyodbc.

The tests can be run locally if you have a SQL Server URI to point them at. They are passing locally.

Stil TODO (in future PRs):
- include pyodbc on linux, once we have it working
- include SQL Server driver in windows, mac, linux builds
- remove xfail markers