### PR TITLE
`import --replace-existing` tweaks & optimisations

### DIFF
--- a/sno/__init__.py
+++ b/sno/__init__.py
@@ -80,6 +80,13 @@ import pygit2
 
 pygit2.option(pygit2.GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, 0)
 
+# By default, libgit2 caches tree object reads (up to 4K trees).
+# However, since sno stores features in a 256x256 tree structure,
+# large repos will have (65536+256) trees.
+# Increasing this limit above that number increases import performance dramatically.
+# (2 here is the value of `GIT_OBJECT_TREE` constant, pygit2 doesn't expose it)
+pygit2.option(pygit2.GIT_OPT_SET_CACHE_OBJECT_LIMIT, 2, 100000)
+
 # Libgit2 TLS CA Certificates
 # We build libgit2 to prefer the OS certificate store on Windows/macOS, but Linux doesn't have one.
 if is_linux:

--- a/sno/dataset2.py
+++ b/sno/dataset2.py
@@ -290,9 +290,9 @@ class Dataset2(RichBaseDataset):
             # Optimisation: Try to avoid rewriting features for compatible schema changes.
             # this can take some time, but often results in much fewer git objects produced.
             # For example, consider revision A with this feature:
-            #   {"a": 1, "b": 2}
+            #   {"x": 1, "y": 2}
             # Now at revision B we add a nullable column, so the new version of the feature is:
-            #   {"a": 1, "b": 2, "c": NULL}
+            #   {"x": 1, "y": 2, "z": NULL}
             # In this situation, during the import of revision B, we can avoid writing the
             # new blob, because the existing feature blob from revision A can be 'upgraded'
             # to the new schema without changing anything.

--- a/sno/dataset2.py
+++ b/sno/dataset2.py
@@ -282,40 +282,51 @@ class Dataset2(RichBaseDataset):
                 blob.data,
             )
 
-    def import_iter_feature_blobs(self, resultset, source, replacing_dataset=None):
+    def import_iter_feature_blobs(
+        self, repo, resultset, source, replacing_dataset=None
+    ):
         schema = source.schema
-        if replacing_dataset is not None and replacing_dataset.schema != source.schema:
+        if replacing_dataset:
             # Optimisation: Try to avoid rewriting features for compatible schema changes.
-            change_types = replacing_dataset.schema.diff_type_counts(source.schema)
-            if not change_types["pk_updates"]:
-                # We can probably avoid rewriting all features.
-                for feature in resultset:
-                    try:
-                        pk_values = (feature[replacing_dataset.primary_key],)
-                        rel_path = self.encode_pks_to_path(pk_values, relative=True)
-                        existing_data = replacing_dataset.get_data_at(
-                            rel_path, as_memoryview=True
-                        )
-                    except KeyError:
-                        # this feature isn't in the dataset we're replacing
-                        yield self.encode_feature(feature, schema)
-                        continue
+            # this can take some time, but often results in much fewer git objects produced.
+            # For example, consider revision A with this feature:
+            #   {"a": 1, "b": 2}
+            # Now at revision B we add a nullable column, so the new version of the feature is:
+            #   {"a": 1, "b": 2, "c": NULL}
+            # In this situation, during the import of revision B, we can avoid writing the
+            # new blob, because the existing feature blob from revision A can be 'upgraded'
+            # to the new schema without changing anything.
+            #
+            # This optimisation is useful in the following situations:
+            #  * a column was added but some values remain NULL (example above)
+            #  * a column was dropped, and some rows have no other values changed
+            for feature in resultset:
+                try:
+                    pk_values = (feature[replacing_dataset.primary_key],)
+                    rel_path = self.encode_pks_to_path(pk_values, relative=True)
+                    existing_data = replacing_dataset.get_data_at(
+                        rel_path, as_memoryview=True
+                    )
+                except KeyError:
+                    # this feature isn't in the dataset we're replacing
+                    yield self.encode_feature(feature, schema)
+                    continue
 
-                    existing_feature_raw_dict = replacing_dataset.get_raw_feature_dict(
-                        pk_values, data=existing_data
-                    )
-                    # This adapts the existing feature to the new schema
-                    existing_feature = schema.feature_from_raw_dict(
-                        existing_feature_raw_dict
-                    )
-                    if existing_feature == feature:
-                        # Nothing changed? No need to rewrite the feature blob
-                        yield self.encode_pks_to_path(pk_values), existing_data
-                    else:
-                        yield self.encode_feature(feature, schema)
-                return
-        for feature in resultset:
-            yield self.encode_feature(feature, schema)
+                existing_feature_raw_dict = replacing_dataset.get_raw_feature_dict(
+                    pk_values, data=existing_data
+                )
+                # This adapts the existing feature to the new schema
+                existing_feature = schema.feature_from_raw_dict(
+                    existing_feature_raw_dict
+                )
+                if existing_feature == feature:
+                    # Nothing changed? No need to rewrite the feature blob
+                    yield self.encode_pks_to_path(pk_values), existing_data
+                else:
+                    yield self.encode_feature(feature, schema)
+        else:
+            for feature in resultset:
+                yield self.encode_feature(feature, schema)
 
     def apply_meta_diff(
         self, meta_diff, tree_builder, *, allow_missing_old_values=False


### PR DESCRIPTION
## Description

When importing features, if there is also a schema change, we compare new blobs against corresponding existing blobs. This is so we can avoid writing subtly-different-but equivalent blobs to the repo unnecessarily.

This is a slow process since we need to fetch all the blobs to do that, so until now we were only running the comparison when a schema change occurred in the commit.

However, during a discussion with @olsen232 we realised that a later non-schema-change commit also needs to run the feature blob comparison, since any features imported with the new schema will vary from the previously-imported feature blob with the old schema.

This PR makes that adjustment (run the feature blob comparison during any import in a repo which has previously had a schema change).

Of necessity I looked into performance to try and mitigate the impact this would have. I found a couple of things which are helpful:

* d1f5dbd9f7f46fc666dfccde6423b69047ecff71 sped up the feature comparison by ~30-40% 👍 
* Increasing the libgit2 object cache size to allow for all sno's tree objects improved the performance by a _further_ ~80-90%.

For reference in a repo with 1M features on my laptop, I achieved the following results for the first 200K features imported in the followup revision:

* no feature comparison, on master: `200,000 features... @11.7s`
* with feature comparison before d1f5dbd9f7f46fc666dfccde6423b69047ecff71: `200,000 features... @68.5s`
* with feature comparison after d1f5dbd9f7f46fc666dfccde6423b69047ecff71: `200,000 features... @47.8s`
* with feature comparison after this PR: `200,000 features... @16.5s`

This also speeds up `sno show` on a large (1M rows imported) commit by 3.5x (4m38 --> 1m45), I guess due to the same issue of trees being looked up repeatedly.

## Related links:

https://github.com/libgit2/libgit2/blob/508361401fbb5d87118045eaeae3356a729131aa/include/git2/common.h#L266

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
