### PR TITLE
Build pyodbc on mac, depend on unixodbc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,12 @@ vendor/proj/**
 !vendor/proj/Makefile
 vendor/psycopg2/**
 !vendor/psycopg2/Makefile
-vendor/pysqlite3/**
-!vendor/pysqlite3/Makefile
 vendor/pygit2/**
 !vendor/pygit2/Makefile
+vendor/pyodbc/**
+!vendor/pyodbc/Makefile
+vendor/pysqlite3/**
+!vendor/pysqlite3/Makefile
 vendor/spatialindex/**
 !vendor/spatialindex/Makefile
 vendor/spatialite/**

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,6 @@ pycparser==2.20
     # via -r requirements/requirements.in
 pygments==2.8.1
     # via -r requirements/requirements.in
-pyodbc==4.0.30 ; platform_system != "Linux"
-    # via -r requirements/requirements.in
 pyrsistent==0.17.3
     # via jsonschema
 rtree==0.9.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,9 @@
 apipkg==1.5
     # via execnet
 appnope==0.1.2
-    # via -r requirements/dev.in
+    # via
+    #   -r requirements/dev.in
+    #   ipython
 attrs==20.3.0
     # via
     #   -c requirements/../requirements.txt
@@ -59,7 +61,7 @@ pluggy==0.13.1
     # via
     #   -c requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.16
+prompt-toolkit==3.0.17
     # via ipython
 ptyprocess==0.7.0
     # via pexpect

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,6 @@ Click~=7.0
 jsonschema
 msgpack~=0.6.1
 Pygments
-pyodbc ; platform_system!="Linux"
 Rtree~=0.9.4
 sqlalchemy
 

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -17,12 +17,14 @@ vendor-Linux-archive = dist/vendor-Linux.tar.gz
 vendor-Darwin-archive = dist/vendor-Darwin.tar.gz
 
 ifeq ($(PLATFORM),Darwin)
+	LIBINFIX = cpython-37m-darwin
 	LIBSUFFIX = dylib
 	WHEELTOOL = delocate
 	PY3 ?= $(realpath /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7)
 	WHEELID = macosx_10_9_x86_64
 	export LDFLAGS += -Wl,-rpath,'@loader_path'
 else ifeq ($(PLATFORM),Linux)
+	LIBINFIX = cpython-37m-x86_64-linux-gnu
 	LIBSUFFIX = so
 	WHEELTOOL = auditwheel
 	WHEELID = linux_x86_64
@@ -58,7 +60,7 @@ lib-libgit2 := env/lib/libgit2.$(LIBSUFFIX)
 lib-pygit2 := env/lib/python3.7/site-packages/pygit2/__init__.py
 lib-pysqlite3 := env/lib/python3.7/site-packages/pysqlite3/__init__.py
 lib-psycopg2 := env/lib/python3.7/site-packages/psycopg2/__init__.py
-lib-pyodbc := env/lib/python3.7/site-packages/pyodbc/__init__.py
+lib-pyodbc := env/lib/python3.7/site-packages/pyodbc.$(LIBINFIX).so
 build-libs := $(lib-gdal) $(lib-spatialite) $(lib-pygit2) $(lib-git) $(lib-libgit2) $(lib-psycopg2) $(lib-pysqlite3) $(lib-pyodbc)
 
 

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -58,7 +58,8 @@ lib-libgit2 := env/lib/libgit2.$(LIBSUFFIX)
 lib-pygit2 := env/lib/python3.7/site-packages/pygit2/__init__.py
 lib-pysqlite3 := env/lib/python3.7/site-packages/pysqlite3/__init__.py
 lib-psycopg2 := env/lib/python3.7/site-packages/psycopg2/__init__.py
-build-libs := $(lib-gdal) $(lib-spatialite) $(lib-pygit2) $(lib-git) $(lib-libgit2) $(lib-psycopg2) $(lib-pysqlite3)
+lib-pyodbc := env/lib/python3.7/site-packages/pyodbc/__init__.py
+build-libs := $(lib-gdal) $(lib-spatialite) $(lib-pygit2) $(lib-git) $(lib-libgit2) $(lib-psycopg2) $(lib-pysqlite3) $(lib-pyodbc)
 
 
 # default target
@@ -94,6 +95,11 @@ $(lib-psycopg2): $(lib-pq)
 $(lib-pysqlite3): $(lib-sqlite)
 	$(MAKE) -C pysqlite3 wheel
 	pip3 install --force-reinstall pysqlite3/wheel/pysqlite3-*$(WHEELID).whl
+
+$(lib-pyodbc): $(lib-unixodbc)
+	$(MAKE) -C pyodbc wheel
+	pip3 install --force-reinstall pyodbc/wheel/pyodbc-*$(WHEELID).whl
+
 
 ifeq ($(PLATFORM),Darwin)
 #
@@ -306,11 +312,10 @@ build-Darwin: $(build-libs) $(brew-libs)
 	cp -vaf env/share/gdal $(VENDOR_ENV)/share/
 	cp -vaf env/share/proj $(VENDOR_ENV)/share/
 
-	# PyGit2
 	cp -vf pygit2/wheel/pygit2-*$(WHEELID).whl $(VENDOR)/wheelhouse/
-
 	cp -vf psycopg2/wheel/psycopg2-*$(WHEELID).whl $(VENDOR)/wheelhouse/
 	cp -vf pysqlite3/wheel/pysqlite3-*$(WHEELID).whl $(VENDOR)/wheelhouse/
+	cp -vf pyodbc/wheel/pyodbc-*$(WHEELID).whl $(VENDOR)/wheelhouse/
 
 	cp -vaf env/lib/*.{dylib,so} $(VENDOR_ENV)/lib/
 

--- a/vendor/pyodbc/Makefile
+++ b/vendor/pyodbc/Makefile
@@ -19,14 +19,14 @@ ifeq ($(PLATFORM),Darwin)
 	LIBSUFFIX = dylib
 	PY3 ?= $(realpath /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7)
 	WHEELTOOL = delocate
-	export LDFLAGS+=-Wl,-rpath,'@loader_path/../../../'
+	export LDFLAGS+=-Wl,-rpath,'@loader_path/../..'
 	UNIXODBC_PREFIX = /usr/local/opt/unixodbc
 else ifeq ($(PLATFORM),Linux)
 	LIBSUFFIX = so
 	CCACHE_PATH = /usr/lib/ccache
 	CCACHE_PATH := $(or $(CCACHE_PATH),/usr/lib64/ccache)
 	WHEELTOOL = auditwheel
-	export LDFLAGS := -Wl,-rpath='$$ORIGIN/../../..'
+	export LDFLAGS := -Wl,-rpath='$$ORIGIN/../..'
 endif
 PY3 := $(or $(PY3),python3.7)
 

--- a/vendor/pyodbc/Makefile
+++ b/vendor/pyodbc/Makefile
@@ -1,0 +1,122 @@
+PYODBC_REF ?= 4.0.30
+PYODBC_REPO ?= mkleehammer/pyodbc
+PYODBC_ARCHIVE := pyodbc-$(PYGIT2_REF).tar.gz
+
+SHELL = /bin/bash
+export PREFIX ?= $(abspath env)
+
+ifeq ($(OS),Windows_NT)
+	PLATFORM := Windows
+else
+	PLATFORM := $(shell uname -s)
+endif
+
+export LIBGIT2 ?= $(PREFIX)
+export CFLAGS += -g
+
+ifeq ($(PLATFORM),Darwin)
+	CCACHE_PATH = /usr/local/opt/ccache/bin
+	LIBSUFFIX = dylib
+	PY3 ?= $(realpath /Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7)
+	WHEELTOOL = delocate
+	export LDFLAGS+=-Wl,-rpath,'@loader_path/../../../'
+	UNIXODBC_PREFIX = /usr/local/opt/unixodbc
+else ifeq ($(PLATFORM),Linux)
+	LIBSUFFIX = so
+	CCACHE_PATH = /usr/lib/ccache
+	CCACHE_PATH := $(or $(CCACHE_PATH),/usr/lib64/ccache)
+	WHEELTOOL = auditwheel
+	export LDFLAGS := -Wl,-rpath='$$ORIGIN/../../..'
+endif
+PY3 := $(or $(PY3),python3.7)
+
+pyodbc := $(abspath $(PREFIX)/lib/pyodbc.$(LIBSUFFIX))
+
+# use ccache if available
+export PATH := $(CCACHE_PATH):$(PREFIX)/bin:$(PATH)
+
+# default target
+.PHONY: all
+all: wheel
+
+.PHONY: clean
+clean:
+	-$(RM) -r env
+	-$(RM) -r wheel wheelhouse
+	-$(RM) -r src/build src/dist src/.eggs
+
+.PHONY: cleaner
+cleaner: clean
+	-(cd src && python3 setup.py clean)
+
+.PHONY: cleanest
+cleanest: clean
+	-$(RM) -r src
+
+.PHONY: clean-configure
+clean-configure:
+
+#
+# Download Archives
+#
+
+$(PYODBC_ARCHIVE):
+	wget https://github.com/$(PYODBC_REPO)/archive/$(PYODBC_REF).tar.gz -O $@
+
+.PHONY: archive
+archive: $(PYODBC_ARCHIVE)
+
+#
+# Extract Archives
+#
+
+src: $(PYODBC_ARCHIVE)
+	rm -rf $@
+	mkdir -p $@
+	@echo "Extracting $(PYODBC_ARCHIVE) ..."
+	tar xzf $(PYODBC_ARCHIVE) --strip-components=1 -C $@
+
+
+.PHONY: source
+source: src
+
+#
+# pyodbc
+#
+
+.PHONY: py-fix-Darwin
+py-fix-Darwin:
+	install_name_tool \
+		-change "$(UNIXODBC_PREFIX)/lib/libodbc.2.dylib" "@rpath/libodbc.2.dylib" \
+		src/build/lib.macosx*/pyodbc.cpython-37m-darwin.so; \
+	otool -L src/build/lib.macosx*/pyodbc.cpython-37m-darwin.so
+
+.PHONY: py-fix-Linux
+py-fix-Linux:
+
+.PHONY: install
+install: | src
+	@echo 'CFLAGS=$(CFLAGS) LDFLAGS=$(LDFLAGS) PY3=$(PY3)'
+	python setup.py install
+
+.PHONY: wheel
+wheel: | src
+	@echo 'CFLAGS=$(CFLAGS) LDFLAGS=$(LDFLAGS) PY3=$(PY3)'
+	cd src && python3 setup.py --no-user-cfg build
+
+	$(MAKE) py-fix-$(PLATFORM)
+
+	cd src && python3 setup.py  --no-user-cfg bdist_wheel -d $(abspath $@)
+
+	$(MAKE) py-deps-$(PLATFORM)
+
+.PHONY: py-deps-Darwin
+py-deps-Darwin:
+	for W in wheel/*.whl; do \
+		echo "$W"; \
+		! ( delocate-listdeps "$$W" | sed -e '/@rpath/d' | grep '[^[:space:]]' ) || exit 1; \
+	done
+
+.PHONY: py-deps-Linux
+py-deps-Linux:
+	auditwheel show wheel/*.whl


### PR DESCRIPTION
![](https://media2.giphy.com/media/xUOrw3Cefz0PcZrLFu/giphy-downsized-medium.gif)

## Description

Fixes pyodbc on the mac build to depend on the unixodbc that is also part of the mac build, instead of depending on a system lib that may or may not be there.

One can test that it worked like so:
```
~/code/sno$ git checkout pyodbc
~/code/sno$ make sno
~/code/sno$ venv/bin/python
>>> import pyodbc
>>> pyodbc.__file__
~/code/sno/venv/lib/python3.7/site-packages/pyodbc.cpython-37m-darwin.so
>>> ^D

~/code/sno$ otool -L venv/lib/python3.7/site-packages/pyodbc.cpython-37m-darwin.so
venv/lib/python3.7/site-packages/pyodbc.cpython-37m-darwin.so:
	@rpath/libodbc.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	
~/code/sno$ otool -L venv/lib/libodbc.2.dylib
otool -L venv/lib/libodbc.2.dylib
venv/lib/libodbc.2.dylib:
	libodbc.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	@loader_path/libltdl.7.dylib (compatibility version 11.0.0, current version 11.1.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)

```