### PR TITLE
Use a server-side cursor for SQL importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `init` now accepts a `--initial-branch` option
  * `clone` now accepts a `--filter` option (advanced users only)
  * `show -o json` now includes the commit hash in the output
+ * `import` from Postgres now uses a server-side cursor, which means sno uses less memory
 
 ## 0.7.1
 

--- a/sno/ogr_import_source.py
+++ b/sno/ogr_import_source.py
@@ -649,7 +649,9 @@ class SQLAlchemyOgrImportSource(OgrImportSource):
         (it turns out that OGR feature iterators can be quite slow!)
         """
         with self.engine.connect() as conn:
-            r = conn.execute(f"SELECT * FROM {self.quote_ident(self.table)};")
+            r = conn.execution_options(stream_results=True).execute(
+                f"SELECT * FROM {self.quote_ident(self.table)};"
+            )
             yield from self._sqlalchemy_to_sno_features(r)
 
     def get_features(self, row_pks, *, ignore_missing=False):
@@ -702,7 +704,7 @@ class GPKGImportSource(SQLAlchemyOgrImportSource):
         yield from gpkg_adapter.all_v2_crs_definitions(self.gpkg_meta_items)
 
 
-class PostgreSQLImportSource(OgrImportSource):
+class PostgreSQLImportSource(SQLAlchemyOgrImportSource):
     @classmethod
     def postgres_url_to_ogr_conn_str(cls, url):
         """


### PR DESCRIPTION
## Description


importing from a postgres source, we noticed high memory consumption with large layers. Turns out sno is fetching all the results from the database rather than using a server-side cursor.

This PR makes it use a server side cursor to fetch results. [SQLAlchemy docs](https://docs.sqlalchemy.org/en/14/core/connections.html?highlight=yield_per#engine-stream-results) say that it will use a low fetch size initially and eventually increase up to 1000 rows at a time, which seems reasonable.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/sno/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?

