### PR TITLE
diff: Add a way to get diff size estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
 
+## 0.9.0 (UNRELEASED)
+
+* `diff` now accepts `--only-feature-count`, which produces a feature count for the diff. The feature count can be exact or a fast estimate.
+* `log` now accepts `--with-feature-count` which adds a feature count to each commit when used with `-o json`. The feature count can be exact or a fast estimate.
+
 ## 0.8.0
 
 ### Breaking changes

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -245,13 +245,9 @@ def feature_count_diff(
 
     repo = ctx.obj.repo
     base_rs, target_rs, working_copy = _parse_diff_commit_spec(repo, commit_spec)
-    if working_copy:
-        raise NotImplementedError(
-            "--only-feature-count isn't supported for working-copy diffs yet"
-        )
 
     dataset_change_counts = diff_estimation.estimate_diff_feature_counts(
-        base_rs, target_rs, accuracy
+        base_rs, target_rs, working_copy, accuracy
     )
 
     if output_format == "text":

--- a/sno/diff.py
+++ b/sno/diff.py
@@ -1,9 +1,6 @@
 import logging
 import re
-import statistics
-import subprocess
 import sys
-import time
 from pathlib import Path
 
 import click
@@ -26,6 +23,7 @@ from .exceptions import (
 from .filter_util import build_feature_filter, UNFILTERED
 from .output_util import dump_json_output
 from .repo import SnoRepoState
+from . import diff_estimation
 
 
 L = logging.getLogger("sno.diff")
@@ -233,61 +231,6 @@ def diff_with_writer(
             sys.exit(1)
 
 
-FEATURE_SUBTREES_PER_TREE = 256
-FEATURE_TREE_NESTING = 2
-MAX_TREES = FEATURE_SUBTREES_PER_TREE ** FEATURE_TREE_NESTING
-
-
-def _feature_count_sample_trees(rev_spec, feature_path, num_trees):
-    num_full_subtrees = num_trees // 256
-    paths = [f"{feature_path}{n:02x}" for n in range(num_full_subtrees)]
-    paths.extend(
-        [
-            f"{feature_path}{num_full_subtrees:02x}/{n:02x}"
-            for n in range(num_trees % 256)
-        ]
-    )
-
-    p = subprocess.Popen(
-        [
-            "git",
-            "diff",
-            "--name-only",
-            "--no-renames",
-            rev_spec,
-            "--",
-            *paths,
-        ],
-        stdout=subprocess.PIPE,
-        encoding="utf-8",
-    )
-    tree_samples = {}
-    for line in p.stdout:
-        # path/to/dataset/.sno-dataset/feature/ab/cd/abcdef123
-        # --> ab/cd
-        root, tree, subtree, basename = line.rsplit("/", 3)
-        k = f"{tree}/{subtree}"
-        tree_samples.setdefault(k, 0)
-        tree_samples[k] += 1
-    p.wait()
-    r = list(tree_samples.values())
-    r.extend([0] * (num_trees - len(r)))
-    return r
-
-
-Z_SCORES = {
-    0.50: 0.0,
-    0.60: 0.26,
-    0.70: 0.53,
-    0.75: 0.68,
-    0.80: 0.85,
-    0.85: 1.04,
-    0.90: 1.29,
-    0.95: 1.65,
-    0.99: 2.33,
-}
-
-
 def feature_count_diff(
     ctx,
     output_format,
@@ -307,118 +250,9 @@ def feature_count_diff(
             "--only-feature-count isn't supported for working-copy diffs yet"
         )
 
-    if base_rs == target_rs:
-        return {}
-
-    base_ds_paths = {ds.path for ds in base_rs.datasets}
-    target_ds_paths = {ds.path for ds in target_rs.datasets}
-    all_ds_paths = base_ds_paths | target_ds_paths
-    rev_spec = f"{base_rs.tree.id}..{target_rs.tree.id}"
-
-    dataset_change_counts = {}
-    for dataset_path in all_ds_paths:
-        base_ds = base_rs.datasets.get(dataset_path)
-        target_ds = target_rs.datasets.get(dataset_path)
-
-        if not base_ds:
-            base_ds, target_ds = target_ds, base_ds
-        elif target_ds:
-            if base_ds.feature_tree == target_ds.feature_tree:
-                continue
-
-        # Come up with a list of trees to diff.
-        # TODO: decouple this stuff from dataset2 a bit (?)
-        feature_path = f"{base_ds.path}/{base_ds.FEATURE_PATH}"
-        if accuracy == "exact":
-            ds_total = sum(
-                _feature_count_sample_trees(rev_spec, feature_path, MAX_TREES)
-            )
-        else:
-            if accuracy == "veryfast":
-                # only ever sample two trees
-                sample_size = 2
-                required_confidence = 0.00001
-                z_score = 0.0
-            else:
-                if accuracy == "fast":
-                    sample_size = 2
-                    required_confidence = 0.60
-                elif accuracy == "medium":
-                    sample_size = 8
-                    required_confidence = 0.80
-                elif accuracy == "good":
-                    sample_size = 16
-                    required_confidence = 0.95
-                z_score = Z_SCORES[required_confidence]
-
-            confidence_interval = (-1, -1)
-            sample_mean = 0
-            while sample_size <= MAX_TREES and (
-                sample_mean < confidence_interval[0]
-                or sample_mean > confidence_interval[1]
-            ):
-                L.debug(f"sampling %d trees for dataset %s", sample_size, dataset_path)
-                t1 = time.monotonic()
-                samples = _feature_count_sample_trees(
-                    rev_spec, feature_path, sample_size
-                )
-                sample_mean = statistics.mean(samples)
-                sample_stdev = statistics.stdev(samples)
-
-                t2 = time.monotonic()
-                if accuracy == "veryfast":
-                    # even if no features were found in the two trees, call it done.
-                    # this will be Good Enough if all you need to know is something like
-                    # "is the diff size probably less than 100K features?"
-                    break
-                if sample_mean == 0:
-                    # no features were encountered in the sample.
-                    # this is likely a very small diff.
-                    # let's just sample a lot more trees.
-                    new_sample_size = sample_size * 1024
-                    if new_sample_size > MAX_TREES:
-                        L.debug(
-                            "sampled %s trees in %.3fs, found 0 features; stopping",
-                            sample_size,
-                            t2 - t1,
-                        )
-                    else:
-                        L.debug(
-                            "sampled %s trees in %.3fs, found 0 features; increased sample size to %d",
-                            sample_size,
-                            t2 - t1,
-                            new_sample_size,
-                        )
-                    sample_size = new_sample_size
-                    continue
-
-                # try and get within 10% of the real mean.
-                margin_of_error = 0.10 * sample_mean
-                required_sample_size = min(
-                    MAX_TREES, (z_score * sample_stdev / margin_of_error) ** 2
-                )
-                L.debug(
-                    "sampled %s trees in %.3fs (ƛ=%.3f, s=%.3f). required: %.1f (margin: %.1f; confidence: %d%%)",
-                    sample_size,
-                    t2 - t1,
-                    sample_mean,
-                    sample_stdev,
-                    required_sample_size,
-                    margin_of_error * MAX_TREES,
-                    required_confidence * 100,
-                )
-                if sample_size >= required_sample_size:
-                    break
-
-                if sample_size == MAX_TREES:
-                    break
-                while sample_size < required_sample_size:
-                    sample_size *= 2
-                sample_size = min(MAX_TREES, sample_size)
-            ds_total = int(round(sample_mean * MAX_TREES))
-
-        if ds_total:
-            dataset_change_counts[dataset_path] = ds_total
+    dataset_change_counts = diff_estimation.estimate_diff_feature_counts(
+        base_rs, target_rs, accuracy
+    )
 
     if output_format == "text":
         if dataset_change_counts:
@@ -470,7 +304,7 @@ def feature_count_diff(
 @click.option(
     "--only-feature-count",
     default=None,
-    type=click.Choice(["veryfast", "fast", "medium", "good", "exact"]),
+    type=click.Choice(diff_estimation.ACCURACY_CHOICES),
     help=(
         "Returns only a feature count (the number of features modified in this diff). "
         "If the value is 'exact', the feature count is exact (this may be slow.) "

--- a/sno/diff_estimation.py
+++ b/sno/diff_estimation.py
@@ -95,7 +95,10 @@ def estimate_diff_feature_counts(
                 working_copy,
                 dataset_path,
             )
-            ds_total = len(ds_diff["feature"])
+            if "feature" not in ds_diff:
+                ds_total = 0
+            else:
+                ds_total = len(ds_diff["feature"])
         else:
             base_ds = base_rs.datasets.get(dataset_path)
             target_ds = target_rs.datasets.get(dataset_path)

--- a/sno/diff_estimation.py
+++ b/sno/diff_estimation.py
@@ -1,0 +1,186 @@
+import logging
+import statistics
+import subprocess
+import time
+
+FEATURE_SUBTREES_PER_TREE = 256
+FEATURE_TREE_NESTING = 2
+MAX_TREES = FEATURE_SUBTREES_PER_TREE ** FEATURE_TREE_NESTING
+
+L = logging.getLogger("sno.diff_estimation")
+Z_SCORES = {
+    0.50: 0.0,
+    0.60: 0.26,
+    0.70: 0.53,
+    0.75: 0.68,
+    0.80: 0.85,
+    0.85: 1.04,
+    0.90: 1.29,
+    0.95: 1.65,
+    0.99: 2.33,
+}
+
+
+def _feature_count_sample_trees(rev_spec, feature_path, num_trees):
+    num_full_subtrees = num_trees // 256
+    paths = [f"{feature_path}{n:02x}" for n in range(num_full_subtrees)]
+    paths.extend(
+        [
+            f"{feature_path}{num_full_subtrees:02x}/{n:02x}"
+            for n in range(num_trees % 256)
+        ]
+    )
+
+    p = subprocess.Popen(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--no-renames",
+            rev_spec,
+            "--",
+            *paths,
+        ],
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    tree_samples = {}
+    for line in p.stdout:
+        # path/to/dataset/.sno-dataset/feature/ab/cd/abcdef123
+        # --> ab/cd
+        root, tree, subtree, basename = line.rsplit("/", 3)
+        k = f"{tree}/{subtree}"
+        tree_samples.setdefault(k, 0)
+        tree_samples[k] += 1
+    p.wait()
+    r = list(tree_samples.values())
+    r.extend([0] * (num_trees - len(r)))
+    return r
+
+
+ACCURACY_CHOICES = ("veryfast", "fast", "medium", "good", "exact")
+
+
+def estimate_diff_feature_counts(
+    base_rs,
+    target_rs,
+    accuracy,
+):
+    """
+    Estimates feature counts for each dataset in the given diff.
+    Returns a dict (keys are dataset paths; values are feature counts)
+    Datasets with (probably) no features changed are not present in the dict.
+    `accuracy` should be one of ACCURACY_CHOICES
+    """
+    if base_rs == target_rs:
+        return {}
+
+    assert accuracy in ACCURACY_CHOICES
+
+    base_ds_paths = {ds.path for ds in base_rs.datasets}
+    target_ds_paths = {ds.path for ds in target_rs.datasets}
+    all_ds_paths = base_ds_paths | target_ds_paths
+    rev_spec = f"{base_rs.tree.id}..{target_rs.tree.id}"
+
+    dataset_change_counts = {}
+    for dataset_path in all_ds_paths:
+        base_ds = base_rs.datasets.get(dataset_path)
+        target_ds = target_rs.datasets.get(dataset_path)
+
+        if not base_ds:
+            base_ds, target_ds = target_ds, base_ds
+        elif target_ds:
+            if base_ds.feature_tree == target_ds.feature_tree:
+                continue
+
+        # Come up with a list of trees to diff.
+        # TODO: decouple this stuff from dataset2 a bit (?)
+        feature_path = f"{base_ds.path}/{base_ds.FEATURE_PATH}"
+        if accuracy == "exact":
+            ds_total = sum(
+                _feature_count_sample_trees(rev_spec, feature_path, MAX_TREES)
+            )
+        else:
+            if accuracy == "veryfast":
+                # only ever sample two trees
+                sample_size = 2
+                required_confidence = 0.00001
+                z_score = 0.0
+            else:
+                if accuracy == "fast":
+                    sample_size = 2
+                    required_confidence = 0.60
+                elif accuracy == "medium":
+                    sample_size = 8
+                    required_confidence = 0.80
+                elif accuracy == "good":
+                    sample_size = 16
+                    required_confidence = 0.95
+                z_score = Z_SCORES[required_confidence]
+
+            sample_mean = 0
+            while sample_size <= MAX_TREES:
+                L.debug("sampling %d trees for dataset %s", sample_size, dataset_path)
+                t1 = time.monotonic()
+                samples = _feature_count_sample_trees(
+                    rev_spec, feature_path, sample_size
+                )
+                sample_mean = statistics.mean(samples)
+                sample_stdev = statistics.stdev(samples)
+
+                t2 = time.monotonic()
+                if accuracy == "veryfast":
+                    # even if no features were found in the two trees, call it done.
+                    # this will be Good Enough if all you need to know is something like
+                    # "is the diff size probably less than 100K features?"
+                    break
+                if sample_mean == 0:
+                    # no features were encountered in the sample.
+                    # this is likely quite a small diff.
+                    # let's just sample a lot more trees.
+                    new_sample_size = sample_size * 1024
+                    if new_sample_size > MAX_TREES:
+                        L.debug(
+                            "sampled %s trees in %.3fs, found 0 features; stopping",
+                            sample_size,
+                            t2 - t1,
+                        )
+                    else:
+                        L.debug(
+                            "sampled %s trees in %.3fs, found 0 features; increased sample size to %d",
+                            sample_size,
+                            t2 - t1,
+                            new_sample_size,
+                        )
+                    sample_size = new_sample_size
+                    continue
+
+                # try and get within 10% of the real mean.
+                margin_of_error = 0.10 * sample_mean
+                required_sample_size = min(
+                    MAX_TREES, (z_score * sample_stdev / margin_of_error) ** 2
+                )
+                L.debug(
+                    "sampled %s trees in %.3fs (ƛ=%.3f, s=%.3f). required: %.1f (margin: %.1f; confidence: %d%%)",
+                    sample_size,
+                    t2 - t1,
+                    sample_mean,
+                    sample_stdev,
+                    required_sample_size,
+                    margin_of_error * MAX_TREES,
+                    required_confidence * 100,
+                )
+                if sample_size >= required_sample_size:
+                    break
+
+                if sample_size == MAX_TREES:
+                    break
+                while sample_size < required_sample_size:
+                    sample_size *= 2
+                sample_size = min(MAX_TREES, sample_size)
+            ds_total = int(round(sample_mean * MAX_TREES))
+
+        if ds_total:
+            dataset_change_counts[dataset_path] = ds_total
+
+    return dataset_change_counts

--- a/sno/log.py
+++ b/sno/log.py
@@ -38,7 +38,7 @@ from . import diff_estimation
     hidden=True,
 )
 @click.option(
-    "--with-feature-counts",
+    "--with-feature-count",
     default=None,
     type=click.Choice(diff_estimation.ACCURACY_CHOICES),
     help=(
@@ -48,7 +48,7 @@ from . import diff_estimation
     ),
 )
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
-def log(ctx, output_format, json_style, do_dataset_changes, with_feature_counts, args):
+def log(ctx, output_format, json_style, do_dataset_changes, with_feature_count, args):
     """ Show commit logs """
     if output_format == "text":
         execvp("git", ["git", "-C", ctx.obj.repo.path, "log"] + list(args))
@@ -85,7 +85,7 @@ def log(ctx, output_format, json_style, do_dataset_changes, with_feature_counts,
                 refs,
                 do_dataset_changes,
                 dataset_change_cache,
-                with_feature_counts,
+                with_feature_count,
             )
             for (commit_id, refs) in commit_ids_and_refs_log
         ]
@@ -109,7 +109,7 @@ def commit_obj_to_json(
     refs=None,
     do_dataset_changes=False,
     dataset_change_cache={},
-    with_feature_counts=None,
+    with_feature_count=None,
 ):
     """Given a commit object, returns a dict ready for dumping as JSON."""
     author = commit.author
@@ -147,7 +147,7 @@ def commit_obj_to_json(
         result["datasetChanges"] = get_dataset_changes(
             repo, commit, dataset_change_cache
         )
-    if with_feature_counts:
+    if with_feature_count:
         if (not do_dataset_changes) or result["datasetChanges"]:
             try:
                 parent_commit = commit.parents[0]
@@ -159,7 +159,7 @@ def commit_obj_to_json(
 
             target_rs = repo.structure(commit)
             result["featureChanges"] = diff_estimation.estimate_diff_feature_counts(
-                base_rs, target_rs, working_copy=None, accuracy=with_feature_counts
+                base_rs, target_rs, working_copy=None, accuracy=with_feature_count
             )
         else:
             result["featureChanges"] = {}

--- a/sno/log.py
+++ b/sno/log.py
@@ -159,7 +159,7 @@ def commit_obj_to_json(
 
             target_rs = repo.structure(commit)
             result["featureChanges"] = diff_estimation.estimate_diff_feature_counts(
-                base_rs, target_rs, accuracy=with_feature_counts
+                base_rs, target_rs, working_copy=None, accuracy=with_feature_counts
             )
         else:
             result["featureChanges"] = {}

--- a/tests/test_diff_feature_count.py
+++ b/tests/test_diff_feature_count.py
@@ -1,0 +1,128 @@
+import json
+
+import pytest
+
+from sno.repo import SnoRepo
+
+H = pytest.helpers.helpers()
+
+
+@pytest.mark.parametrize(
+    "head_sha,head1_sha",
+    [
+        pytest.param(H.POINTS.HEAD_SHA, H.POINTS.HEAD1_SHA, id="commit_hash"),
+        pytest.param(H.POINTS.HEAD_TREE_SHA, H.POINTS.HEAD1_TREE_SHA, id="tree_hash"),
+    ],
+)
+@pytest.mark.parametrize(
+    "accuracy",
+    ["exact", "fast"],
+)
+def test_feature_count_noops(
+    head_sha, head1_sha, accuracy, data_archive_readonly, cli_runner
+):
+    NOOP_SPECS = (
+        f"{head_sha[:6]}...{head_sha[:6]}",
+        f"{head_sha}...{head_sha}",
+        f"{head1_sha}...{head1_sha}",
+        "HEAD^1...HEAD^1",
+        f"{head_sha}...",
+        f"...{head_sha}",
+    )
+
+    with data_archive_readonly("points"):
+        for spec in NOOP_SPECS:
+            print(f"noop: {spec}")
+            r = cli_runner.invoke(["diff", f"--only-feature-count={accuracy}", spec])
+            assert r.exit_code == 0, r
+
+
+def test_feature_count_commits_exact(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points"):
+        r = cli_runner.invoke(["diff", "--only-feature-count=exact", "HEAD^...HEAD"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "nz_pa_points_topo_150k:",
+            "\t5 features changed",
+        ]
+
+
+def test_feature_count_commits_json_output(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points"):
+        r = cli_runner.invoke(
+            ["diff", "--only-feature-count=exact", "HEAD^...HEAD", "-o", "json"]
+        )
+        assert r.exit_code == 0, r.stderr
+        assert json.loads(r.stdout) == {"nz_pa_points_topo_150k": 5}
+
+
+def test_feature_count_commits_veryfast(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points"):
+        r = cli_runner.invoke(["diff", "--only-feature-count=veryfast", "HEAD^...HEAD"])
+        assert r.exit_code == 0, r.stderr
+
+        # we get "0 features changed" because veryfast only ever samples 1/65536 trees.
+        assert r.stdout.splitlines() == [
+            "0 features changed",
+        ]
+
+
+def test_feature_count_commits_fast(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points"):
+        r = cli_runner.invoke(["diff", "--only-feature-count=fast", "HEAD^...HEAD"])
+        assert r.exit_code == 0, r.stderr
+
+        assert r.stdout.splitlines() == [
+            "nz_pa_points_topo_150k:",
+            "\t5 features changed",
+        ]
+
+
+def test_feature_count_no_working_copy(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points"):
+        r = cli_runner.invoke(["diff", "--only-feature-count=fast", "HEAD^"])
+        # No working copy
+        assert r.exit_code == 45, r.stderr
+
+
+def test_feature_count_with_working_copy(data_working_copy, cli_runner):
+    with data_working_copy("points") as (repo_path, wc):
+        # empty
+        r = cli_runner.invoke(["diff", "--only-feature-count=exact", "HEAD"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "0 features changed",
+        ]
+
+        # make some changes
+        repo = SnoRepo(repo_path)
+        with repo.working_copy.session() as sess:
+            # this actually undoes a change from the HEAD commit
+            r = sess.execute(
+                f"UPDATE {H.POINTS.LAYER} SET name_ascii=NULL, name=NULL WHERE fid = 1166;"
+            )
+            assert r.rowcount == 1
+
+        r = cli_runner.invoke(["diff", "--only-feature-count=exact", "HEAD"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "nz_pa_points_topo_150k:",
+            "\t1 features changed",
+        ]
+
+        # 'exact' diff has 4 features changed - HEAD had 5 but one change was undone by the working copy
+        r = cli_runner.invoke(["diff", "--only-feature-count=exact", "HEAD^"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "nz_pa_points_topo_150k:",
+            "\t4 features changed",
+        ]
+
+        # other accuracy settings just add the WC count to the committed diff count,
+        # so we get 6 here instead of 4.
+        r = cli_runner.invoke(["diff", "--only-feature-count=good", "HEAD^"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "nz_pa_points_topo_150k:",
+            "\t6 features changed",
+        ]

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -115,7 +115,7 @@ def test_log_with_feature_count(data_archive_readonly, cli_runner):
     """ review commit history """
     with data_archive_readonly("points"):
         r = cli_runner.invoke(
-            ["log", "--output-format=json", "--with-feature-counts=exact"]
+            ["log", "--output-format=json", "--with-feature-count=exact"]
         )
         assert r.exit_code == 0, r
         result = json.loads(r.stdout)
@@ -125,7 +125,7 @@ def test_log_with_feature_count(data_archive_readonly, cli_runner):
             {"nz_pa_points_topo_150k": 2143},
         ]
         r = cli_runner.invoke(
-            ["log", "--output-format=json", "--with-feature-counts=good"]
+            ["log", "--output-format=json", "--with-feature-count=good"]
         )
         assert r.exit_code == 0, r
         result = json.loads(r.stdout)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -109,3 +109,28 @@ def test_log_shallow_clone(
                     "abbrevParents": ["7bc3b56f20d1559208bcf5bb56860dda6e190b70"],
                 },
             ]
+
+
+def test_log_with_feature_count(data_archive_readonly, cli_runner):
+    """ review commit history """
+    with data_archive_readonly("points"):
+        r = cli_runner.invoke(
+            ["log", "--output-format=json", "--with-feature-counts=exact"]
+        )
+        assert r.exit_code == 0, r
+        result = json.loads(r.stdout)
+        result = [c["featureChanges"] for c in result]
+        assert result == [
+            {"nz_pa_points_topo_150k": 5},
+            {"nz_pa_points_topo_150k": 2143},
+        ]
+        r = cli_runner.invoke(
+            ["log", "--output-format=json", "--with-feature-counts=good"]
+        )
+        assert r.exit_code == 0, r
+        result = json.loads(r.stdout)
+        result = [c["featureChanges"] for c in result]
+        assert result == [
+            {"nz_pa_points_topo_150k": 5},
+            {"nz_pa_points_topo_150k": 2480},
+        ]


### PR DESCRIPTION
## Description

Large diffs are currently quite slow. Even if we can optimise a lot,
it's not uncommon to diff an import commit and produce 50M features
of output, which can take minutes/hours to generate and be
difficult or impossible to handle.

This change adds a size estimate feature so scripts can avoid showing
large diffs altogether.

The feature is implemented via a flag:

```
  --only-feature-count [veryfast|fast|medium|good|exact]
                                  Returns only a feature count (the number of
                                  features modified in this diff). If the
                                  value is 'exact', the feature count is exact
                                  (this may be slow.) Otherwise, the feature
                                  count will be approximated with varying
                                  levels of accuracy.
```

`fast` is normally good enough for a ballpark estimate.


## strategies

The different values vary in strategy as well as confidence intervals.

* `veryfast` always samples only one of 65536 trees.
* `exact` always samples all 65536 trees.
* `fast`, `medium` and `good` all iterate until they achieve a particular confidence that the feature count is within 10% of the sample feature count. The algorithm is roughly:
    - start with `sample_size` trees (fast: 2, medium: 8, good: 16)
    - use the sampled trees to estimate the required sample size for a particular confidence interval (fast: 60%; medium: 80%; good: 95%)
    - if the sample size is >= the required sample size, stop (result is the sample mean multiplied by sample size). otherwise, repeat

One small sample seems to be plenty for a large diff, because each tree has enough features that there is a low variance in the results.

For smaller repos, the first sample often yields no features, or very few features, and we have to increase the sample size.

## examples

### `exact` (slow):

```
$ time sno diff e39a101444d721abc7f2105e5eb81ecce74011ca^...e39a101444d721abc7f2105e5eb81ecce74011ca --only-feature-count=exact
landonline_setup:
	1040738 features changed

real	2m2.328s
```

(note that generating the full diff takes 7m56s for this commit so even though 2m2 is slow, it's still a bit of a win if you need the exact feature count)


```
$ sno -vv diff cbc25ebc80a670ab1b092d18fd4f323c79b244f8^...cbc25ebc80a670ab1b092d18fd4f323c79b244f8 --only-feature-count=exact
nz_waca_adjustments:
	228 features changed
```

### `good`:

```
$ time sno -vv diff e39a101444d721abc7f2105e5eb81ecce74011ca^...e39a101444d721abc7f2105e5eb81ecce74011ca --only-feature-count=good
2021-04-13 14:13:28,719 T4690804160 DEBUG sno.diff [diff.py:360] - sampling 16 trees for dataset landonline_setup
2021-04-13 14:13:28,845 T4690804160 DEBUG sno.diff [diff.py:408] - sampled 16 trees in 0.126s (ƛ=15.562, s=3.346). required: 12.6 (margin: 101990.4; confidence: 95%)
landonline_setup:
	1019904 features changed

real	0m0.725s
```

```
$ time sno -vv diff cbc25ebc80a670ab1b092d18fd4f323c79b244f8^...cbc25ebc80a670ab1b092d18fd4f323c79b244f8 --only-feature-count=good
2021-04-13 14:18:10,208 T4521086400 DEBUG sno.diff [diff.py:360] - sampling 16 trees for dataset nz_waca_adjustments
2021-04-13 14:18:10,215 T4521086400 DEBUG sno.diff [diff.py:390] - sampled 16 trees in 0.007s, found 0 features; increased sample size to 16384
2021-04-13 14:18:10,215 T4521086400 DEBUG sno.diff [diff.py:360] - sampling 16384 trees for dataset nz_waca_adjustments
2021-04-13 14:18:10,260 T4521086400 DEBUG sno.diff [diff.py:408] - sampled 16384 trees in 0.045s (ƛ=0.004, s=0.062). required: 65536.0 (margin: 24.8; confidence: 95%)
2021-04-13 14:18:10,260 T4521086400 DEBUG sno.diff [diff.py:360] - sampling 65536 trees for dataset nz_waca_adjustments
2021-04-13 14:18:10,415 T4521086400 DEBUG sno.diff [diff.py:408] - sampled 65536 trees in 0.155s (ƛ=0.003, s=0.059). required: 65536.0 (margin: 22.8; confidence: 95%)
nz_waca_adjustments:
	228 features changed

real	0m0.795s
```

### `fast`:

```
$ time sno -vv diff e39a101444d721abc7f2105e5eb81ecce74011ca^...e39a101444d721abc7f2105e5eb81ecce74011ca --only-feature-count=fast
2021-04-13 14:12:41,661 T4425674176 DEBUG sno.diff [diff.py:360] - sampling 2 trees for dataset landonline_setup
2021-04-13 14:12:41,788 T4425674176 DEBUG sno.diff [diff.py:408] - sampled 2 trees in 0.127s (ƛ=13.500, s=0.707). required: 0.0 (margin: 88473.6; confidence: 60%)
landonline_setup:
	884736 features changed

real	0m0.739s
```

```
$ time sno -vv diff cbc25ebc80a670ab1b092d18fd4f323c79b244f8^...cbc25ebc80a670ab1b092d18fd4f323c79b244f8 --only-feature-count=fast
2021-04-13 14:18:36,896 T4787953088 DEBUG sno.diff [diff.py:360] - sampling 2 trees for dataset nz_waca_adjustments
2021-04-13 14:18:36,902 T4787953088 DEBUG sno.diff [diff.py:390] - sampled 2 trees in 0.007s, found 0 features; increased sample size to 2048
2021-04-13 14:18:36,902 T4787953088 DEBUG sno.diff [diff.py:360] - sampling 2048 trees for dataset nz_waca_adjustments
2021-04-13 14:18:36,913 T4787953088 DEBUG sno.diff [diff.py:408] - sampled 2048 trees in 0.011s (ƛ=0.003, s=0.054). required: 2301.8 (margin: 19.2; confidence: 60%)
2021-04-13 14:18:36,913 T4787953088 DEBUG sno.diff [diff.py:360] - sampling 4096 trees for dataset nz_waca_adjustments
2021-04-13 14:18:36,929 T4787953088 DEBUG sno.diff [diff.py:408] - sampled 4096 trees in 0.015s (ƛ=0.003, s=0.058). required: 1971.5 (margin: 22.4; confidence: 60%)
nz_waca_adjustments:
	224 features changed

real	0m0.634s
```

## todo:

- [x] add tests

## Related links:

- #405 is related (even with `veryfast` this command still takes a little while to run)

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
