### PR TITLE
import: Add --replace-ids flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * Backwards compatibility with Datasets V1 ends at Sno 0.8.0 - all Sno commands except `sno upgrade` will no longer work in a V1 repository. Since Datasets V2 has been the default since Sno 0.5.0, most users will be unaffected. Remaining V1 repositories can be upgraded to V2 using `sno upgrade EXISTING_REPO NEW_REPO`, and the ability to upgrade from V1 to V2 continues to be supported indefinitely. [#342](https://github.com/koordinates/sno/pull/342)
  * `sno init` now sets the head branch to `main` by default, instead of `master`. To override this, add `--initial-branch=master`
  * `reset` now behaves more like `git reset` - specifically, `sno reset COMMIT` stays on the same branch but sets the branch tip to be `COMMIT`. [#60](https://github.com/koordinates/sno/issues/60)
+ * `import` now accepts a `--replace-ids` argument for much faster importing of small changesets from large sources. [#378](https://github.com/koordinates/sno/issues/378)
 
 ### Other changes
 

--- a/sno/utils.py
+++ b/sno/utils.py
@@ -1,4 +1,5 @@
 import functools
+import itertools
 
 
 def ungenerator(cast_function):
@@ -23,3 +24,13 @@ def ungenerator(cast_function):
         return wrapper
 
     return decorator
+
+
+def chunk(iterable, size):
+    """Generator. Yield successive chunks from iterable of length <size>."""
+    it = iter(iterable)
+    while True:
+        chunk = tuple(itertools.islice(it, size))
+        if not chunk:
+            return
+        yield chunk


### PR DESCRIPTION

## Description

The existing `--replace-existing` flag imports over the top of an
existing dataset.

Imports from huge source tables can be slow, since the entire table
must be read and imported into git, even if only a small subset of the
table changed.

If the caller knows what parts of the table have changed, it makes
sense for them to supply that information to sno, to speed up the
import.

This change adds a `--replace-ids` flag, which supplies a list of
primary key values which sno should look at when determining the
changeset to import.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
