### PR TITLE
Rewrote the find-similar-feature algorithm in PK-less import to be faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,9 +147,9 @@ jobs:
           brew uninstall --force php
           brew update-reset
           sudo installer -pkg .cache/pydist/${{ env.PY3_PKG }} -dumplog -target /
+          brew upgrade python@3.9 || echo "The link step of `brew upgrade python@3.9` fails. This is okay."
           brew install --force ccache pkg-config sqlite3 pandoc
           brew install --force --cask Packages
-          brew upgrade python@3.9 || true
 
       - name: "vendor: ccache"
         uses: actions/cache@v1

--- a/sno/import_source.py
+++ b/sno/import_source.py
@@ -119,6 +119,14 @@ class ImportSource:
         """
         return Schema.from_column_dicts(self.get_meta_item("schema.json"))
 
+    def align_schema_to_existing_schema(self, existing_schema):
+        """
+        Aligning the schema with an existing schema means that the pre-existing colunms will keep the same ID
+        that they had last time. Failing to align the schema would mean that some features would be re-encoded
+        even if they hadn't actually chaned.
+        """
+        self.schema = existing_schema.align_to_self(self.schema)
+
     @property
     def has_geometry(self):
         return self.schema.has_geometry

--- a/sno/init.py
+++ b/sno/init.py
@@ -162,7 +162,7 @@ class GenerateIDsFromFile(StringFromFile):
     "--similarity-detection-limit",
     hidden=True,
     type=click.INT,
-    default=500,
+    default=10000,
     help=(
         "When replacing an existing dataset where primary keys are auto-generated: the maximum number of unmatched "
         "features to search through for similar features, so that primary keys can be reassigned for features that "

--- a/sno/init.py
+++ b/sno/init.py
@@ -310,9 +310,7 @@ def import_table(
                     dest_path=dest_path,
                     similarity_detection_limit=similarity_detection_limit,
                 )
-                import_source.schema = existing_ds.schema.align_to_self(
-                    import_source.schema
-                )
+                import_source.align_schema_to_existing_schema(existing_ds.schema)
         import_source.dest_path = dest_path
         import_sources.append(import_source)
 

--- a/sno/pk_generation.py
+++ b/sno/pk_generation.py
@@ -1,4 +1,3 @@
-from itertools import zip_longest
 import pygit2
 
 from .dataset2 import Dataset2

--- a/sno/schema.py
+++ b/sno/schema.py
@@ -231,8 +231,13 @@ class Schema:
 
     @property
     @functools.lru_cache(maxsize=1)
+    def non_pk_columns(self):
+        return tuple(c for c in self.columns if c.pk_index is None)
+
+    @property
+    @functools.lru_cache(maxsize=1)
     def geometry_columns(self):
-        return [c for c in self.columns if c.data_type == "geometry"]
+        return tuple(c for c in self.columns if c.data_type == "geometry")
 
     @property
     def has_geometry(self):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -648,7 +648,6 @@ def test_postgis_import_from_view_no_pk(
                 os.environ["SNO_POSTGRES_URL"],
                 "nz_pa_points_view",
                 "--replace-existing",
-                "--similarity-detection-limit=10000",
             ]
         )
         assert r.exit_code == 0, r.stderr
@@ -694,7 +693,6 @@ def test_postgis_import_from_view_no_pk(
                 os.environ["SNO_POSTGRES_URL"],
                 "nz_pa_points_view",
                 "--replace-existing",
-                "--similarity-detection-limit=10000",
             ]
         )
         assert r.exit_code == 0, r.stderr


### PR DESCRIPTION
![](https://media1.giphy.com/media/yXVO50FJIJMSQ/giphy.gif)

When git does exact-rename detection, it simply hashes all of the contents of all of the inserted or deleted files. Then it checks which hashes are the same. We do something similar when we detecting exact-feature-reimports during PK-less import. In our use-case, these features will *not* be renamed, they will be assigned the same PK. This algorithm is fast - linear on the number of features.

When git does similar-rename-detection - finding files that have been both renamed and edited - git has to compare the full contents of every deleted file to every inserted file. This is because the hashes of similar files are not themselves similar, so git has no choice but to compare all of the contents. We are currently doing something similar when we detect similar-feature-reimports during PK-less import. Again, these are the features that, if detected, will *not* be renamed, but assigned the same PKs as previously. This algorithm is slow - quadratic on the number of features.

Because our similarity detection metric is actually "would these two features by identical, if we ignored one field", we can do a trick that git cannot. We can remove all of the fields of a feature, one at a time, and generate a hash for each of those. Then we can look for hash collisions for those hashes. There will be a lot of hashes to keep track of - if every feature has 10 fields, then there will be 10 times as many hashes as features. Instead of being quadratic on the number of features, this algorithm is:
O(N * M) where N is the number of inserts + deletes, and M is the number of fields a feature has.

Also changed the tests to actually make the algorithm work harder - previously it was only trying to find renames among 4 inserts + deletes, now there are 1400 insert + deletes which it has to hunt through. With the algorithm change, the test runs in 4 seconds instead of 5 seconds on my machine - haven't profiled beyond this yet, not sure how much is setup time etc. Actually mirroring a repo which has a lot of churn would give much more useful data anyway.

Also increased the default rename detection limit up to 500.