### PR TITLE
macos: pyodbc packaging fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -324,6 +324,15 @@ jobs:
           name: ${{ matrix.platform.name }}-rpm
           path: platforms/linux/dist/*.rpm
 
+      - name: "package: save packaging logs"
+        uses: actions/upload-artifact@v2
+        with:
+          name: packaging-logs-${{ matrix.platform.name }}
+          path: |
+            platforms/*/build/sno/*.toc
+            platforms/*/build/sno/*.txt
+            platforms/*/build/sno/*.html
+
       #
       # Package tests
       #
@@ -515,6 +524,15 @@ jobs:
         with:
           name: Windows-msi
           path: ${{ steps.package.outputs.msi }}
+
+      - name: "package: save packaging logs"
+        uses: actions/upload-artifact@v2
+        with:
+          name: packaging-logs-Windows
+          path: |
+            platforms/windows/build/sno/*.toc
+            platforms/windows/build/sno/*.txt
+            platforms/windows/build/sno/*.html
 
       #
       # Package tests

--- a/platforms/macos/entitlements.plist
+++ b/platforms/macos/entitlements.plist
@@ -4,5 +4,11 @@
 <dict>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
 </dict>
 </plist>

--- a/sno.spec
+++ b/sno.spec
@@ -44,7 +44,7 @@ if is_linux:
     dylib.exclude_list = dylib.ExcludeList()
 
     print(
-        "❄️  Configured binary exclude-list overrides for libstdc++ & libgcc1:",
+        "❄️  Configured binary exclude-list overrides for libstdc++ & libgcc1",
         file=sys.stderr,
     )
     assert dylib.exclude_list.search('libstdc++.so.6.0.20')
@@ -61,7 +61,7 @@ if is_linux or is_darwin:
         dylib.exclude_list = dylib.MacExcludeList(dylib.exclude_list)
 
     print(
-        "❄️  Configured binary exclude-list overrides for libodbc:",
+        "❄️  Configured binary exclude-list overrides for libodbc",
         file=sys.stderr,
     )
     assert dylib.exclude_list.search('libodbc.2.dylib')

--- a/sno.spec
+++ b/sno.spec
@@ -67,6 +67,20 @@ if is_linux or is_darwin:
     assert dylib.exclude_list.search('libodbc.2.dylib')
     assert dylib.exclude_list.search('libodbc.so.1')
 
+if is_darwin:
+    # on macOS every dylib dependency path gets rewritten to @loader_path/...,
+    # which isn't much use wrt unixODBC. And PyInstaller has no useful hooks.
+    # TODO: when we upgrade PyInstaller this probably needs redoing
+    import macholib.util
+    macholib.util._orig_in_system_path = macholib.util.in_system_path
+    def sno__in_system_path(filename):
+        if re.match(r'/usr/local(/opt/unixodbc)?/lib/libodbc\.\d+\.dylib$', filename):
+            print(f"❄️  Treating {filename} as a system library", file=sys.stderr)
+            return True
+        else:
+            return macholib.util._orig_in_system_path(filename)
+    macholib.util.in_system_path = sno__in_system_path
+
 
 pyi_analysis = Analysis(
     ['platforms/sno_cli.py'],

--- a/sno/sqlalchemy/create_engine.py
+++ b/sno/sqlalchemy/create_engine.py
@@ -1,22 +1,24 @@
+import logging
 import os
-from pathlib import Path
 import re
 import socket
 import subprocess
+from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit, urlencode, parse_qs
-
 
 import sqlalchemy
 from pysqlite3 import dbapi2 as sqlite
 import psycopg2
 from psycopg2.extensions import Binary, new_type, register_adapter, register_type
 
-
 from sno import spatialite_path, is_windows
 from sno.geometry import Geometry
 from sno.exceptions import NotFound, NO_DRIVER
 
+
 GPKG_CACHE_SIZE_MiB = 200
+
+L = logging.getLogger("sno.sqlalchemy.create_engine")
 
 
 def gpkg_engine(path):
@@ -146,9 +148,10 @@ def get_odbc_drivers():
     """Returns a list of names of all ODBC drivers."""
     try:
         import pyodbc
-    except ImportError:
+    except ImportError as e:
         # this likely means unixODBC isn't installed. But since the MSSQL
         # drivers on macOS/Linux depend on it then it'll be installed with them.
+        L.debug("pyodbc import error: %s", e)
         raise NotFound(
             f"ODBC support for SQL Server is required but was not found.\nSee {SQL_SERVER_INSTALL_DOC_URL}",
             exit_code=NO_DRIVER,


### PR DESCRIPTION
## Description

Further fixes to pyodbc packaging on macOS.

* Modify macOS app entitlements to include allowing unsigned libraries to be loaded
* Prevent PyInstaller on macOS modifying the pyodbc module to rewrite the libodbc dependency path
* Improvements to logging for pyodbc import errors
* Keep PyInstaller logs/status files as CI artifacts

## Related links:

#381
#353 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] ~Have you included test(s)?~ tested manually
- [ ] ~Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?~ included in MSSQL
