### PR TITLE
Disable deltified objects by default

### DIFF
--- a/sno/cli.py
+++ b/sno/cli.py
@@ -13,7 +13,6 @@ from . import core  # noqa
 from .cli_util import (
     add_help_subcommand,
     call_and_exit_flag,
-    startup_load_git_init_config,
     tool_environment,
 )
 from .context import Context
@@ -283,7 +282,6 @@ def reflog(ctx, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def config(ctx, args):
     """ Get and set repository or global options """
-    startup_load_git_init_config()
     params = ["git", "config"]
     if ctx.obj.user_repo_path:
         params[1:1] = ["-C", ctx.obj.user_repo_path]

--- a/sno/clone.py
+++ b/sno/clone.py
@@ -6,7 +6,6 @@ from urllib.parse import urlsplit
 import click
 
 from . import checkout
-from .cli_util import startup_load_git_init_config
 from .exceptions import InvalidOperation
 from .repo import SnoRepo, PotentialRepo
 
@@ -111,7 +110,6 @@ def clone(
     directory,
 ):
     """ Clone a repository into a new directory """
-    startup_load_git_init_config()
     repo_path = Path(directory or get_directory_from_url(url)).resolve()
 
     if repo_path.exists() and any(repo_path.iterdir()):

--- a/sno/init.py
+++ b/sno/init.py
@@ -11,7 +11,6 @@ from . import checkout
 from .core import check_git_user
 from .cli_util import (
     call_and_exit_flag,
-    startup_load_git_init_config,
     MutexOption,
     StringFromFile,
     JsonFromFile,
@@ -427,7 +426,6 @@ def init(
     Initialise a new repository and optionally import data.
     DIRECTORY must be empty. Defaults to the current directory.
     """
-    startup_load_git_init_config()
     if directory is None:
         directory = os.curdir
     repo_path = Path(directory).resolve()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,6 +364,9 @@ class SnoCliRunner(CliRunner):
 
     def invoke(self, args=None, **kwargs):
         from sno.cli import load_commands_from_args, cli
+        from sno.cli_util import init_git_config
+
+        init_git_config.cache_clear()
 
         if args:
             # force everything to strings (eg. PathLike objects, numbers)


### PR DESCRIPTION


## Description

This is a continuation of #159 and #163,
in which we discovered that even a small proportion of deltified
objects (~0.1%) with small delta chains can cause catastrophic
performance issues for diff. We've since discovered it causes similar
problems with clone, if the deltas exist on the server.

sno's repo layout is quite different than your typical git repo
(there are typically millions of small blobs, distributed much more
evenly across a constant number of trees) and no deltas seems to be
a better fit for large sno repo layouts.

Set `pack.window` and `pack.depth` in your gitconfig explicitly to
override this default.

## Related links:

 #159 and #163 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
