### PR TITLE
Include unixodbc in mac build

### DIFF
--- a/vendor/Brewfile
+++ b/vendor/Brewfile
@@ -15,3 +15,5 @@ brew "json-c"
 brew "curl"
 
 brew "sqlite3"
+
+brew "unixodbc"

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -50,6 +50,7 @@ lib-pq := env/lib/libpq.$(LIBSUFFIX)
 lib-sqlite := env/lib/libsqlite3.$(LIBSUFFIX)
 lib-git := env/bin/git
 lib-curl := env/lib/libcurl.$(LIBSUFFIX)
+lib-unixodbc := env/lib/libodbc.$(LIBSUFFIX)
 
 lib-spatialite := env/lib/mod_spatialite.$(LIBSUFFIX)
 lib-gdal := env/lib/python3.7/site-packages/osgeo/__init__.py
@@ -98,7 +99,7 @@ ifeq ($(PLATFORM),Darwin)
 #
 # MacOS
 #
-brew-libs = $(lib-sqlite) $(lib-curl) $(lib-git) $(lib-spatialindex) $(lib-geos) $(lib-jsonc)
+brew-libs = $(lib-sqlite) $(lib-curl) $(lib-git) $(lib-spatialindex) $(lib-geos) $(lib-jsonc) $(lib-unixodbc)
 
 $(brew-deps): Brewfile
 	brew bundle
@@ -106,7 +107,7 @@ $(brew-deps): Brewfile
 .PHONY: brew-deps
 brew-deps: $(brew-deps)
 
-.PHONE: brew-libs
+.PHONY: brew-libs
 brew-libs: $(brew-libs)
 
 env: brew-deps
@@ -180,6 +181,11 @@ $(lib-spatialindex): $(brew-deps) | env
 $(lib-geos): $(brew-deps) | env
 	$(MAKE) .delocate
 	cp -av /usr/local/opt/geos/lib/libgeos*.dylib .delocate
+	$(MAKE) delocate-deps
+
+$(lib-unixodbc): $(brew-deps) | env
+	$(MAKE) .delocate
+	cp -av /usr/local/opt/unixodbc/lib/libodbc*.dylib .delocate
 	$(MAKE) delocate-deps
 
 else


### PR DESCRIPTION
![](https://media2.giphy.com/media/zTxxoe3TToHbq/giphy.gif)

## Description

Adds unixodbc to the mac build, delocates it appropriately.
unixodbc is required by pyodbc.

Still TODO:
- On mac: modify pyodbc library rpath to point to unixodbc
- On linux: build unixodbc, build or install pyodbc and point it to unixodbc

This was a long day's work