### PR TITLE
Fix test_gdal_proj_data - files have moved around

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -287,5 +287,5 @@ def test_gdal_proj_data():
     assert "PROJ_LIB" in os.environ
     osr = osr.SpatialReference()
     osr.ImportFromEPSG(4167)
-    assert osr.ExportToWkt()
-    assert (Path(os.environ["PROJ_LIB"]) / "nzgd2kgrid0005.gsb").exists()
+    assert "NZGD2000" in osr.ExportToWkt()
+    assert (Path(os.environ["PROJ_LIB"]) / "proj.db").exists()


### PR DESCRIPTION
Simplest fix for failing GDAL test on Windows - started failing when we upgraded gdal-3.1.4 to gdal-3.2.2 - Rob to verify if this test is sufficient, or if further testing is needed.
