### PR TITLE
Make sno repos support kart branding

### DIFF
--- a/sno/__init__.py
+++ b/sno/__init__.py
@@ -56,7 +56,7 @@ else:
     os.environ["GIT_TEMPLATE_DIR"] = os.path.join(
         prefix, "share", "git-core", "templates"
     )
-# See LockedGitIndex in.repo.py:
+# See locked_git_index in.repo.py:
 os.environ["GIT_INDEX_FILE"] = os.path.join(".sno", "unlocked_index")
 
 # GDAL Data

--- a/sno/checkout.py
+++ b/sno/checkout.py
@@ -384,14 +384,14 @@ def create_workingcopy(ctx, delete_existing, discard_changes, new_wc_loc):
             "Can't create a working copy for an empty repository — first import some data with `sno import`"
         )
 
-    old_wc_loc = repo.workingcopy_path
+    old_wc_loc = repo.workingcopy_location
     if not new_wc_loc and old_wc_loc is not None:
         new_wc_loc = old_wc_loc
     elif not new_wc_loc:
-        new_wc_loc = BaseWorkingCopy.default_location(repo.workdir_path)
+        new_wc_loc = BaseWorkingCopy.default_location(repo)
 
     if new_wc_loc != old_wc_loc:
-        BaseWorkingCopy.check_valid_creation_location(new_wc_loc, repo.workdir_path)
+        BaseWorkingCopy.check_valid_creation_location(new_wc_loc, repo)
 
     if old_wc_loc:
         old_wc = BaseWorkingCopy.get_at_location(
@@ -461,3 +461,8 @@ def create_workingcopy(ctx, delete_existing, discard_changes, new_wc_loc):
 
     BaseWorkingCopy.write_config(repo, new_wc_loc)
     reset_wc_if_needed(repo, repo.head_commit)
+
+    # This command is used in tests and by other commands, so we have to be extra careful to
+    # tidy up properly - otherwise, tests can fail (on Windows especially) due to PermissionError.
+    repo.free()
+    del repo

--- a/sno/cli.py
+++ b/sno/cli.py
@@ -38,7 +38,7 @@ MODULE_COMMANDS = {
     "show": {"create-patch", "show"},
     "status": {"status"},
     "query": {"query"},
-    "upgrade": {"upgrade", "upgrade-to-tidy"},
+    "upgrade": {"upgrade", "upgrade-to-tidy", "upgrade-to-kart"},
 }
 
 

--- a/sno/fsck.py
+++ b/sno/fsck.py
@@ -39,19 +39,18 @@ def fsck(ctx, reset_datasets, fsck_args):
 
     # now check our stuff:
     # 1. working copy
-    if "sno.workingcopy.path" not in repo.config:
-        click.echo("No working-copy configured")
+    if not repo.workingcopy_location:
+        click.echo("No working copy configured")
         return
 
-    working_copy_path = repo.config["sno.workingcopy.path"]
     working_copy = repo.working_copy
     if not working_copy:
         raise NotFound(
-            click.style(f"Working copy missing: {working_copy_path}", fg="red"),
+            click.style(f"Working copy missing: {working_copy}", fg="red"),
             exit_code=NO_WORKING_COPY,
         )
 
-    click.secho(f"✔︎ Working copy: {working_copy_path}", fg="green")
+    click.secho(f"✔︎ Working copy: {working_copy}", fg="green")
 
     if reset_datasets:
         click.secho(

--- a/sno/init.py
+++ b/sno/init.py
@@ -20,7 +20,7 @@ from .import_source import ImportSource
 from .ogr_import_source import OgrImportSource, FORMAT_TO_OGR_MAP
 from .pk_generation import PkGeneratingImportSource
 from .fast_import import fast_import_tables, ReplaceExisting
-from .repo import SnoRepo
+from .repo import SnoRepo, PotentialRepo
 from .working_copy import WorkingCopyStatus
 
 
@@ -376,11 +376,14 @@ def import_(
     ),
 )
 @click.option(
+    "--workingcopy-location",
     "--workingcopy-path",
     "--workingcopy",
-    "wc_path",
-    help="Path where the working copy should be created. "
-    "This should be a GPKG file eg example.gpkg or a postgres URI including schema eg postgresql://[HOST]/DBNAME/SCHEMA",
+    "wc_location",
+    help="Location where the working copy should be created. This should be in one of the following formats:\n"
+    "- PATH.gpkg\n"
+    "- postgresql://[HOST]/DBNAME/SCHEMA\n"
+    "- mssql://[HOST]/DBNAME/SHEMA\n",
 )
 @click.option(
     "--max-delta-depth",
@@ -397,7 +400,7 @@ def init(
     do_checkout,
     bare,
     initial_branch,
-    wc_path,
+    wc_location,
     max_delta_depth,
 ):
     """
@@ -414,7 +417,7 @@ def init(
 
     from sno.working_copy.base import BaseWorkingCopy
 
-    BaseWorkingCopy.check_valid_creation_location(wc_path, repo_path)
+    BaseWorkingCopy.check_valid_creation_location(wc_location, PotentialRepo(repo_path))
 
     if not repo_path.exists():
         repo_path.mkdir(parents=True)
@@ -431,7 +434,7 @@ def init(
 
     # Create the repository
     repo = SnoRepo.init_repository(
-        repo_path, wc_path, bare, initial_branch=initial_branch
+        repo_path, wc_location, bare, initial_branch=initial_branch
     )
 
     if import_from:

--- a/sno/repo_version.py
+++ b/sno/repo_version.py
@@ -6,7 +6,6 @@ from .core import walk_tree
 from .dataset2 import Dataset2
 
 REPO_VERSION_BLOB_PATH = ".sno.repository.version"
-REPO_VERSION_CONFIG_PATH = "sno.repository.version"
 
 ALL_REPO_VERSIONS = (0, 1, 2)
 
@@ -49,10 +48,15 @@ def get_repo_version(repo, tree=None):
 
 
 def _get_repo_version_from_config(repo):
+    from sno.repo import KartConfigKeys
+
     repo_cfg = repo.config
-    if REPO_VERSION_CONFIG_PATH in repo_cfg:
-        return repo_cfg.get_int(REPO_VERSION_CONFIG_PATH)
-    return SUPPORTED_REPO_VERSION
+    if KartConfigKeys.KART_REPOSTRUCTURE_VERSION in repo_cfg:
+        return repo_cfg.get_int(KartConfigKeys.KART_REPOSTRUCTURE_VERSION)
+    elif KartConfigKeys.SNO_REPOSITORY_VERSION in repo_cfg:
+        return repo_cfg.get_int(KartConfigKeys.SNO_REPOSITORY_VERSION)
+    else:
+        return SUPPORTED_REPO_VERSION
 
 
 def _distinguish_v0_v1(tree):

--- a/sno/working_copy/sqlserver.py
+++ b/sno/working_copy/sqlserver.py
@@ -44,14 +44,14 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
         self.repo = repo
         self.uri = self.location = location
 
-        self.check_valid_db_uri(self.uri)
+        self.check_valid_db_uri(self.uri, repo)
         self.db_uri, self.db_schema = self._separate_db_schema(self.uri)
 
         self.engine = sqlserver_engine(self.db_uri)
         self.sessionmaker = sessionmaker(bind=self.engine)
         self.preparer = MSIdentifierPreparer(self.engine.dialect)
 
-        self.kart_tables = SqlServerKartTables(self.db_schema)
+        self.kart_tables = SqlServerKartTables(self.db_schema, repo.is_kart_branded)
 
     def _create_table_for_dataset(self, sess, dataset):
         table_spec = sqlserver_adapter.v2_schema_to_sqlserver_spec(
@@ -158,13 +158,12 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
         # SQL server deletes the spatial index automatically when the table is deleted.
         pass
 
-    def _quoted_sno_tracking_name(self, trigger_type, dataset):
+    def _sno_tracking_name(self, trigger_type, dataset):
         assert trigger_type == "trigger"
         assert dataset is not None
         # This is how the trigger is named in Sno 0.8.0 and earlier.
-        # Newer repos that use kart branding use _quoted_kart_tracking_name.
-        trigger_name = f"{dataset.table_name}_sno_track"
-        return f"{self.DB_SCHEMA}.{self.quote(trigger_name)}"
+        # Newer repos that use kart branding use _kart_tracking_name.
+        return f"{dataset.table_name}_sno_track"
 
     def _create_triggers(self, sess, dataset):
         pk_name = dataset.primary_key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -559,15 +559,11 @@ class TestHelpers:
         repo = SnoRepo(repo_path)
         wc = repo.get_working_copy(allow_invalid_state=True)
         if wc:
-            print(
-                f"Deleting existing working copy: {repo.config['sno.workingcopy.path']}"
-            )
+            print(f"Deleting existing working copy: {repo.workingcopy_location}")
             wc.delete()
 
-        if "sno.workingcopy.path" in repo.config:
-            del repo.config["sno.workingcopy.path"]
-        if "sno.workingcopy.version" in repo.config:
-            del repo.config["sno.workingcopy.version"]
+        if repo.WORKINGCOPY_LOCATION_KEY in repo.config:
+            del repo.config[repo.WORKINGCOPY_LOCATION_KEY]
 
     @classmethod
     def db_table_hash(cls, conn, table, pk=None):

--- a/tests/test_kart.py
+++ b/tests/test_kart.py
@@ -1,0 +1,164 @@
+import re
+import subprocess
+
+import pytest
+
+from sno.sqlalchemy.create_engine import gpkg_engine
+
+
+H = pytest.helpers.helpers()
+
+GPKG_IMPORTS = (
+    "archive,gpkg,table_ref",
+    [
+        pytest.param(
+            "gpkg-points", "nz-pa-points-topo-150k.gpkg", "POINTS", id="points"
+        ),
+        pytest.param(
+            "gpkg-polygons", "nz-waca-adjustments.gpkg", "POLYGONS", id="polygons"
+        ),
+    ],
+)
+
+
+@pytest.mark.slow
+@pytest.mark.e2e
+@pytest.mark.parametrize(*GPKG_IMPORTS)
+def test_kart(
+    archive,
+    gpkg,
+    table_ref,
+    data_archive,
+    tmp_path,
+    chdir,
+    cli_runner,
+    insert,
+    request,
+    monkeypatch,
+):
+    # Like test_e2e.py, but, uses a Kart branded repo instead of a Sno one.
+    metadata = H.metadata(table_ref)
+    table = metadata.LAYER
+    row_count = metadata.ROWCOUNT
+
+    repo_path = tmp_path / "myproject.kart"
+    repo_path.mkdir()
+
+    remote_path = tmp_path / "myremote.kart"
+    remote_path.mkdir()
+    with chdir(remote_path):
+        # initialise empty repo for remote
+        subprocess.run(["git", "init", "--bare", str(remote_path)], check=True)
+
+    with data_archive(archive) as data:
+        with chdir(repo_path):
+            # initialise empty Kart repo
+
+            from sno.repo import SnoRepo
+
+            monkeypatch.setattr(SnoRepo, "BRANDING_FOR_NEW_REPOS", "kart")
+            monkeypatch.setattr(SnoRepo, "DIRNAME_FOR_NEW_REPOS", ".kart")
+
+            r = cli_runner.invoke(["init"])
+            assert r.exit_code == 0
+
+            assert not (repo_path / ".sno").exists()
+            assert (repo_path / ".kart").is_dir()
+            assert (repo_path / "KART_README.txt").is_file()
+
+            # import data
+            r = cli_runner.invoke(["import", f"GPKG:{data / gpkg}", table])
+            assert r.exit_code == 0
+
+            # check there's a commit
+            r = cli_runner.invoke(["log"])
+            assert r.exit_code == 0
+            assert "Import from " in r.stdout
+            sha_import = r.stdout.splitlines()[0].split()[1]
+            print("Imported SHA:", sha_import)
+
+            # checkout a working copy
+            r = cli_runner.invoke(["checkout"])
+            assert r.exit_code == 0
+            working_copy = repo_path / "myproject.gpkg"
+            assert working_copy.exists()
+
+            # check we have the right data in the WC
+            with gpkg_engine(working_copy).connect() as conn:
+                assert H.row_count(conn, table) == row_count
+                assert (
+                    conn.scalar(
+                        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name LIKE ('gpkg_kart%');",
+                    )
+                    == 2
+                )
+
+                assert (
+                    conn.scalar(
+                        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name LIKE ('gpkg_sno%');",
+                    )
+                    == 0
+                )
+
+            # create & switch to a new branch
+            r = cli_runner.invoke(["switch", "-c", "edit-1"])
+            assert r.exit_code == 0
+            assert r.stdout.splitlines()[0] == "Creating new branch 'edit-1'..."
+
+            r = cli_runner.invoke(["status"])
+            assert r.exit_code == 0
+            assert r.stdout.splitlines()[0] == "On branch edit-1"
+
+            # make an edit
+            with gpkg_engine(working_copy).connect() as conn:
+                insert(conn, commit=False)
+
+            r = cli_runner.invoke(["diff"])
+            assert r.exit_code == 0
+            assert re.match(fr"\+\+\+ {table}:feature:\d+$", r.stdout.splitlines()[0])
+
+            # commit it
+            r = cli_runner.invoke(["commit", "-m", "commit-1"])
+            assert r.exit_code == 0
+            sha_edit1 = r.stdout.splitlines()[-1].split()[1]
+            print("Edit SHA:", sha_edit1)
+
+            # go back to main
+            r = cli_runner.invoke(["switch", "main"])
+            assert r.exit_code == 0
+            assert r.stdout.splitlines()[0] == f"Updating {working_copy.name} ..."
+
+            r = cli_runner.invoke(["status"])
+            assert r.exit_code == 0
+            assert r.stdout.splitlines()[0] == "On branch main"
+
+            # merge it
+            r = cli_runner.invoke(["merge", "edit-1", "--no-ff", "-m", "merge-1"])
+            assert r.exit_code == 0
+            assert "Fast-forward" not in r.stdout
+            sha_merge1 = r.stdout.splitlines()[-1].split(" ")[-1]
+            print("Merge SHA:", sha_merge1)
+
+            H.git_graph(request, "post edit-1 merge", count=10)
+
+            # add a remote
+            r = cli_runner.invoke(["remote", "add", "myremote", remote_path])
+            assert r.exit_code == 0
+
+            # push
+            r = cli_runner.invoke(["push", "--set-upstream", "myremote", "main"])
+            assert r.exit_code == 0
+            assert re.match(
+                r"Branch '?main'? set up to track remote branch '?main'? from '?myremote'?\.$",
+                r.stdout.splitlines()[0],
+            )
+
+            # check reflog
+            r = cli_runner.invoke(["reflog"])
+            assert r.exit_code == 0
+            assert [x.split(" ", 1)[1] for x in r.stdout.splitlines()][0:4] == [
+                "HEAD@{0}: commit (merge): merge-1",
+                "HEAD@{1}: checkout: moving from edit-1 to main",
+                "HEAD@{2}: commit: commit-1",
+                "HEAD@{3}: checkout: moving from main to edit-1",
+            ]

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,6 +1,6 @@
 import subprocess
 
-from sno.repo import SnoRepo, LockedGitIndex
+from sno.repo import SnoRepo, LOCKED_GIT_INDEX_CONTENTS
 
 
 def test_init_repository(tmp_path):
@@ -14,9 +14,9 @@ def test_init_repository(tmp_path):
     assert (repo_path / ".sno").is_dir()
     assert (repo_path / ".sno" / "HEAD").exists()
 
-    assert (
-        repo_path / ".sno" / "index"
-    ).read_bytes() == LockedGitIndex.LOCKED_EMPTY_GIT_INDEX
+    assert (repo_path / ".sno" / "index").read_bytes() == LOCKED_GIT_INDEX_CONTENTS[
+        "sno"
+    ]
 
     assert sno_repo.config.get_int("sno.repository.version") == 2
     assert sno_repo.config["sno.workingcopy.path"] == "test_repo.gpkg"


### PR DESCRIPTION
![](https://media1.giphy.com/media/13NKbbVWMt6nFm/giphy.gif)

Only affects local-only objects: 
- folder names
- config variables
- working copy tables

Git objects - objects that are version controlled and can be pushed and pulled across repos, still support only Sno branding. Rebranded these with kart will be done separately - so that even if our mirrors continue to have Sno branded git objects indefinitely, and so will the clones of them, at least the clones of them will have Kart branded local-only objects.
Git objects are relatively hidden anyway, so are lower priority than, eg, folder names.

Sno repo branding is still the default - no visible way for user to enable Kart branding.
Repos that use Sno branding work just as before.
Tested=test pass
- need to add new tests to make sure Kart branded repos work too.

