### PR TITLE
GPKG status performance regression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `clone` now accepts a `--filter` option (advanced users only)
  * `show -o json` now includes the commit hash in the output
  * `import` from Postgres now uses a server-side cursor, which means sno uses less memory
+ * Improved log formatting at higher verbosity levels
 
 ## 0.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * `show -o json` now includes the commit hash in the output
  * `import` from Postgres now uses a server-side cursor, which means sno uses less memory
  * Improved log formatting at higher verbosity levels
+ * `sno -vvv` will log SQL queries to the console for debugging
 
 ## 0.7.1
 

--- a/sno/__init__.py
+++ b/sno/__init__.py
@@ -75,10 +75,14 @@ gdal.UseExceptions()
 ogr.UseExceptions()
 osr.UseExceptions()
 
+# Libgit2 options
+import pygit2
+
+pygit2.option(pygit2.GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, 0)
+
 # Libgit2 TLS CA Certificates
 # We build libgit2 to prefer the OS certificate store on Windows/macOS, but Linux doesn't have one.
 if is_linux:
     import certifi
-    import pygit2
 
     pygit2.settings.ssl_cert_file = certifi.where()

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -177,6 +177,10 @@ def cli(ctx, repo_dir, verbose, post_mortem):
         fmt = "%(asctime)s %(levelname)s %(name)s - %(message)s"
     logging.basicConfig(level=log_level, format=fmt)
 
+    if verbose >= 3:
+        # enable SQLAlchemy query logging
+        logging.getLogger("sqlalchemy.engine").setLevel("INFO")
+
 
 # Commands from modules:
 cli.add_command(apply.apply)

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -171,7 +171,11 @@ def cli(ctx, repo_dir, verbose, post_mortem):
     # default == WARNING; -v == INFO; -vv == DEBUG
     ctx.obj.verbosity = verbose
     log_level = logging.WARNING - min(10 * verbose, 20)
-    logging.basicConfig(level=log_level)
+    if verbose >= 2:
+        fmt = "%(asctime)s T%(thread)d %(levelname)s %(name)s [%(filename)s:%(lineno)d] - %(message)s"
+    else:
+        fmt = "%(asctime)s %(levelname)s %(name)s - %(message)s"
+    logging.basicConfig(level=log_level, format=fmt)
 
 
 # Commands from modules:

--- a/sno/working_copy/gpkg.py
+++ b/sno/working_copy/gpkg.py
@@ -94,6 +94,10 @@ class WorkingCopy_GPKG(WorkingCopy):
             # Don't need to specify type information for other columns at present, since we just pass through the values.
             return None
 
+    @property
+    def _tracking_table_requires_cast(self):
+        return False
+
     @contextlib.contextmanager
     def session(self, bulk=0):
         """


### PR DESCRIPTION
## Description

Workaround for a GPKG performance regression introduced in b20eec47.

For a 29K feature dataset with 21K changes in the working copy, `sno status` went from ~7s to ~3m20s.

Key driver is this query (~200ms):

```
SELECT gpkg_sno_track.pk AS ".__track_pk", nz_mainland_powerline_centrelines_topo_150k.t50_fid, nz_mainland_powerline_centrelines_topo_150k."GEOMETRY", nz_mainland_powerline_centrelines_topo_150k.support_ty
FROM gpkg_sno_track
  LEFT OUTER JOIN nz_mainland_powerline_centrelines_topo_150k ON gpkg_sno_track.pk = nz_mainland_powerline_centrelines_topo_150k.t50_fid
WHERE gpkg_sno_track.table_name = 'nz_mainland_powerline_centrelines_topo_150k';
```

Becoming ~200s:

```
SELECT gpkg_sno_track.pk AS ".__track_pk", nz_mainland_powerline_centrelines_topo_150k.t50_fid, nz_mainland_powerline_centrelines_topo_150k."GEOMETRY", nz_mainland_powerline_centrelines_topo_150k.support_ty
FROM gpkg_sno_track
  LEFT OUTER JOIN nz_mainland_powerline_centrelines_topo_150k ON gpkg_sno_track.pk = CAST(nz_mainland_powerline_centrelines_topo_150k.t50_fid AS TEXT)
WHERE gpkg_sno_track.table_name = 'nz_mainland_powerline_centrelines_topo_150k';
```

I think the speedup is only possible via this method because Sqlite is basically untyped. Expectedly, removing the cast altogether fails tests on MSSQL & PostGIS, but I suspect they're impacted too. Need a better solution really so we can at least always make use of the dataset PK index. Minimum might be casting the other way (ie. tracking table → dataset pk type) with the logic there's often likely to be less changes in the tracking table than there are rows in the dataset table?

While I was profiling, [disabled an extra hash verification](https://github.com/libgit2/libgit2/blob/508361401fbb5d87118045eaeae3356a729131aa/include/git2/common.h#L376-L381) per-object lookup.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/sno/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] ~Have you included test(s)?~ covered by existing tests
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
