### PR TITLE
Faster startup by delayed loading of commands

### DIFF
--- a/platforms/sno_cli.py
+++ b/platforms/sno_cli.py
@@ -1,4 +1,4 @@
 import sno.cli
 
 if __name__ == "__main__":
-    sno.cli.cli()
+    sno.cli.entrypoint()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     zip_safe=False,
     entry_points={
         "console_scripts": [
-            "sno = sno.cli:cli",
+            "sno = sno.cli:entrypoint",
         ],
     },
 )

--- a/sno.spec
+++ b/sno.spec
@@ -72,13 +72,16 @@ if is_darwin:
     # which isn't much use wrt unixODBC. And PyInstaller has no useful hooks.
     # TODO: when we upgrade PyInstaller this probably needs redoing
     import macholib.util
+
     macholib.util._orig_in_system_path = macholib.util.in_system_path
+
     def sno__in_system_path(filename):
         if re.match(r'/usr/local(/opt/unixodbc)?/lib/libodbc\.\d+\.dylib$', filename):
             print(f"❄️  Treating {filename} as a system library", file=sys.stderr)
             return True
         else:
             return macholib.util._orig_in_system_path(filename)
+
     macholib.util.in_system_path = sno__in_system_path
 
 
@@ -99,6 +102,7 @@ pyi_analysis = Analysis(
         '_cffi_backend',
         # via a cython module ???
         'csv',
+        *collect_submodules('sno'),
         *collect_submodules('sqlalchemy'),
     ],
     hookspath=[
@@ -216,7 +220,10 @@ if is_darwin:
                 if not os.path.exists(fpath) and not os.path.exists(
                     os.path.join(dist_bin_root, link_path)
                 ):
-                    print(f"❄️  ignoring broken link {relpath} -> {link_path}", file=sys.stderr)
+                    print(
+                        f"❄️  ignoring broken link {relpath} -> {link_path}",
+                        file=sys.stderr,
+                    )
                     # ignore broken symlinks (git-csvserver/git-shell)
                     continue
             elif subprocess.check_output(['file', '-b', fpath], text=True).startswith(
@@ -258,7 +265,10 @@ elif is_linux:
                 if not os.path.exists(fpath) and not os.path.exists(
                     os.path.join(dist_bin_root, link_path)
                 ):
-                    print(f"❄️  ignoring broken link {relpath} -> {link_path}", file=sys.stderr)
+                    print(
+                        f"❄️  ignoring broken link {relpath} -> {link_path}",
+                        file=sys.stderr,
+                    )
                     # ignore broken symlinks (git-csvserver/git-shell)
                     continue
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -193,7 +193,7 @@ class GenerateIDsFromFile(StringFromFile):
     default=True,
     help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
 )
-def import_table(
+def import_(
     ctx,
     all_tables,
     message,

--- a/sno/merge.py
+++ b/sno/merge.py
@@ -5,13 +5,16 @@ import click
 
 from . import commit
 from .cli_util import call_and_exit_flag, StringFromFile
-from .conflicts import (
-    list_conflicts,
-    conflicts_json_as_text,
-)
+from .conflicts import list_conflicts
 from .diff import get_repo_diff
 from .exceptions import InvalidOperation
-from .merge_util import AncestorOursTheirs, MergeIndex, MergeContext, ALL_MERGE_FILES
+from .merge_util import (
+    AncestorOursTheirs,
+    MergeIndex,
+    MergeContext,
+    ALL_MERGE_FILES,
+    merge_status_to_text,
+)
 from .output_util import dump_json_output
 from .repo import SnoRepoFiles, SnoRepoState
 from .structs import CommitWithReference
@@ -241,89 +244,6 @@ def complete_merging_state(ctx):
     # TODO - support json output
     click.echo(merge_status_to_text(merge_jdict, fresh=True))
     repo.gc("--auto")
-
-
-def merge_context_to_text(jdict):
-    theirs = jdict["theirs"]
-    ours = jdict["ours"]
-    theirs_branch = theirs.get("branch", None)
-    theirs_desc = (
-        f'branch "{theirs_branch}"' if theirs_branch else theirs["abbrevCommit"]
-    )
-    ours_desc = ours.get("branch", None) or ours["abbrevCommit"]
-    return f"Merging {theirs_desc} into {ours_desc}"
-
-
-def merge_status_to_text(jdict, fresh):
-    """
-    Converts the json output of sno merge (or of sno status, which uses
-    the same format during a merge) to text output.
-
-    jdict - the dictionary of json output.
-    fresh - True if we just arrived in this state due to a merge command,
-            False if the user is just checking the current state.
-    """
-    merging_text = merge_context_to_text(jdict["merging"])
-
-    if jdict.get("noOp", False):
-        return merging_text + "\nAlready up to date"
-
-    dry_run = jdict.get("dryRun", False)
-    commit = jdict.get("commit", None)
-
-    if jdict.get("fastForward", False):
-        if dry_run:
-            ff_text = (
-                f"Can fast-forward to {commit}\n"
-                "(Not actually fast-forwarding due to --dry-run)",
-            )
-        else:
-            ff_text = f"Fast-forwarded to {commit}"
-        return "\n".join([merging_text, ff_text])
-
-    conflicts = jdict.get("conflicts", None)
-    if not conflicts:
-        if dry_run:
-            no_conflicts_text = (
-                "No conflicts: merge will succeed!\n"
-                "(Not actually merging due to --dry-run)"
-            )
-        else:
-            if fresh:
-                no_conflicts_text = f"No conflicts!\nMerge commited as {commit}"
-            else:
-                no_conflicts_text = (
-                    f"No conflicts!\nUse `sno merge --continue` to complete the merge"
-                )
-        return "\n".join([merging_text, no_conflicts_text])
-
-    conflicts_header = "Conflicts found:" if fresh else "Conflicts:"
-    conflicts_text = "\n\n".join([conflicts_header, conflicts_json_as_text(conflicts)])
-
-    if dry_run:
-        dry_run_text = "(Not actually merging due to --dry-run)"
-        return "\n".join([merging_text, conflicts_text, dry_run_text])
-
-    conflicts_help_text = (
-        "View conflicts with `sno conflicts` and resolve them with `sno resolve`.\n"
-        "Once no conflicts remain, complete this merge with `sno merge --continue`.\n"
-        "Or use `sno merge --abort` to return to the previous state."
-    )
-    is_in = "is now in" if fresh else "is in"
-    repo_state_text = f'Repository {is_in} "merging" state.'
-
-    if fresh:
-        # When the user performs a merge, we format the output as follows:
-        # 1. Merging X and Y. 2. Conflicts found: XYZ. 3. Repo is now in merging state.
-        return "\n".join(
-            [merging_text, conflicts_text, repo_state_text, conflicts_help_text]
-        )
-    else:
-        # When the user requests the current status, we format the output as follows:
-        # 1. Repo is in merging state. 2. Merging X and Y. 3. Conflicts: XYZ.
-        return "\n".join(
-            [repo_state_text, merging_text, conflicts_text, conflicts_help_text]
-        )
 
 
 @click.command()

--- a/sno/status.py
+++ b/sno/status.py
@@ -5,8 +5,7 @@ import pygit2
 
 from .conflicts import list_conflicts
 from .output_util import dump_json_output
-from .merge import merge_status_to_text
-from .merge_util import MergeContext, MergeIndex
+from .merge_util import MergeContext, MergeIndex, merge_status_to_text
 from .repo import SnoRepoState
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -363,7 +363,7 @@ class SnoCliRunner(CliRunner):
         super().__init__(*args, mix_stderr=mix_stderr, **kwargs)
 
     def invoke(self, args=None, **kwargs):
-        from sno.cli import cli
+        from sno.cli import load_commands_from_args, cli
 
         if args:
             # force everything to strings (eg. PathLike objects, numbers)
@@ -374,6 +374,7 @@ class SnoCliRunner(CliRunner):
         params = {"catch_exceptions": not self._in_pdb}
         params.update(kwargs)
 
+        load_commands_from_args(args)
         r = super().invoke(cli, args=args, **params)
 
         L.debug("Command result: %s (%s)", r.exit_code, repr(r))


### PR DESCRIPTION

## Description

This trims ~150ms from startup in my dev setup, by just avoiding
import of all commands at startup.

We load the one command that's being run, unless we don't recognise
any command, or the user is running `help` (we need to load all commands
to provide useful help text)


## TODO

* [x] make the tests pass

## Related links:

re #405


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
