### PR TITLE
Fix reporting of windows tests

### DIFF
--- a/makefile.vc
+++ b/makefile.vc
@@ -62,6 +62,7 @@ test: $(app) venv\.test.installed
 
 ci-test:
 	set CI=true
+	set failed=0
 	FOR /L %%I IN (0, 1, 9) DO \
 		pytest \
 			--num-shards 10 \
@@ -70,7 +71,11 @@ ci-test:
 			--benchmark-enable \
 			--no-cov \
 			-p no:sugar \
-			-p no:xdist
+			-p no:xdist \
+		|| (echo **** SHARDS FAILED SO FAR: & set /A failed+=1 & echo. ) \
+		& set /A success=1/!failed
+
+	echo **** ALL TESTS PASSED ****
 
 # Packaging
 


### PR DESCRIPTION
Fixes windows test failures to actually show up as a red build.

Uses a divide by zero since, inside the loop, variable substitutions don't work properly (even if you turn on enabledelayedexpansion - not sure why) - so set /A is the only command I could find that could read a variable, so I needed set /A to be the command that causes the build to fail. And outside the loop, the variable is for some reason reset to its pre-loop value, so I needed the command to fail due to a set /A from inside the loop.

This drove me a bit insane actually. I hope it actually works 
