### PR TITLE
postgis WC: Avoid INSERT to spatial_ref_sys

### DIFF
--- a/sno/working_copy/postgis_adapter.py
+++ b/sno/working_copy/postgis_adapter.py
@@ -222,7 +222,6 @@ def generate_postgis_spatial_ref_sys(v2_obj):
     The result is a list containing a dict per table row.
     Each dict has the format {column-name: value}.
     """
-    # TODO - this is not yet written anywhere.
     result = []
     for crs_name, definition in v2_obj.crs_definitions():
         spatial_ref = SpatialReference(definition)


### PR DESCRIPTION
## Description

Unless user is doing something rather exotic with custom CRSes, there's
no need to write to spatial_ref_sys. The existing code acknowledges
this, but still does an INSERT (with a fallback to ON CONFLICT UPDATE)

However doing an INSERT requires additional privileges beyond what might
be expected. We only need read-only access to spatial_ref_sys
for normal operation.

This commit does a SELECT first to determine if an INSERT is really
necessary, so that in most cases we don't need INSERT perm on the table.


## Related links:
.

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
