### PR TITLE
Fix libcrypto warning on Ubuntu

### DIFF
--- a/sno/cli.py
+++ b/sno/cli.py
@@ -30,12 +30,13 @@ from . import (
     upgrade,
 )
 from .cli_util import (
-    call_and_exit_flag,
     add_help_subcommand,
+    call_and_exit_flag,
+    git_remote_environment,
     startup_load_git_init_config,
 )
 from .context import Context
-from .exec import execvp
+from .exec import execvp, execvpe
 
 
 def get_version():
@@ -218,7 +219,7 @@ cli.add_command(upgrade.upgrade_to_tidy)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def push(ctx, do_progress, args):
     """ Update remote refs along with associated objects """
-    execvp(
+    execvpe(
         "git",
         [
             "git",
@@ -226,8 +227,9 @@ def push(ctx, do_progress, args):
             ctx.obj.repo.path,
             "push",
             "--progress" if do_progress else "--quiet",
-        ]
-        + list(args),
+            *args,
+        ],
+        git_remote_environment(),
     )
 
 
@@ -243,7 +245,7 @@ def push(ctx, do_progress, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def fetch(ctx, do_progress, args):
     """ Download objects and refs from another repository """
-    execvp(
+    execvpe(
         "git",
         [
             "git",
@@ -251,8 +253,9 @@ def fetch(ctx, do_progress, args):
             ctx.obj.repo.path,
             "fetch",
             "--progress" if do_progress else "--quiet",
-        ]
-        + list(args),
+            *args,
+        ],
+        git_remote_environment(),
     )
 
 

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -32,11 +32,11 @@ from . import (
 from .cli_util import (
     add_help_subcommand,
     call_and_exit_flag,
-    git_remote_environment,
     startup_load_git_init_config,
+    tool_environment,
 )
 from .context import Context
-from .exec import execvp, execvpe
+from .exec import execvp
 
 
 def get_version():
@@ -58,7 +58,7 @@ def print_version(ctx):
     click.echo(f"Sno v{get_version()}, Copyright (c) Sno Contributors")
 
     git_version = (
-        subprocess.check_output(["git", "--version"])
+        subprocess.check_output(["git", "--version"], env=tool_environment())
         .decode("ascii")
         .strip()
         .split()[-1]
@@ -219,7 +219,7 @@ cli.add_command(upgrade.upgrade_to_tidy)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def push(ctx, do_progress, args):
     """ Update remote refs along with associated objects """
-    execvpe(
+    execvp(
         "git",
         [
             "git",
@@ -229,7 +229,6 @@ def push(ctx, do_progress, args):
             "--progress" if do_progress else "--quiet",
             *args,
         ],
-        git_remote_environment(),
     )
 
 
@@ -245,7 +244,7 @@ def push(ctx, do_progress, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def fetch(ctx, do_progress, args):
     """ Download objects and refs from another repository """
-    execvpe(
+    execvp(
         "git",
         [
             "git",
@@ -255,7 +254,6 @@ def fetch(ctx, do_progress, args):
             "--progress" if do_progress else "--quiet",
             *args,
         ],
-        git_remote_environment(),
     )
 
 

--- a/sno/cli_util.py
+++ b/sno/cli_util.py
@@ -1,8 +1,9 @@
-import json
 import click
+import io
+import json
 import jsonschema
 import os
-import io
+import platform
 
 import pygit2
 
@@ -43,6 +44,21 @@ def startup_load_git_init_config():
         if "GIT_CONFIG_PARAMETERS" in os.environ:
             existing = f" {os.environ['GIT_CONFIG_PARAMETERS']}"
         os.environ["GIT_CONFIG_PARAMETERS"] = f"'init.defaultBranch=main'{existing}"
+
+
+def git_remote_environment():
+    """
+    Returns a dict of environment for launching a git process
+    for interacting with a remote.
+    """
+    env = os.environ.copy()
+    if platform.system() == "Linux":
+        # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
+        if "LD_LIBRARY_PATH_ORIG" in env:
+            env["LD_LIBRARY_PATH"] = env["LD_LIBRARY_PATH_ORIG"]
+        else:
+            env.pop("LD_LIBRARY_PATH", None)
+    return env
 
 
 def add_help_subcommand(group):

--- a/sno/cli_util.py
+++ b/sno/cli_util.py
@@ -46,12 +46,11 @@ def startup_load_git_init_config():
         os.environ["GIT_CONFIG_PARAMETERS"] = f"'init.defaultBranch=main'{existing}"
 
 
-def git_remote_environment():
+def tool_environment(env=None):
     """
-    Returns a dict of environment for launching a git process
-    for interacting with a remote.
+    Returns a dict of environment for launching an external process
     """
-    env = os.environ.copy()
+    env = (env or os.environ).copy()
     if platform.system() == "Linux":
         # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
         if "LD_LIBRARY_PATH_ORIG" in env:

--- a/sno/commit.py
+++ b/sno/commit.py
@@ -10,7 +10,7 @@ import click
 import pygit2
 
 from . import is_windows
-from .cli_util import StringFromFile
+from .cli_util import StringFromFile, tool_environment
 from .core import check_git_user
 from .exceptions import (
     NotFound,
@@ -188,7 +188,7 @@ def user_edit_file(path):
 
 
 def run_editor_cmd(editor_cmd):
-    subprocess.check_call(editor_cmd, shell=True)
+    subprocess.check_call(editor_cmd, shell=True, env=tool_environment())
 
 
 def commit_obj_to_json(commit, repo, wc_diff):

--- a/sno/exec.py
+++ b/sno/exec.py
@@ -5,15 +5,21 @@ import sys
 from . import is_windows
 
 
-def execvp(cmd, args):
+def execvpe(cmd, args, env):
     if "_SNO_NO_EXEC" in os.environ:
         # used in testing. This is pretty hackzy
-        p = subprocess.run([cmd] + args[1:], capture_output=True, encoding="utf-8")
+        p = subprocess.run(
+            [cmd] + args[1:], capture_output=True, encoding="utf-8", env=env
+        )
         sys.stdout.write(p.stdout)
         sys.stderr.write(p.stderr)
         sys.exit(p.returncode)
     elif is_windows:
-        p = subprocess.run([cmd] + args[1:])
+        p = subprocess.run([cmd] + args[1:], env=env)
         sys.exit(p.returncode)
     else:  # Posix
-        os.execvp(cmd, args)
+        os.execvpe(cmd, args, env)
+
+
+def execvp(cmd, args):
+    return execvpe(cmd, args, os.environ)

--- a/sno/exec.py
+++ b/sno/exec.py
@@ -3,9 +3,12 @@ import subprocess
 import sys
 
 from . import is_windows
+from .cli_util import tool_environment
 
 
 def execvpe(cmd, args, env):
+    env = tool_environment(env)
+
     if "_SNO_NO_EXEC" in os.environ:
         # used in testing. This is pretty hackzy
         p = subprocess.run(

--- a/sno/fast_import.py
+++ b/sno/fast_import.py
@@ -7,6 +7,7 @@ from enum import Enum, auto
 import click
 import pygit2
 
+from .cli_util import tool_environment
 from .exceptions import SubprocessError, InvalidOperation, NotFound, NO_CHANGES
 from .import_source import ImportSource
 from .repo_version import (
@@ -130,6 +131,7 @@ def fast_import_tables(
         [*cmd, *extra_cmd_args],
         cwd=repo.path,
         stdin=subprocess.PIPE,
+        env=tool_environment(),
     )
     try:
         if replace_existing != ReplaceExisting.ALL:

--- a/sno/fsck.py
+++ b/sno/fsck.py
@@ -3,9 +3,10 @@ import subprocess
 
 import click
 
-from .working_copy import gpkg_adapter
+from .cli_util import tool_environment
 from .exceptions import NotFound, NO_WORKING_COPY
 from .geometry import normalise_gpkg_geom
+from .working_copy import gpkg_adapter
 
 
 def _fsck_reset(repo, working_copy, dataset_paths):
@@ -30,7 +31,9 @@ def fsck(ctx, reset_datasets, fsck_args):
     repo = ctx.obj.repo
 
     click.echo("Checking repository integrity...")
-    r = subprocess.call(["git", "-C", repo.path, "fsck"] + list(fsck_args))
+    r = subprocess.call(
+        ["git", "-C", repo.path, "fsck"] + list(fsck_args), env=tool_environment()
+    )
     if r:
         click.Abort()
 

--- a/sno/log.py
+++ b/sno/log.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from .cli_util import tool_environment
 from .exec import execvp
 from .exceptions import SubprocessError
 from .output_util import dump_json_output
@@ -51,7 +52,13 @@ def log(ctx, output_format, json_style, do_dataset_changes, args):
                 "log",
                 "--pretty=format:%H,%D",
             ] + list(args)
-            r = subprocess.run(cmd, encoding="utf8", check=True, capture_output=True)
+            r = subprocess.run(
+                cmd,
+                encoding="utf8",
+                check=True,
+                capture_output=True,
+                env=tool_environment(),
+            )
         except subprocess.CalledProcessError as e:
             raise SubprocessError(
                 f"There was a problem with git log: {e}", called_process_error=e

--- a/sno/pull.py
+++ b/sno/pull.py
@@ -4,7 +4,7 @@ import subprocess
 import click
 
 from . import merge
-from .cli_util import git_remote_environment
+from .cli_util import tool_environment
 from .exceptions import NotFound, NO_BRANCH
 
 
@@ -84,7 +84,7 @@ def pull(ctx, ff, ff_only, do_progress, repository, refspecs):
             repository,
             *refspecs,
         ],
-        env=git_remote_environment(),
+        env=tool_environment(),
     )
 
     # now merge with FETCH_HEAD

--- a/sno/pull.py
+++ b/sno/pull.py
@@ -4,6 +4,7 @@ import subprocess
 import click
 
 from . import merge
+from .cli_util import git_remote_environment
 from .exceptions import NotFound, NO_BRANCH
 
 
@@ -81,8 +82,9 @@ def pull(ctx, ff, ff_only, do_progress, repository, refspecs):
             "fetch",
             "--progress" if do_progress else "--quiet",
             repository,
-        ]
-        + list(refspecs)
+            *refspecs,
+        ],
+        env=git_remote_environment(),
     )
 
     # now merge with FETCH_HEAD

--- a/sno/repo.py
+++ b/sno/repo.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 import os
 import re
@@ -12,6 +11,7 @@ import click
 import pygit2
 
 from . import is_windows
+from .cli_util import git_remote_environment
 from .exceptions import (
     translate_subprocess_exit_code,
     InvalidOperation,
@@ -266,7 +266,7 @@ class SnoRepo(pygit2.Repository):
     @classmethod
     def _create_with_git_command(cls, cmd, gitdir_path, temp_workdir_path=None):
         try:
-            subprocess.check_call(cmd)
+            subprocess.check_call(cmd, env=git_remote_environment())
         except subprocess.CalledProcessError as e:
             sys.exit(translate_subprocess_exit_code(e.returncode))
 

--- a/sno/repo.py
+++ b/sno/repo.py
@@ -11,7 +11,7 @@ import click
 import pygit2
 
 from . import is_windows
-from .cli_util import git_remote_environment
+from .cli_util import tool_environment
 from .exceptions import (
     translate_subprocess_exit_code,
     InvalidOperation,
@@ -266,7 +266,7 @@ class SnoRepo(pygit2.Repository):
     @classmethod
     def _create_with_git_command(cls, cmd, gitdir_path, temp_workdir_path=None):
         try:
-            subprocess.check_call(cmd, env=git_remote_environment())
+            subprocess.check_call(cmd, env=tool_environment())
         except subprocess.CalledProcessError as e:
             sys.exit(translate_subprocess_exit_code(e.returncode))
 
@@ -341,8 +341,8 @@ class SnoRepo(pygit2.Repository):
         if is_windows:
             # Hide .git and .sno
             # Best effort: if it doesn't work for some reason, continue anyway.
-            subprocess.call(["attrib", "+h", str(dot_git_path)])
-            subprocess.call(["attrib", "+h", str(dot_sno_path)])
+            subprocess.call(["attrib", "+h", str(dot_git_path)], env=tool_environment())
+            subprocess.call(["attrib", "+h", str(dot_sno_path)], env=tool_environment())
 
     def is_bare_style_sno_repo(self):
         """Bare-style sno repos are bare git repos. They are not "tidy": all of the git internals are visible."""
@@ -447,7 +447,7 @@ class SnoRepo(pygit2.Repository):
         """Runs git-gc on the sno repository."""
         try:
             args = ["git", "-C", self.path, "gc", *args]
-            subprocess.check_call(args)
+            subprocess.check_call(args, env=tool_environment())
         except subprocess.CalledProcessError as e:
             sys.exit(translate_subprocess_exit_code(e.returncode))
 
@@ -510,7 +510,7 @@ class SnoRepo(pygit2.Repository):
             ["git", "var", f"GIT_{person_type}_IDENT"],
             cwd=self.path,
             encoding="utf8",
-            env=env,
+            env=tool_environment(env),
         )
         m = self._GIT_VAR_OUTPUT_RE.match(output)
         kwargs = m.groupdict()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,7 @@ def test_cli_tool_environment():
         assert env_exec["my"] == "me"
 
         env_in = {"LD_LIBRARY_PATH": "bob", "my": "me"}
-        env_exec = tool_environment(fake_env)
+        env_exec = tool_environment(env_in)
         assert "LD_LIBRARY_PATH" not in env_exec
     else:
         env_in = {"my": "me"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,12 @@
 import os
+import platform
 import re
 
 import pygit2
 import pytest
 
 from sno import cli
+from sno.cli_util import tool_environment
 
 
 H = pytest.helpers.helpers()
@@ -53,3 +55,25 @@ def test_config(empty_gitconfig, cli_runner):
     r = cli_runner.invoke(["config", "init.defaultBranch"])
     assert r.exit_code == 0, r.stderr
     assert r.stdout == "main\n"
+
+
+def test_cli_tool_environment():
+    env_exec = tool_environment()
+    assert len(env_exec)
+    assert env_exec is not os.environ
+
+    if platform.system() == "Linux":
+        env_in = {"LD_LIBRARY_PATH": "bob", "LD_LIBRARY_PATH_ORIG": "alex", "my": "me"}
+        env_exec = tool_environment(env_in)
+        assert env_exec is not env_in
+        assert env_exec["LD_LIBRARY_PATH"] == "alex"
+        assert env_exec["my"] == "me"
+
+        env_in = {"LD_LIBRARY_PATH": "bob", "my": "me"}
+        env_exec = tool_environment(fake_env)
+        assert "LD_LIBRARY_PATH" not in env_exec
+    else:
+        env_in = {"my": "me"}
+        env_exec = tool_environment(env_in)
+        assert env_exec is not env_in
+        assert env_exec == env_in


### PR DESCRIPTION

## Description

In non-dev sno, when running a command that invokes ssh via git
(clone, push, pull, fetch), SSH issues this warning twice:

```
ssh: /opt/sno/libcrypto.so.1.0.0: no version information available (required by ssh)
ssh: /opt/sno/libcrypto.so.1.0.0: no version information available (required by ssh)
```

This is probably because Pyinstaller has set LD_LIBRARY_PATH to find
bundled libraries, but we don't bundle ssh.
So, (system) ssh is loading our custom libcrypto, which doesn't
have the versioning information it expects.

This commit un-overrides LD_LIBRARY_PATH to fix the issue.


## Related links:

https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
