### PR TITLE
Allow --replace-ids= (no value) to work with no PK

### DIFF
--- a/sno/pk_generation.py
+++ b/sno/pk_generation.py
@@ -256,6 +256,19 @@ class PkGeneratingImportSource(ImportSource):
             # Just assign new PKs to those we couldn't find a match for.
             yield from self._assign_pk_range(buffered_inserts, next_new_pk)
 
+    def get_features(self, row_pks, *, ignore_missing=False):
+        # we implement this so you can specifically call it with an empty
+        # list of PKs.
+        # this means you can use `sno import --replace-ids=` to import
+        # a meta-only change with no actual feature changes, efficiently.
+        # Calling it with a non-empty list of PKs raises an error.
+        for pk in row_pks:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} doesn't support retrieving features by PK"
+            )
+            # make this a generator, even though it's never non-empty
+            yield None
+
     def _assign_pk_range(self, features, pk):
         for feature in features:
             yield self._assign_pk(feature, pk)


### PR DESCRIPTION
## Description

It's possible to import meta-only changes via `sno import` using the `--table-info` option. For datasets with a PK, this can be made efficient by using `--replace-ids=` (i.e. replace no features; only touch meta changes)

For datasets with no PK, `--replace-ids` doesn't work, so the only alternatives are:
 - make a patch and use `sno apply` (annoying if you're already using `sno import` for importing other datasets)
 - reimport the entire dataset from the source database, eventually ending up with no changes.

This PR makes `--replace-ids=` (specifically the empty value, which means 'replace no features', work for non-PK datasets. If you need to replace any features, the only option is still to omit the flag altogether and replace the whole dataset.

## Related links:

.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?

I think this change isn't needed in the changelog; the latest release adds `--replace-ids` and the description there is adequate.